### PR TITLE
v1.1: vocabulary RAG indexer + manual refresh tool + discovery prompt updates

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -54,6 +54,16 @@ for column meanings, disposition definitions, and maintenance rules.
 | add_nested_execution | execution.py | kept | deriva_ml_add_nested_execution | tools/execution.py | hostname/catalog_id added | Already takes both RIDs explicitly. Same intent; no signature change beyond the boundary args. |
 | list_nested_executions | execution.py | renamed | deriva_ml_list_execution_children | tools/execution.py | name change mirrors upstream rename `Execution.list_nested_executions` → `ExecutionRecord.list_execution_children`; aligns with dataset-hierarchy template (`list_dataset_children`); hostname/catalog_id added | Net-new symmetric complement `list_execution_parents` (catalog-side parent query) lands alongside this in Phase 5.2 but is NOT a port of any old tool — it has no row here. |
 
+### Net-new tools (post-v1.0 additions)
+
+Tools not present in the old `deriva-mcp` repo. Added because v1.0+
+landed new infrastructure (RAG, on_catalog_connect hooks, etc.) that
+had no corresponding old-tool to migrate from.
+
+| name | module | mutates | added_in | notes |
+|---|---|---|---|---|
+| deriva_ml_reindex_vocabularies | tools/vocabulary.py | False | v1.1 (issue #5) | Force re-index of vocabulary tables in the RAG vector store. The on_catalog_connect hook bulk-indexes all vocabs on first connect; this tool is the manual bridge for after-the-fact mutations via core's `add_term` / `delete_term` (which don't fire any framework lifecycle hook -- tracked upstream as deriva-mcp-core#3). `mutates=False` because the vector store is a cache; the audit log is for catalog state changes and a cache refresh isn't one. Optional `vocab="schema.table"` arg restricts to one vocab; default re-indexes all. |
+
 ### Pre-existing core-owned tools (Phase 7.1 backfill)
 
 These 52 old `deriva-mcp` tools were never analyzed in the per-domain phases (2-5) because they have no ML-domain semantics — they're generic Deriva primitives that live in `deriva-mcp-core` (or were dropped with the connection-singleton architecture). Phase 7.1's `scripts/check_coverage.py` flagged them as missing from `coverage.md`; this section catalogues the disposition for completeness.
@@ -180,7 +190,7 @@ These 52 old `deriva-mcp` tools were never analyzed in the per-domain phases (2-
 
 ## Upstream gaps (Phase 6 RAG)
 
-One open `deriva-mcp-core` limitation. The other (issue #1) was filed during
+Two open `deriva-mcp-core` limitations. The other (issue #1) was filed during
 Phase 6.6 and landed upstream in commit
 [`0aef9fc`](https://github.com/informatics-isi-edu/deriva-mcp-core/commit/0aef9fc)
 during the v1.0 polish sprint -- `rag_search` now filters `data:` sources by
@@ -198,6 +208,17 @@ Still open:
   inline for the LLM. Fix is a one-line `doc_type` parameter addition
   upstream. The plugin marks the gap with `# TODO(upstream-rag-doctype)` at
   the `index_table_data` call site in `resources/rag.py`.
+
+- **No `on_data_change` lifecycle hook**
+  ([deriva-mcp-core#3](https://github.com/informatics-isi-edu/deriva-mcp-core/issues/3)).
+  Vocabulary mutations via core's `add_term` / `delete_term` do not fire
+  `on_schema_change` (verified by reading core's `vocabulary.py`), and there
+  is no `on_data_change` equivalent. The v1.1 vocab indexer in
+  `resources/rag.py` therefore can't auto-refresh after term mutations.
+  Bridge: the `deriva_ml_reindex_vocabularies` tool exposes a manual
+  re-index that callers (or the LLM) can fire after `add_term`. Long-term
+  fix is the upstream hook; the manual tool stays as the targeted-refresh
+  affordance even after the hook lands.
 
 ## Validation (Phase 7+)
 

--- a/src/deriva_ml_mcp/_helpers.py
+++ b/src/deriva_ml_mcp/_helpers.py
@@ -14,6 +14,8 @@ Public API:
         dicts with a known key.
     _row_rid_for: Key extractor factory for denormalized-row dicts
         with Table.column-style keys.
+    _table_qname: Render a deriva-py Table as ``"schema.name"``.
+    _table_to_dict: Render a deriva-py Table as ``{"name", "schema"}``.
     _MAX_LIMIT: Pagination cap (1000 rows per page).
 
 The leading underscore on each helper is preserved -- they're internal
@@ -197,6 +199,52 @@ def _read_rid(item: Any, rid_key: str) -> str:
                 return str(item[candidate])
         raise KeyError(f"no RID-like key in member dict (looked for RID, {rid_key})")
     return str(getattr(item, rid_key))
+
+
+def _table_qname(table: Any) -> str:
+    """Return the qualified ``schema.name`` form of a deriva-py Table.
+
+    Args:
+        table: A ``deriva.core.ermrest_model.Table`` instance (the type
+            returned by ``ml.find_vocabularies()`` and similar deriva-py
+            model accessors).
+
+    Returns:
+        The string ``f"{table.schema.name}.{table.name}"``.
+
+    Example:
+        >>> from unittest.mock import MagicMock
+        >>> t = MagicMock()
+        >>> t.name = "Dataset_Type"
+        >>> t.schema.name = "deriva-ml"
+        >>> _table_qname(t)
+        'deriva-ml.Dataset_Type'
+    """
+    return f"{table.schema.name}.{table.name}"
+
+
+def _table_to_dict(table: Any) -> dict[str, str]:
+    """Return a JSON-friendly ``{schema, name}`` dict for a deriva-py Table.
+
+    The canonical shape used across the plugin's tool/resource responses
+    when emitting table references. Use ``_table_qname`` when a string
+    form (e.g., for log messages or markdown headers) is preferable.
+
+    Args:
+        table: A ``deriva.core.ermrest_model.Table`` instance.
+
+    Returns:
+        ``{"name": table.name, "schema": table.schema.name}``.
+
+    Example:
+        >>> from unittest.mock import MagicMock
+        >>> t = MagicMock()
+        >>> t.name = "Image"
+        >>> t.schema.name = "demo-schema"
+        >>> _table_to_dict(t)
+        {'name': 'Image', 'schema': 'demo-schema'}
+    """
+    return {"name": table.name, "schema": table.schema.name}
 
 
 def _row_rid_for(row_per: str | None) -> Callable[[dict[str, Any]], str]:

--- a/src/deriva_ml_mcp/plugin.py
+++ b/src/deriva_ml_mcp/plugin.py
@@ -25,6 +25,7 @@ from deriva_ml_mcp.resources import rag as _ml_rag
 from deriva_ml_mcp.tools import dataset as _dataset
 from deriva_ml_mcp.tools import execution as _execution
 from deriva_ml_mcp.tools import feature as _feature
+from deriva_ml_mcp.tools import vocabulary as _vocabulary
 from deriva_ml_mcp.tools import workflow as _workflow
 
 if TYPE_CHECKING:
@@ -40,7 +41,15 @@ def register(ctx: PluginContext) -> None:
     Workflow, and Execution rows). v1.0 polish added 3 MCP prompts
     (``deriva_ml_getting_started``, ``deriva_ml_execution_lifecycle``,
     ``deriva_ml_workflow_dedup``) so an LLM connecting cold has an
-    anchor for the 39-tool ML domain.
+    anchor for the ML domain.
+
+    v1.1 added vocabulary RAG indexing: a fourth on_catalog_connect
+    hook bulk-indexes all discovered vocabulary tables under a
+    catalog-public ``vocab:`` source, and a one-tool vocabulary domain
+    (``deriva_ml_reindex_vocabularies``) lets callers force a refresh
+    after using core's ``add_term`` / ``delete_term`` (which don't
+    fire any framework lifecycle hook -- tracked upstream as
+    deriva-mcp-core#3).
 
     Args:
         ctx: PluginContext supplied by deriva-mcp-core at startup.
@@ -57,6 +66,7 @@ def register(ctx: PluginContext) -> None:
     _feature.register(ctx)
     _workflow.register(ctx)
     _execution.register(ctx)
+    _vocabulary.register(ctx)
     _ml_resources.register(ctx)
     _ml_rag.register_rag_sources(ctx)
     _ml_prompts.register(ctx)

--- a/src/deriva_ml_mcp/prompts.py
+++ b/src/deriva_ml_mcp/prompts.py
@@ -131,6 +131,67 @@ Fall back to the paginated list tools (``deriva_ml_list_datasets``,
 you need filtered scans (e.g. "executions with status=Failed for
 workflow 1-WF") that resources cannot express.
 
+DISCOVERY: RESOLVING USER-MENTIONED NAMES TO CATALOG IDENTIFIERS
+----------------------------------------------------------------
+When the user mentions a vocabulary term, table or column, workflow,
+dataset, or feature by name, resolve it to the canonical catalog
+identifier in this order:
+
+1. EXACT MATCH FIRST. If the user-supplied string matches a known
+   canonical name exactly (case-sensitive), use it. Don't search,
+   don't ask. DerivaML names are case-sensitive: "Training" is the
+   Dataset_Type term; "training" is not. If the user says
+   "Training", they mean Training.
+
+2. SEMANTIC SEARCH WHEN AMBIGUOUS OR DESCRIPTIVE. If the user's
+   phrasing is descriptive ("the training data type", "labels for
+   image quality"), or if their string doesn't match any canonical
+   name, call rag_search with their phrase. Examine the results:
+
+   - Single clear top hit (score significantly above runners-up):
+     use it, but tell the user what you resolved it to in one
+     sentence. ("I'm using the Training Dataset_Type.") Fast for
+     normal cases, traceable if wrong.
+
+   - Multiple close hits or genuinely ambiguous: present a picker.
+     List 3-5 candidates with their canonical name + one-line
+     description + RID (or table.column for column hits). Ask
+     the user to pick. Don't choose blindly when reasonable
+     people might disagree.
+
+   - No useful hits: ask a clarifying question. Do not fabricate
+     a name; do not call create_* with a guessed identifier.
+
+3. EXPLICIT LIST REQUEST GETS A LIST. If the user says "show me
+   all dataset types" or "list workflows", use the appropriate
+   list endpoint (ml/registries, deriva_ml_list_workflows,
+   deriva://catalog/{h}/{c}/ml/datasets). Don't run rag_search
+   when they explicitly want enumeration.
+
+INDEX COVERAGE BY CATEGORY
+--------------------------
+The picker pattern works for these categories. Freshness varies:
+
+  Vocabulary terms (built-in + user-defined)
+    Indexed by this plugin per-vocab. Fresh on first connect to
+    the catalog. To re-index after adding a term via core's
+    add_term, call deriva_ml_reindex_vocabularies first.
+
+  Tables and columns (any schema, ML or domain)
+    Indexed by the framework's schema RAG, per-user. Fresh on
+    first connect; refreshed automatically when any tool mutates
+    the schema. A column hit lands inside its surrounding table
+    chunk -- when the user says "the rid column" you'll see RID
+    exists in many tables and need to ask which one.
+
+  Workflows, datasets, executions
+    Indexed by this plugin per-user. Fresh on first connect;
+    NOT automatically refreshed when new ones are created or
+    existing ones are modified (deriva-ml-mcp#8 tracks the
+    surgical re-index redesign). If the user just created or
+    modified one, prefer the deriva_ml_list_* tools or the
+    detail resources for that one over rag_search.
+
 MUTATION: WORKFLOW -> EXECUTION -> OUTPUTS
 ------------------------------------------
 The canonical mutation chain is:

--- a/src/deriva_ml_mcp/resources/rag.py
+++ b/src/deriva_ml_mcp/resources/rag.py
@@ -88,6 +88,7 @@ from deriva_ml_mcp.tools.workflow import _list_workflows_impl
 
 if TYPE_CHECKING:
     from deriva_mcp_core.plugin.api import PluginContext
+    from deriva_mcp_core.rag.store import VectorStore
 
 logger = logging.getLogger(__name__)
 
@@ -252,6 +253,13 @@ class _VocabSerializer(RowSerializer):
 
     def serialize(self, table_name: str, row: dict) -> str | None:  # noqa: D401
         """Serialize one vocabulary term, or return None when ``name`` is absent."""
+        # Contract divergence vs _DatasetSerializer/_WorkflowSerializer/
+        # _ExecutionSerializer: those gate on table_name to dispatch among
+        # multiple known table types. This serializer accepts ANY vocab
+        # table; dispatch is handled by the caller's discovery loop in
+        # _index_vocabularies (which iterates ml.find_vocabularies()), not
+        # by the serializer itself. table_name is only used for the inline
+        # header so a search hit carries its parent vocab inline.
         name = row.get("name") or row.get("Name")
         if not name:
             return None
@@ -428,7 +436,7 @@ def _vocab_source_name(hostname: str, catalog_id: str, qname: str) -> str:
 
 
 async def _write_vocab_chunks(
-    store: Any,
+    store: VectorStore,
     source: str,
     vocab_table: str,
     terms: list[dict[str, Any]],

--- a/src/deriva_ml_mcp/resources/rag.py
+++ b/src/deriva_ml_mcp/resources/rag.py
@@ -1,33 +1,70 @@
-"""Per-user RAG indexing + DerivaML docs source for deriva-ml-mcp.
+"""Per-user RAG indexing + vocab indexing + DerivaML docs source for deriva-ml-mcp.
 
-Phase 6.3 wires three things into the RAG subsystem:
+Phase 6.3 wired three things into the RAG subsystem; v1.1 adds a
+fourth (vocabularies):
 
 1. **One GitHub doc source** -- ``informatics-isi-edu/deriva-ml`` ``docs/``
    (declared synchronously via ``ctx.rag_github_source``). The indexer
    crawls it once when RAG is enabled.
 
-2. **Three ``on_catalog_connect`` hooks** -- one each for ``Dataset``,
-   ``Workflow``, and ``Execution`` rows. Each hook resolves the calling
-   user's identity, fetches rows under that user's credential, and
-   upserts into the vector store with a user-scoped source name
-   (``data:{host}:{cat}:{user_id}``). The fetch path goes through the
-   plugin's existing ``_list_*_impl`` helpers, so ACL behavior matches
-   the read tools.
+2. **Three per-user ``on_catalog_connect`` hooks** -- one each for
+   ``Dataset``, ``Workflow``, and ``Execution`` rows. Each hook resolves
+   the calling user's identity, fetches rows under that user's
+   credential, and upserts into the vector store with a user-scoped
+   source name (``data:{host}:{cat}:{user_id}``). The fetch path goes
+   through the plugin's existing ``_list_*_impl`` helpers, so ACL
+   behavior matches the read tools.
 
-3. **Three ``RowSerializer`` implementations** -- one per table, each
-   producing rich Markdown sections for the LLM (header, fields,
-   subsections; empties omitted FaceBase-style).
+3. **One catalog-public ``on_catalog_connect`` hook for vocabularies**
+   (v1.1) -- discovers all vocabulary tables via
+   ``ml.find_vocabularies()`` (built-in ML vocabs + any user-defined
+   domain vocabs) and writes each vocab's terms to the vector store
+   under a custom source prefix
+   ``vocab:{hostname}:{catalog_id}:{schema}.{table}``. The ``vocab:``
+   prefix bypasses upstream's ``data:`` user-id filter so chunks are
+   served to all users in the catalog -- vocabularies have no per-user
+   ACL. Each term renders to markdown with name + description +
+   synonyms + RID; the parent vocab table appears inline in the H2
+   header so a search hit carries the disambiguating context.
 
-Why hooks + ``index_table_data`` (not ``ctx.rag_dataset_indexer``)?
-``rag_dataset_indexer`` produces a single global enriched source shared
-across all users (the enricher fires under whichever credential happens
-to connect first). For ML data with per-user ACLs that would leak rows
-across users. The per-user pattern here partitions the source name by
-user identity and fetches under the calling user's credential -- same
-posture as every other tool in this plugin.
+4. **Four ``RowSerializer`` implementations** -- one per per-user table
+   (Dataset, Workflow, Execution) and one for vocabulary terms
+   (``_VocabSerializer``), each producing rich Markdown sections for
+   the LLM (header, fields, subsections; empties omitted FaceBase-style).
 
-Wiring into ``plugin.py`` is deferred to Phase 6.4. This module is
-import-safe and idempotent on its own.
+Why hooks + ``index_table_data`` for the per-user trio (not
+``ctx.rag_dataset_indexer``)? ``rag_dataset_indexer`` produces a single
+global enriched source shared across all users (the enricher fires
+under whichever credential happens to connect first). For ML data with
+per-user ACLs that would leak rows across users. The per-user pattern
+here partitions the source name by user identity and fetches under the
+calling user's credential -- same posture as every other tool in this
+plugin.
+
+Why direct store writes (not ``index_table_data``) for vocabularies?
+``index_table_data``'s source naming is hardcoded to
+``data:{host}:{cat}:{user_id}``, which would (a) be incorrectly
+per-user-partitioned for public vocab data, and (b) get filtered out
+by upstream's ``data:`` user-id filter for users whose ``user_id`` is
+not the indexer's. The vocab path writes to the store directly with
+its own ``vocab:`` prefix; the upstream filter only applies to
+``schema:``, ``data:``, and ``enriched:`` prefixes (verified in
+``deriva-mcp-core/src/deriva_mcp_core/rag/tools.py`` around lines
+425-440), so ``vocab:`` chunks are served to all users.
+
+Vocab freshness (v1.1):
+    First catalog connect per server lifetime indexes all vocabs in
+    bulk via the new on_catalog_connect hook. The
+    ``deriva_ml_reindex_vocabularies`` tool re-runs the same
+    discovery + per-vocab write -- use it after adding terms via
+    core's ``add_term``, which doesn't fire any framework lifecycle
+    hook (tracked upstream as deriva-mcp-core#3). v1.1 deliberately
+    does NOT add an ``on_schema_change`` hook -- ``add_term`` doesn't
+    fire it, and the cost/benefit is wrong for v1.1; the manual tool
+    is the bridge until upstream ships ``on_data_change``.
+
+Wiring into ``plugin.py`` is in ``register_rag_sources(ctx)``. This
+module is import-safe and idempotent on its own.
 """
 
 from __future__ import annotations
@@ -39,9 +76,11 @@ from typing import TYPE_CHECKING, Any
 
 from deriva_mcp_core.context import resolve_user_identity
 from deriva_mcp_core.rag import get_rag_store
+from deriva_mcp_core.rag.chunker import chunk_markdown
 from deriva_mcp_core.rag.data import RowSerializer, index_table_data
+from deriva_mcp_core.rag.store import Chunk
 
-from deriva_ml_mcp._helpers import _MAX_LIMIT
+from deriva_ml_mcp._helpers import _MAX_LIMIT, _table_qname
 from deriva_ml_mcp.ml_context import get_ml
 from deriva_ml_mcp.tools.dataset import _list_datasets_impl
 from deriva_ml_mcp.tools.execution import _list_executions_impl
@@ -195,6 +234,37 @@ class _ExecutionSerializer(RowSerializer):
         return _render_block(f"## Execution: {rid}", lines)
 
 
+class _VocabSerializer(RowSerializer):
+    """Serialize a vocabulary term as Markdown for RAG indexing.
+
+    Used for all discovered vocabulary tables (built-in ML vocabs and
+    user-defined domain vocabs). The parent vocab table name appears
+    inline in the H2 header so a search hit carries enough context for
+    the LLM to know which vocabulary the term belongs to.
+
+    Contract:
+        Returns rendered markdown if the row carries a ``"name"`` (or
+        ``"Name"``) value; ``None`` otherwise. The ``table_name``
+        argument is treated as an opaque identifier for the inline
+        header -- typically the qualified ``schema.table`` form -- and
+        does not gate dispatch the way the per-user serializers do.
+    """
+
+    def serialize(self, table_name: str, row: dict) -> str | None:  # noqa: D401
+        """Serialize one vocabulary term, or return None when ``name`` is absent."""
+        name = row.get("name") or row.get("Name")
+        if not name:
+            return None
+        synonyms = row.get("synonyms") or row.get("Synonyms")
+        synonyms_list = list(synonyms) if synonyms else None
+        lines: list[str | None] = [
+            _kv_line("Description", row.get("description") or row.get("Description")),
+            _kv_line("Synonyms", synonyms_list),
+            _kv_line("RID", row.get("rid") or row.get("RID")),
+        ]
+        return _render_block(f"## Vocab Term: {name} ({table_name})", lines)
+
+
 # ---------------------------------------------------------------------------
 # Row fetchers
 # ---------------------------------------------------------------------------
@@ -341,18 +411,198 @@ def _make_hook(
 
 
 # ---------------------------------------------------------------------------
+# Vocabulary indexing (catalog-public, custom ``vocab:`` source prefix)
+# ---------------------------------------------------------------------------
+
+
+def _vocab_source_name(hostname: str, catalog_id: str, qname: str) -> str:
+    """Build the canonical ``vocab:`` source name for one vocab table.
+
+    The ``vocab:`` prefix is a deliberate carve-out from upstream's
+    ``data:`` user-id filter (see module docstring) -- chunks under
+    this prefix are returned to all users in the catalog, regardless
+    of which user's connect triggered the index pass. This is correct
+    for vocabularies, which carry no per-user ACL.
+    """
+    return f"vocab:{hostname}:{catalog_id}:{qname}"
+
+
+async def _write_vocab_chunks(
+    store: Any,
+    source: str,
+    vocab_table: str,
+    terms: list[dict[str, Any]],
+    serializer: _VocabSerializer,
+) -> int:
+    """Render terms, chunk them, and replace the existing vocab source.
+
+    The delete-then-add pattern mirrors what ``index_table_data`` does
+    internally. Idempotent: a prior version of this source is drained
+    before the new chunks land, so re-running on an unchanged vocab is
+    a no-op from the caller's perspective (the chunks are equivalent).
+
+    Args:
+        store: An active ``VectorStore`` (call site checks for ``None``).
+        source: Canonical source name from ``_vocab_source_name``.
+        vocab_table: Qualified ``schema.table`` -- passed to the
+            serializer as the inline header context.
+        terms: List of term dicts (``name``, ``description``, ``synonyms``,
+            ``rid``). Empty list short-circuits without touching the store.
+        serializer: A ``_VocabSerializer`` instance.
+
+    Returns:
+        Count of indexed terms (the rendered, chunked count -- one term
+        typically yields one chunk under our 800-token budget).
+    """
+    await store.delete_source(source)
+    if not terms:
+        return 0
+    chunks: list[Chunk] = []
+    chunk_index = 0
+    for term in terms:
+        rendered = serializer.serialize(vocab_table, term)
+        if rendered is None:
+            continue
+        # TODO(upstream-rag-doctype): tracked as deriva-mcp-core#2
+        # (https://github.com/informatics-isi-edu/deriva-mcp-core/issues/2).
+        # Once chunks can carry a domain-specific doc_type, switch to
+        # "ml-vocab" so rag_search(doc_type=...) can distinguish vocab
+        # term chunks from generic catalog-data chunks.
+        for c in chunk_markdown(rendered, source=source, doc_type="catalog-data"):
+            chunks.append(
+                Chunk(
+                    text=c.text,
+                    source=source,
+                    doc_type="catalog-data",
+                    section_heading=c.section_heading,
+                    heading_hierarchy=c.heading_hierarchy,
+                    chunk_index=chunk_index,
+                )
+            )
+            chunk_index += 1
+    if chunks:
+        await store.add(chunks)
+    return len(terms)
+
+
+async def _index_vocabularies(
+    hostname: str,
+    catalog_id: str,
+    only_vocab: str | None = None,
+) -> dict[str, int]:
+    """Discover and index vocabulary tables for the catalog.
+
+    Iterates ``ml.find_vocabularies()`` (built-in ML vocabs +
+    user-defined domain vocabs in any schema) and writes one shared
+    source per vocab table at
+    ``vocab:{hostname}:{catalog_id}:{schema}.{table}``. The custom
+    ``vocab:`` prefix bypasses upstream's ``data:`` user-id filter so
+    chunks are served to all users in the catalog (vocabularies carry
+    no per-user ACL).
+
+    Best-effort: per-vocab failures (missing vocab table, fetch error)
+    are logged and skipped without aborting the whole index pass.
+
+    Args:
+        hostname: Deriva hostname.
+        catalog_id: Catalog ID.
+        only_vocab: If provided, only re-index this vocab (qualified
+            ``"schema.table"`` form). If ``None``, re-index all
+            discovered vocabs.
+
+    Returns:
+        Dict mapping vocab qname to indexed-term count for each vocab
+        that was successfully indexed. Vocabs that errored or were
+        filtered out by ``only_vocab`` do not appear.
+    """
+    store = get_rag_store()
+    if store is None:
+        logger.debug("rag store unavailable, skipping vocab index")
+        return {}
+
+    ml = get_ml(hostname, catalog_id)
+    serializer = _VocabSerializer()
+    indexed: dict[str, int] = {}
+
+    for vocab_table in ml.find_vocabularies():
+        qname = _table_qname(vocab_table)
+        if only_vocab is not None and qname != only_vocab:
+            continue
+        try:
+            terms = ml.list_vocabulary_terms(vocab_table)
+            term_dicts = [
+                {
+                    "name": t.name,
+                    "description": t.description,
+                    "synonyms": list(t.synonyms or []),
+                    "rid": t.rid,
+                }
+                for t in terms
+            ]
+            source = _vocab_source_name(hostname, catalog_id, qname)
+            count = await _write_vocab_chunks(store, source, qname, term_dicts, serializer)
+            indexed[qname] = count
+            logger.debug("indexed %d terms for vocab %s", count, qname)
+        except Exception:
+            logger.exception("failed to index vocab %s", qname)
+            continue
+
+    return indexed
+
+
+def _make_vocab_hook() -> Callable[[str, str, str, dict], Awaitable[None]]:
+    """Build the on_catalog_connect hook that bulk-indexes vocabularies.
+
+    Distinct from ``_make_hook`` because vocab indexing has a different
+    shape: one hook fires N writes (one per discovered vocab) rather
+    than one write. Forcing this into the per-user factory's
+    ``(fetch_fn, table_name, serializer)`` signature would obscure the
+    difference. Two clear factories beat one general one.
+
+    Returns:
+        An async hook with the ``on_catalog_connect`` signature
+        ``(hostname, catalog_id, schema_hash, schema_json) -> None``.
+    """
+
+    async def hook(
+        hostname: str,
+        catalog_id: str,
+        schema_hash: str,  # noqa: ARG001 -- hook signature requires it
+        schema_json: dict,  # noqa: ARG001 -- hook signature requires it
+    ) -> None:
+        try:
+            await _index_vocabularies(hostname, catalog_id)
+        except Exception:  # noqa: BLE001 -- vocab discovery is best-effort
+            logger.exception(
+                "deriva-ml RAG: vocab index pass failed for %s/%s",
+                hostname,
+                catalog_id,
+            )
+
+    return hook
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
 
 def register_rag_sources(ctx: PluginContext) -> None:
-    """Register the DerivaML docs source and three per-user catalog hooks.
+    """Register the DerivaML docs source and four catalog-connect hooks.
 
-    Called from ``plugin.register(ctx)`` (wired in Phase 6.4). Safe to
-    call without any RAG config -- ``ctx.rag_github_source`` is a no-op
-    when RAG is disabled, and the hooks are best-effort: they swallow
-    fetch exceptions and short-circuit when the vector store is
-    unavailable.
+    Hooks fire in registration order on every catalog connect:
+
+    1. Dataset (per-user, ``data:`` source prefix)
+    2. Workflow (per-user, ``data:`` source prefix)
+    3. Execution (per-user, ``data:`` source prefix)
+    4. Vocabularies (catalog-public, custom ``vocab:`` source prefix --
+       v1.1; bypasses upstream's ``data:`` user-id filter, served to
+       all users in the catalog)
+
+    Called from ``plugin.register(ctx)``. Safe to call without any RAG
+    config -- ``ctx.rag_github_source`` is a no-op when RAG is
+    disabled, and the hooks are best-effort: they swallow fetch
+    exceptions and short-circuit when the vector store is unavailable.
 
     Args:
         ctx: PluginContext supplied by deriva-mcp-core at startup.
@@ -378,3 +628,4 @@ def register_rag_sources(ctx: PluginContext) -> None:
     ctx.on_catalog_connect(
         _make_hook(_fetch_execution_rows, _EXECUTION_TABLE, _ExecutionSerializer())
     )
+    ctx.on_catalog_connect(_make_vocab_hook())

--- a/src/deriva_ml_mcp/tools/dataset.py
+++ b/src/deriva_ml_mcp/tools/dataset.py
@@ -45,6 +45,7 @@ from deriva_ml_mcp._helpers import (
     _paginate,
     _read_rid,
     _row_rid_for,
+    _table_to_dict,
 )
 from deriva_ml_mcp.ml_context import get_ml
 
@@ -606,7 +607,7 @@ def register(ctx: PluginContext) -> None:
                 tables = list(ml.list_dataset_element_types())
             return json.dumps(
                 {
-                    "element_types": [{"name": t.name, "schema": t.schema.name} for t in tables],
+                    "element_types": [_table_to_dict(t) for t in tables],
                     "count": len(tables),
                 }
             )

--- a/src/deriva_ml_mcp/tools/vocabulary.py
+++ b/src/deriva_ml_mcp/tools/vocabulary.py
@@ -1,0 +1,110 @@
+"""Vocabulary management tools for deriva-ml-mcp.
+
+Currently exposes one tool:
+
+- ``deriva_ml_reindex_vocabularies`` -- force re-index of vocabulary
+  tables in the RAG vector store. Use after adding/removing terms via
+  core's ``add_term`` / ``delete_term`` tools (which don't fire any
+  framework lifecycle hook -- tracked upstream as
+  ``deriva-mcp-core#3``).
+
+Why this is a tool, not a resource: it has a side effect (vector
+store mutation), even though catalog state is unchanged. ``mutates=False``
+because it doesn't change *catalog* state -- the audit log doesn't
+care about cache refreshes.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from deriva_mcp_core import deriva_call
+
+from deriva_ml_mcp._helpers import _error_envelope
+
+if TYPE_CHECKING:
+    from deriva_mcp_core.plugin.api import PluginContext
+
+
+def register(ctx: PluginContext) -> None:
+    """Register vocabulary management tools with the plugin context.
+
+    Args:
+        ctx: PluginContext supplied by deriva-mcp-core at startup.
+
+    Returns:
+        None.
+
+    Example:
+        >>> from deriva_mcp_core.plugin.api import PluginContext
+        >>> # ctx provided by the framework
+        >>> register(ctx)  # doctest: +SKIP
+    """
+
+    @ctx.tool(mutates=False)
+    async def deriva_ml_reindex_vocabularies(
+        hostname: str,
+        catalog_id: str,
+        vocab: str | None = None,
+    ) -> str:
+        """Force re-index of vocabulary tables in the RAG vector store.
+
+        Use after adding/removing terms via core's ``add_term`` /
+        ``delete_term`` tools (which don't fire any framework lifecycle
+        hook -- tracked upstream as deriva-mcp-core#3). The
+        ``deriva_ml_getting_started`` prompt's discovery section
+        explains when to call this.
+
+        ``mutates=False`` because the call does not change catalog
+        state -- the audit log treats cache refreshes as reads, so no
+        audit row is emitted on success or failure.
+
+        Args:
+            hostname: The Deriva server hostname.
+            catalog_id: The catalog ID as a string.
+            vocab: Optional vocab qname (``"schema.table"``). If
+                ``None``, re-indexes all vocabularies in the catalog.
+
+        Returns:
+            JSON string. Success: ``{"reindexed": {qname: term_count, ...}}``.
+            Failure: ``{"error": str}``.
+
+        Raises:
+            RuntimeError: Wrapped as ``{"error": ...}``, propagated
+                from ``ml.find_vocabularies`` /
+                ``ml.list_vocabulary_terms`` if catalog access itself
+                fails. Per-vocab failures during a successful pass are
+                swallowed and logged; they do not appear in the
+                response.
+
+        Example:
+            Re-index all vocabs after adding a Tissue_Type term::
+
+                deriva_ml_reindex_vocabularies(hostname="myhost", catalog_id="1")
+
+            Re-index only the Dataset_Type vocab::
+
+                deriva_ml_reindex_vocabularies(
+                    hostname="myhost",
+                    catalog_id="1",
+                    vocab="deriva-ml.Dataset_Type",
+                )
+        """
+        try:
+            with deriva_call():
+                # Imported lazily so module import time stays cheap and
+                # so test patches of ``rag._index_vocabularies`` reach
+                # this call site cleanly.
+                from deriva_ml_mcp.resources.rag import _index_vocabularies
+
+                indexed = await _index_vocabularies(hostname, catalog_id, only_vocab=vocab)
+            return json.dumps({"reindexed": indexed})
+        except Exception as exc:
+            return _error_envelope(
+                exc,
+                operation="reindex_vocabularies",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,  # not a catalog mutation
+            )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,49 @@
+"""Unit tests for ``deriva_ml_mcp._helpers``.
+
+The other helpers (``_error_envelope``, ``_paginate``, ``_read_rid``,
+``_row_rid_for``) are exercised end-to-end by the per-domain test suites
+and by the doctest examples in their own docstrings -- they have no
+dedicated test file. The small Table-rendering helpers added in v1.1
+(``_table_qname`` / ``_table_to_dict``) are pure value transforms with
+no domain coupling, so they get isolated tests here rather than being
+rolled into the dataset suite.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from deriva_ml_mcp._helpers import _table_qname, _table_to_dict
+
+
+def test_table_qname_joins_schema_and_name() -> None:
+    """``_table_qname`` produces the canonical ``schema.name`` string."""
+    t = MagicMock()
+    t.name = "Dataset_Type"
+    t.schema.name = "deriva-ml"
+    assert _table_qname(t) == "deriva-ml.Dataset_Type"
+
+
+def test_table_qname_handles_domain_schema() -> None:
+    """Works for domain-schema vocabularies, not just the ML schema."""
+    t = MagicMock()
+    t.name = "Tissue_Type"
+    t.schema.name = "demo-schema"
+    assert _table_qname(t) == "demo-schema.Tissue_Type"
+
+
+def test_table_to_dict_returns_canonical_shape() -> None:
+    """``_table_to_dict`` returns ``{"name", "schema"}`` -- the JSON shape used by tools."""
+    t = MagicMock()
+    t.name = "Image"
+    t.schema.name = "demo-schema"
+    assert _table_to_dict(t) == {"name": "Image", "schema": "demo-schema"}
+
+
+def test_table_to_dict_keys_are_lowercase() -> None:
+    """Pin the key names so any rename is caught here (callers depend on these keys)."""
+    t = MagicMock()
+    t.name = "X"
+    t.schema.name = "y"
+    out = _table_to_dict(t)
+    assert set(out.keys()) == {"name", "schema"}

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -87,9 +87,20 @@ _EXECUTION_TOOLS = frozenset(
     }
 )
 
-# Union of all per-domain tool sets. Phase 5 registers dataset + feature
-# + workflow + execution.
-_ALL_REGISTERED_TOOLS = _DATASET_TOOLS | _FEATURE_TOOLS | _WORKFLOW_TOOLS | _EXECUTION_TOOLS
+# v1.1 vocabulary domain -- one tool: a manual RAG re-index trigger.
+# It mutates the vector store but not catalog state, so mutates=False
+# (audit log treats cache refreshes as reads).
+_VOCABULARY_TOOLS = frozenset(
+    {
+        "deriva_ml_reindex_vocabularies",
+    }
+)
+
+# Union of all per-domain tool sets. Phase 5 registered dataset + feature
+# + workflow + execution; v1.1 adds vocabulary.
+_ALL_REGISTERED_TOOLS = (
+    _DATASET_TOOLS | _FEATURE_TOOLS | _WORKFLOW_TOOLS | _EXECUTION_TOOLS | _VOCABULARY_TOOLS
+)
 
 # All ML-domain MCP resource URIs registered by ``resources/ml.py``.
 # Mirrors the per-domain tool frozensets above so the same exact-equality
@@ -244,15 +255,17 @@ def test_register_wires_rag_github_source(ctx):
     assert ctx._rag_sources[0].name == "deriva-ml-docs"
 
 
-def test_register_wires_three_catalog_connect_hooks(ctx):
-    """``register(ctx)`` must wire the three per-user RAG catalog hooks.
+def test_register_wires_four_catalog_connect_hooks(ctx):
+    """``register(ctx)`` must wire the four RAG catalog hooks.
 
-    Hook identity is already covered by ``tests/test_rag.py``; this
-    test only pins the count so that dropping one hook from
-    ``register_rag_sources`` is also caught at the plugin level.
+    Three per-user row indexers (Dataset, Workflow, Execution) plus
+    one catalog-public vocab indexer (added in v1.1). Hook identity
+    is already covered by ``tests/test_rag.py``; this test only pins
+    the count so that dropping one hook from ``register_rag_sources``
+    is also caught at the plugin level.
     """
     register(ctx)
-    assert len(ctx._catalog_connect_hooks) == 3
+    assert len(ctx._catalog_connect_hooks) == 4
 
 
 def test_register_wires_three_prompts(ctx, capturing_mcp):
@@ -275,10 +288,78 @@ def test_register_does_not_use_rag_dataset_indexer(ctx):
     shared across all users (the enricher fires under whichever
     credential happens to connect first), which would leak per-user ACL
     rows across users. Phase 6.3 deliberately rejected this API in
-    favor of per-user ``on_catalog_connect`` hooks. If a future commit
-    accidentally introduces a call to ``ctx.rag_dataset_indexer(...)``
-    anywhere in the plugin (in ``tools/``, ``resources/``, or any new
-    file), this test catches it at the plugin level.
+    favor of per-user ``on_catalog_connect`` hooks. v1.1 vocab indexing
+    likewise rejects it -- vocab chunks land via direct store writes
+    under a custom ``vocab:`` prefix, not via ``rag_dataset_indexer``.
+    If a future commit accidentally introduces a call to
+    ``ctx.rag_dataset_indexer(...)`` anywhere in the plugin (in
+    ``tools/``, ``resources/``, or any new file), this test catches it
+    at the plugin level.
     """
     register(ctx)
     assert len(ctx._rag_dataset_indexers) == 0
+
+
+def test_vocab_hook_writes_to_vocab_prefix_not_data_prefix(ctx):
+    """Architectural carve-out pin: vocab chunks land under ``vocab:``, never ``data:``.
+
+    The vocab hook is the fourth ``on_catalog_connect`` hook registered
+    by ``register_rag_sources``. It MUST write to the vector store
+    under a ``vocab:`` source prefix (catalog-public, no per-user
+    partitioning) and MUST NOT route through ``index_table_data``
+    (whose source naming is hardcoded to ``data:{host}:{cat}:{user_id}``
+    -- which would (a) over-partition vocabularies per user, and (b)
+    get caught by upstream's ``data:`` user-id filter for any caller
+    whose user_id differs from the indexer's).
+
+    The test fires the registered vocab hook with a mocked ``ml`` and
+    ``store``, then asserts every chunk passed to ``store.add`` carries
+    a source starting with ``vocab:``. If a future refactor pushes
+    vocab indexing through ``index_table_data`` instead, the chunks
+    would carry ``data:`` and this test would fail.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    register(ctx)
+    vocab_hook = ctx._catalog_connect_hooks[3]
+
+    # Mock the vocab table the hook iterates over.
+    vocab_table = MagicMock()
+    vocab_table.name = "Dataset_Type"
+    vocab_table.schema.name = "deriva-ml"
+    term = MagicMock()
+    term.name = "Training"
+    term.description = "training-data partition"
+    term.synonyms = []
+    term.rid = "1-TRAIN"
+
+    fake_ml = MagicMock()
+    fake_ml.find_vocabularies.return_value = [vocab_table]
+    fake_ml.list_vocabulary_terms.return_value = [term]
+
+    fake_store = MagicMock()
+    fake_store.delete_source = AsyncMock()
+    fake_store.add = AsyncMock()
+
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=fake_store),
+        patch.object(rag_module, "get_ml", return_value=fake_ml),
+    ):
+        import asyncio
+
+        asyncio.run(vocab_hook("h.example", "1", "hash", {}))
+
+    # All chunks land under vocab:..., never data:... .
+    add_calls = fake_store.add.await_args_list
+    assert add_calls, "vocab hook should have written at least one chunk batch"
+    for call in add_calls:
+        chunks = call.args[0]
+        for chunk in chunks:
+            assert chunk.source.startswith("vocab:"), (
+                f"vocab hook produced non-vocab source: {chunk.source!r}"
+            )
+            assert not chunk.source.startswith("data:"), (
+                f"vocab hook accidentally routed through data: prefix: {chunk.source!r}"
+            )

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -36,12 +36,13 @@ def _run(coro):
 
 
 # Hook registration order in register_rag_sources(ctx):
-#   0 -> Dataset, 1 -> Workflow, 2 -> Execution.
+#   0 -> Dataset, 1 -> Workflow, 2 -> Execution, 3 -> Vocabularies.
 # Tests pull hooks via index rather than by name because the factory
 # refactor produces anonymous closures (no module-level attribute to import).
 _DATASET_HOOK_IDX = 0
 _WORKFLOW_HOOK_IDX = 1
 _EXECUTION_HOOK_IDX = 2
+_VOCAB_HOOK_IDX = 3
 
 
 def _hook_at(idx: int):
@@ -86,9 +87,9 @@ def test_register_rag_sources_github_source_targets_deriva_ml_docs(rag_ctx) -> N
     assert decl.doc_type == "ml-docs"
 
 
-def test_register_rag_sources_registers_three_catalog_hooks(rag_ctx) -> None:
-    """Three on_catalog_connect callbacks are registered (Dataset, Workflow, Execution)."""
-    assert len(rag_ctx._catalog_connect_hooks) == 3
+def test_register_rag_sources_registers_four_catalog_hooks(rag_ctx) -> None:
+    """Four on_catalog_connect callbacks are registered (Dataset, Workflow, Execution, Vocab)."""
+    assert len(rag_ctx._catalog_connect_hooks) == 4
 
 
 def test_register_rag_sources_does_not_use_rag_dataset_indexer(rag_ctx) -> None:
@@ -461,3 +462,363 @@ def test_dataset_hook_partitions_per_user() -> None:
     assert fake_index.call_count == 2
     assert fake_index.call_args_list[0].kwargs["user_id"] == "userA"
     assert fake_index.call_args_list[1].kwargs["user_id"] == "userB"
+
+
+# ---------------------------------------------------------------------------
+# 7. _VocabSerializer
+# ---------------------------------------------------------------------------
+
+
+def test_vocab_serializer_renders_full_term() -> None:
+    """A populated vocab term renders all sections + parent table in header."""
+    from deriva_ml_mcp.resources.rag import _VocabSerializer
+
+    row = {
+        "name": "epithelial",
+        "description": "Epithelial tissue type.",
+        "synonyms": ["epithelium", "epi"],
+        "rid": "1-VOAA",
+    }
+    md = _VocabSerializer().serialize("demo-schema.Tissue_Type", row)
+
+    assert md is not None
+    assert md.startswith("## Vocab Term: epithelial (demo-schema.Tissue_Type)")
+    assert "**Description:** Epithelial tissue type." in md
+    assert "**Synonyms:** epithelium, epi" in md
+    assert "**RID:** 1-VOAA" in md
+
+
+def test_vocab_serializer_omits_empty_description() -> None:
+    """Term without description still renders header + synonyms + RID."""
+    from deriva_ml_mcp.resources.rag import _VocabSerializer
+
+    row = {
+        "name": "stromal",
+        "description": None,
+        "synonyms": ["stroma"],
+        "rid": "1-VOBB",
+    }
+    md = _VocabSerializer().serialize("demo-schema.Tissue_Type", row)
+
+    assert md is not None
+    assert md.startswith("## Vocab Term: stromal")
+    assert "Description" not in md
+    assert "**Synonyms:** stroma" in md
+    assert "**RID:** 1-VOBB" in md
+
+
+def test_vocab_serializer_omits_empty_synonyms() -> None:
+    """Term with empty synonyms list drops the line."""
+    from deriva_ml_mcp.resources.rag import _VocabSerializer
+
+    row = {
+        "name": "muscle",
+        "description": "Muscle tissue.",
+        "synonyms": [],
+        "rid": "1-VOCC",
+    }
+    md = _VocabSerializer().serialize("demo-schema.Tissue_Type", row)
+
+    assert md is not None
+    assert "Synonyms" not in md
+    assert "**Description:** Muscle tissue." in md
+
+
+def test_vocab_serializer_omits_both_empty() -> None:
+    """Term with neither description nor synonyms renders header + RID only."""
+    from deriva_ml_mcp.resources.rag import _VocabSerializer
+
+    row = {
+        "name": "bare",
+        "description": None,
+        "synonyms": None,
+        "rid": "1-VODD",
+    }
+    md = _VocabSerializer().serialize("demo-schema.Tissue_Type", row)
+
+    assert md is not None
+    assert md.startswith("## Vocab Term: bare")
+    assert "Description" not in md
+    assert "Synonyms" not in md
+    assert "**RID:** 1-VODD" in md
+
+
+def test_vocab_serializer_returns_none_when_name_missing() -> None:
+    """A row without a name is skipped (returns None)."""
+    from deriva_ml_mcp.resources.rag import _VocabSerializer
+
+    assert _VocabSerializer().serialize("schema.Vocab", {"description": "x"}) is None
+    assert _VocabSerializer().serialize("schema.Vocab", {"name": ""}) is None
+
+
+def test_vocab_serializer_accepts_capitalized_keys() -> None:
+    """ERMrest-style ``Name``/``Synonyms``/``Description``/``RID`` keys also work."""
+    from deriva_ml_mcp.resources.rag import _VocabSerializer
+
+    row = {
+        "Name": "foo",
+        "Description": "Foo desc",
+        "Synonyms": ["f"],
+        "RID": "1-VOEE",
+    }
+    md = _VocabSerializer().serialize("schema.Vocab", row)
+
+    assert md is not None
+    assert "## Vocab Term: foo (schema.Vocab)" in md
+    assert "**Description:** Foo desc" in md
+    assert "**Synonyms:** f" in md
+    assert "**RID:** 1-VOEE" in md
+
+
+# ---------------------------------------------------------------------------
+# 8. _index_vocabularies discovery / filter / failure-isolation / shared source
+# ---------------------------------------------------------------------------
+
+
+def _vocab_table(schema_name: str, table_name: str) -> MagicMock:
+    """Build a MagicMock standing in for a deriva-py Table with schema/name."""
+    t = MagicMock()
+    t.name = table_name
+    t.schema.name = schema_name
+    return t
+
+
+def _vocab_term(name: str, description: str | None, synonyms: list[str], rid: str) -> MagicMock:
+    """Build a MagicMock standing in for a VocabularyTerm."""
+    term = MagicMock()
+    term.name = name
+    term.description = description
+    term.synonyms = synonyms
+    term.rid = rid
+    return term
+
+
+def test_index_vocabularies_writes_one_source_per_vocab() -> None:
+    """All discovered vocabs land under their own ``vocab:`` source."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    vocabs = [
+        _vocab_table("deriva-ml", "Dataset_Type"),
+        _vocab_table("deriva-ml", "Workflow_Type"),
+        _vocab_table("demo-schema", "Tissue_Type"),
+    ]
+    terms_by_table = {
+        "deriva-ml.Dataset_Type": [_vocab_term("Training", "train", [], "1-T1")],
+        "deriva-ml.Workflow_Type": [
+            _vocab_term("Model_Training", None, ["MT"], "1-T2"),
+            _vocab_term("Eval", "eval", [], "1-T3"),
+        ],
+        "demo-schema.Tissue_Type": [_vocab_term("epi", None, [], "1-T4")],
+    }
+
+    fake_ml = MagicMock()
+    fake_ml.find_vocabularies.return_value = vocabs
+    fake_ml.list_vocabulary_terms.side_effect = lambda t: terms_by_table[
+        f"{t.schema.name}.{t.name}"
+    ]
+    fake_store = MagicMock()
+    fake_store.delete_source = AsyncMock()
+    fake_store.add = AsyncMock()
+
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=fake_store),
+        patch.object(rag_module, "get_ml", return_value=fake_ml),
+    ):
+        result = _run(rag_module._index_vocabularies("h.example", "1"))
+
+    assert result == {
+        "deriva-ml.Dataset_Type": 1,
+        "deriva-ml.Workflow_Type": 2,
+        "demo-schema.Tissue_Type": 1,
+    }
+    deleted_sources = [c.args[0] for c in fake_store.delete_source.call_args_list]
+    assert "vocab:h.example:1:deriva-ml.Dataset_Type" in deleted_sources
+    assert "vocab:h.example:1:deriva-ml.Workflow_Type" in deleted_sources
+    assert "vocab:h.example:1:demo-schema.Tissue_Type" in deleted_sources
+
+    # Every chunk written carries the vocab: prefix (catalog-public carve-out).
+    for call in fake_store.add.call_args_list:
+        chunks = call.args[0]
+        for chunk in chunks:
+            assert chunk.source.startswith("vocab:h.example:1:")
+
+
+def test_index_vocabularies_filter_only_writes_requested_vocab() -> None:
+    """``only_vocab='schema.X'`` indexes only that vocab; others are skipped."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    vocabs = [
+        _vocab_table("deriva-ml", "Dataset_Type"),
+        _vocab_table("deriva-ml", "Workflow_Type"),
+    ]
+    fake_ml = MagicMock()
+    fake_ml.find_vocabularies.return_value = vocabs
+    fake_ml.list_vocabulary_terms.return_value = [_vocab_term("X", None, [], "1-T")]
+
+    fake_store = MagicMock()
+    fake_store.delete_source = AsyncMock()
+    fake_store.add = AsyncMock()
+
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=fake_store),
+        patch.object(rag_module, "get_ml", return_value=fake_ml),
+    ):
+        result = _run(
+            rag_module._index_vocabularies("h.example", "1", only_vocab="deriva-ml.Workflow_Type")
+        )
+
+    assert result == {"deriva-ml.Workflow_Type": 1}
+    deleted_sources = [c.args[0] for c in fake_store.delete_source.call_args_list]
+    assert deleted_sources == ["vocab:h.example:1:deriva-ml.Workflow_Type"]
+
+
+def test_index_vocabularies_per_vocab_failures_are_isolated(caplog) -> None:
+    """A fetch error on one vocab does not abort the whole pass."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    bad = _vocab_table("deriva-ml", "Broken_Vocab")
+    good = _vocab_table("deriva-ml", "Working_Vocab")
+    fake_ml = MagicMock()
+    fake_ml.find_vocabularies.return_value = [bad, good]
+
+    def fake_terms(t):
+        if t is bad:
+            raise RuntimeError("boom")
+        return [_vocab_term("ok", None, [], "1-OK")]
+
+    fake_ml.list_vocabulary_terms.side_effect = fake_terms
+
+    fake_store = MagicMock()
+    fake_store.delete_source = AsyncMock()
+    fake_store.add = AsyncMock()
+
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=fake_store),
+        patch.object(rag_module, "get_ml", return_value=fake_ml),
+        caplog.at_level("ERROR", logger="deriva_ml_mcp.resources.rag"),
+    ):
+        result = _run(rag_module._index_vocabularies("h.example", "1"))
+
+    assert result == {"deriva-ml.Working_Vocab": 1}
+    assert any("Broken_Vocab" in record.message for record in caplog.records)
+
+
+def test_index_vocabularies_short_circuits_when_store_none() -> None:
+    """``get_rag_store() is None`` -> empty result, no ml call."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    fake_ml = MagicMock()  # should not even be touched
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=None),
+        patch.object(rag_module, "get_ml", return_value=fake_ml),
+    ):
+        result = _run(rag_module._index_vocabularies("h.example", "1"))
+
+    assert result == {}
+    fake_ml.find_vocabularies.assert_not_called()
+
+
+def test_index_vocabularies_uses_shared_source_across_users() -> None:
+    """Two consecutive runs (different identities) write under the SAME source name.
+
+    Vocabularies have no per-user ACL -- the source name is keyed only
+    by (hostname, catalog_id, vocab qname). Two runs back-to-back must
+    target the same ``vocab:...`` source regardless of caller, so the
+    second run replaces the first (drain-then-add) instead of forking
+    a per-user partition.
+    """
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    vocabs = [_vocab_table("deriva-ml", "Dataset_Type")]
+    fake_ml = MagicMock()
+    fake_ml.find_vocabularies.return_value = vocabs
+    fake_ml.list_vocabulary_terms.return_value = [_vocab_term("Training", None, [], "1-T")]
+
+    fake_store = MagicMock()
+    fake_store.delete_source = AsyncMock()
+    fake_store.add = AsyncMock()
+
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=fake_store),
+        patch.object(rag_module, "get_ml", return_value=fake_ml),
+    ):
+        _run(rag_module._index_vocabularies("h.example", "1"))
+        _run(rag_module._index_vocabularies("h.example", "1"))
+
+    deleted_sources = [c.args[0] for c in fake_store.delete_source.call_args_list]
+    expected = "vocab:h.example:1:deriva-ml.Dataset_Type"
+    assert deleted_sources == [expected, expected]
+
+
+# ---------------------------------------------------------------------------
+# 9. Vocab on_catalog_connect hook
+# ---------------------------------------------------------------------------
+
+
+def test_vocab_hook_calls_index_vocabularies_with_args() -> None:
+    """The vocab hook forwards (hostname, catalog_id) to ``_index_vocabularies``."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    fake = AsyncMock(return_value={})
+    with patch.object(rag_module, "_index_vocabularies", new=fake):
+        _run(_hook_at(_VOCAB_HOOK_IDX)("h.example", "1", "hash", {}))
+
+    fake.assert_awaited_once_with("h.example", "1")
+
+
+def test_vocab_hook_swallows_index_exception() -> None:
+    """If _index_vocabularies raises, the hook logs and does not propagate."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    fake = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch.object(rag_module, "_index_vocabularies", new=fake):
+        # Must not raise.
+        _run(_hook_at(_VOCAB_HOOK_IDX)("h.example", "1", "hash", {}))
+
+
+# ---------------------------------------------------------------------------
+# 10. _write_vocab_chunks delete-then-add semantics
+# ---------------------------------------------------------------------------
+
+
+def test_write_vocab_chunks_deletes_then_adds() -> None:
+    """``delete_source`` is called first, then chunks are added via ``store.add``."""
+    from deriva_ml_mcp.resources.rag import _VocabSerializer, _write_vocab_chunks
+
+    fake_store = MagicMock()
+    fake_store.delete_source = AsyncMock()
+    fake_store.add = AsyncMock()
+    terms = [
+        {"name": "a", "description": "alpha", "synonyms": [], "rid": "1-A"},
+        {"name": "b", "description": "beta", "synonyms": ["B"], "rid": "1-B"},
+    ]
+    count = _run(
+        _write_vocab_chunks(
+            fake_store,
+            "vocab:h:1:s.t",
+            "s.t",
+            terms,
+            _VocabSerializer(),
+        )
+    )
+
+    assert count == 2
+    fake_store.delete_source.assert_awaited_once_with("vocab:h:1:s.t")
+    assert fake_store.add.await_count == 1
+    chunks = fake_store.add.await_args.args[0]
+    assert all(c.source == "vocab:h:1:s.t" for c in chunks)
+    assert all(c.doc_type == "catalog-data" for c in chunks)
+
+
+def test_write_vocab_chunks_empty_terms_drains_only() -> None:
+    """An empty term list still drains the prior source but does not call add."""
+    from deriva_ml_mcp.resources.rag import _VocabSerializer, _write_vocab_chunks
+
+    fake_store = MagicMock()
+    fake_store.delete_source = AsyncMock()
+    fake_store.add = AsyncMock()
+    count = _run(_write_vocab_chunks(fake_store, "vocab:h:1:s.t", "s.t", [], _VocabSerializer()))
+
+    assert count == 0
+    fake_store.delete_source.assert_awaited_once_with("vocab:h:1:s.t")
+    fake_store.add.assert_not_called()

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -1,0 +1,129 @@
+"""Unit tests for the vocabulary domain tool.
+
+The single tool exposed by ``tools/vocabulary.py`` is the manual
+``deriva_ml_reindex_vocabularies`` re-indexer. It's a thin wrapper
+around ``resources.rag._index_vocabularies`` (the same coroutine the
+on_catalog_connect hook fires) -- the tests focus on the wrapper's
+contract: success-path JSON shape, the ``vocab=`` qname filter
+forwarding, and the ``mutates=False`` no-audit-on-failure guarantee
+(audit log is for catalog state changes; cache refreshes don't count).
+
+Note on audit patching: unlike the other domain test files, this one
+patches only ``deriva_ml_mcp._helpers.audit_event`` -- the failure-path
+bind site. The tool module itself never imports ``audit_event``
+(success path is mutates=False, so no emission anywhere). A single
+patch is sufficient to assert "audit_event was not called".
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+def _patch_helpers_audit():
+    """Context manager that patches the helpers-module audit_event bind site.
+
+    The vocabulary tool is mutates=False on both success and failure
+    paths, so neither bind site should ever fire. This single patch is
+    sufficient to assert that contract (helpers.audit_event is the
+    failure-path entry; the tool module never imports the success-path
+    binding because it never emits one).
+    """
+    return patch("deriva_ml_mcp._helpers.audit_event")
+
+
+@pytest.fixture()
+def vocab_ctx(ctx):
+    """Register vocabulary tools on a fresh PluginContext."""
+    from deriva_ml_mcp.tools import vocabulary as vocabulary_module
+
+    vocabulary_module.register(ctx)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+
+async def test_reindex_all_vocabs_returns_indexed_dict(vocab_ctx, capturing_mcp):
+    """No ``vocab`` arg -> _index_vocabularies called with only_vocab=None."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    indexed = {
+        "deriva-ml.Dataset_Type": 7,
+        "deriva-ml.Workflow_Type": 4,
+    }
+    with (
+        patch.object(rag_module, "_index_vocabularies", return_value=indexed) as fake_index,
+        _patch_helpers_audit() as mock_audit,
+    ):
+        result = await capturing_mcp.tools["deriva_ml_reindex_vocabularies"](
+            hostname="h.example", catalog_id="1"
+        )
+
+    fake_index.assert_awaited_once_with("h.example", "1", only_vocab=None)
+    payload = json.loads(result)
+    assert payload == {"reindexed": indexed}
+    # mutates=False -> no audit emission on success.
+    mock_audit.assert_not_called()
+
+
+async def test_reindex_specific_vocab_forwards_filter(vocab_ctx, capturing_mcp):
+    """``vocab="schema.X"`` is forwarded to _index_vocabularies as ``only_vocab``."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    indexed = {"deriva-ml.Workflow_Type": 4}
+    with patch.object(rag_module, "_index_vocabularies", return_value=indexed) as fake_index:
+        result = await capturing_mcp.tools["deriva_ml_reindex_vocabularies"](
+            hostname="h.example", catalog_id="1", vocab="deriva-ml.Workflow_Type"
+        )
+
+    fake_index.assert_awaited_once_with("h.example", "1", only_vocab="deriva-ml.Workflow_Type")
+    payload = json.loads(result)
+    assert payload == {"reindexed": indexed}
+
+
+async def test_reindex_empty_result_is_propagated(vocab_ctx, capturing_mcp):
+    """If no vocab indexed (e.g. RAG disabled, _index returns {}) we still return success shape."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    with patch.object(rag_module, "_index_vocabularies", return_value={}):
+        result = await capturing_mcp.tools["deriva_ml_reindex_vocabularies"](
+            hostname="h.example", catalog_id="1"
+        )
+
+    payload = json.loads(result)
+    assert payload == {"reindexed": {}}
+
+
+# ---------------------------------------------------------------------------
+# Error path -- mutates=False, so no audit emission even on failure
+# ---------------------------------------------------------------------------
+
+
+async def test_reindex_failure_returns_error_envelope_without_audit(vocab_ctx, capturing_mcp):
+    """A raised exception lands as ``{"error": ...}`` and does NOT emit an audit event.
+
+    ``mutates=False`` is the contract: the audit log is for catalog
+    state changes; a cache refresh failure (vector-store outage,
+    catalog auth glitch) doesn't change catalog state and so doesn't
+    rate an audit row -- only an error log line.
+    """
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    with (
+        patch.object(rag_module, "_index_vocabularies", side_effect=RuntimeError("boom")),
+        _patch_helpers_audit() as mock_audit,
+    ):
+        result = await capturing_mcp.tools["deriva_ml_reindex_vocabularies"](
+            hostname="h.example", catalog_id="1"
+        )
+
+    payload = json.loads(result)
+    assert "error" in payload
+    assert "boom" in payload["error"]
+    mock_audit.assert_not_called()


### PR DESCRIPTION
Closes #5.

## Summary

- Discovers all vocabulary tables (built-in ML + user-defined domain) on first catalog connect via `ml.find_vocabularies()` and writes each vocab's terms to `vocab:{host}:{cat}:{schema}.{table}` -- a custom source prefix that bypasses upstream's `data:` user-id filter so chunks are served to all users (vocabularies are catalog-public).
- Each term renders to markdown with name + description + synonyms + RID, so `rag_search` hits the full semantic surface.
- New `deriva_ml_reindex_vocabularies` tool (mutates=False) is the manual bridge for after-the-fact mutations via core's `add_term` / `delete_term` (which don't fire any framework lifecycle hook -- tracked upstream as deriva-mcp-core#3).
- Prompt update: `deriva_ml_getting_started` gains a "Discovery: resolving user-mentioned names to catalog identifiers" section + an "Index coverage by category" reference -- the picker pattern (exact-match-first; soft-confirm single hit; explicit picker on ambiguous; clarifying question on no hit) is documented for vocab terms, table/column names, workflows, datasets, executions, and features.
- New helpers `_table_qname` / `_table_to_dict` in `_helpers.py`; refactored the one inline use site in `tools/dataset.py:609`.

## Vocab freshness

- First catalog connect per server lifetime: bulk index via the new `on_catalog_connect` hook (4 hooks total now, was 3 row-indexer hooks).
- Manual: `deriva_ml_reindex_vocabularies` tool re-runs the discovery + per-vocab write.

## Test plan

- [x] `uv run pytest tests/ -m "not integration" -q` -> 225 passed (was 201; +24 vocab/helper tests)
- [x] `uv run ruff check src tests` -> all checks passed
- [x] `uv run ruff format --check src tests` -> 33 files already formatted
- [x] New plugin-level pin `test_vocab_hook_writes_to_vocab_prefix_not_data_prefix` asserts the `vocab:` prefix architectural carve-out
- [x] Existing pin `test_register_does_not_use_rag_dataset_indexer` continues to pass (vocab path uses direct store writes, not `rag_dataset_indexer`)
- [ ] Integration tests against a live demo catalog (deferred to a follow-up commit -- the design needs a vocab to actually exist in the demo catalog; verify after the unit tests are green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)