### PR TITLE
v1.3.0 #8: surgical per-RID re-indexing for Dataset/Workflow/Execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,12 +55,28 @@ into a focused-submodule package.
 enriched source shared across users (`enriched:{host}:{cat}:{schema}:{table}`),
 which leaks data for any catalog table where rows have user-specific
 ACLs. Instead, the plugin uses `ctx.on_catalog_connect(...)` with
-`index_table_data(..., user_id=resolve_user_identity(hostname))` so
-each user's chunks land under `data:{host}:{cat}:{user_id}` and ACL
-is applied at fetch time using the calling user's credential. The
-plugin-level test `test_register_does_not_use_rag_dataset_indexer`
-pins this; future commits accidentally calling the unsafe API will
-fail CI.
+direct `store.delete_source + store.add` writes so each user's chunks
+land under per-RID source names of the shape
+`data:{host}:{cat}:{user_id}:{table}:{rid}` (v1.3) and ACL is applied
+at fetch time using the calling user's credential. The `data:` prefix
+keeps upstream's `rag_search` user-id filter in play (it accepts both
+the legacy bulk form `data:{host}:{cat}:{user_id}` and prefix-match
+on the per-RID form). The plugin-level test
+`test_register_does_not_use_rag_dataset_indexer` pins the unsafe-API
+ban; `test_data_sources_use_per_rid_naming` pins the v1.3 source-name
+shape; future commits accidentally calling the unsafe API or
+regressing the source-name shape will fail CI.
+
+**Surgical per-RID re-index (v1.3).** Each mutating tool that affects
+a Dataset / Workflow / Execution row calls `_reindex_<entity>` (a
+lazy import inside the tool body, mirroring the v1.1 vocab indexer
+pattern) immediately after the catalog mutation succeeds. The
+re-index is best-effort: any failure is logged but does NOT propagate
+to the tool's success path (the catalog mutation already succeeded).
+The audit event for the catalog mutation always fires before the
+re-index call so audit captures the success regardless of cache
+state. Result: a freshly created or modified row is searchable via
+`rag_search` on the very next call from the same user.
 
 Vocabularies are the documented exception: vocab content is catalog-
 public (no per-user ACL), so the plugin writes vocab terms directly

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -194,6 +194,26 @@ These 52 old `deriva-mcp` tools were never analyzed in the per-domain phases (2-
 | deriva://storage/execution-dirs | resources.py | dropped | (none) | (none) | Local filesystem execution directories; same disposition as `storage/summary` |
 | deriva://cache/results | resources.py | dropped | (none) | (none) | Per-connection result cache from the dead connection-singleton era; no successor concept in the new architecture |
 
+## v1.3 surgical per-RID re-index design
+
+Each Dataset / Workflow / Execution chunk now lives in its own per-user
+source named `data:{host}:{cat}:{user_id}:{table}:{rid}` (one source per
+user-table-RID tuple) rather than the v1.0 bulk-per-user shape
+`data:{host}:{cat}:{user_id}`. Mutating tools call `_reindex_<entity>`
+(or `_delete_dataset_source` for `deriva_ml_delete_dataset`) inline
+after the catalog mutation succeeds so the affected source is refreshed
+immediately and `rag_search` finds the change on the very next call from
+the same user. The re-index is best-effort: a failure logs but does NOT
+propagate to the tool's success path. The audit event for the catalog
+mutation always fires before the re-index call so audit captures the
+success regardless of cache state. Required a small upstream change to
+the `rag_search` user-id filter (extended from exact equality to also
+prefix-match `data:{host}:{cat}:{user_id}:` for the v1.3 per-RID shape;
+the trailing colon prevents accidental string-prefix overlap from
+weakening per-user isolation). Cross-user freshness (user A's mutation
+-> user B's RAG view) is still imperfect and tracked separately as #9
+for v1.4.
+
 ## Upstream gaps (Phase 6 RAG)
 
 Two open `deriva-mcp-core` limitations. The other (issue #1) was filed during

--- a/src/deriva_ml_mcp/prompts.py
+++ b/src/deriva_ml_mcp/prompts.py
@@ -193,12 +193,18 @@ The picker pattern works for these categories. Freshness varies:
     exists in many tables and need to ask which one.
 
   Workflows, datasets, executions
-    Indexed by this plugin per-user. Fresh on first connect;
-    NOT automatically refreshed when new ones are created or
-    existing ones are modified (deriva-ml-mcp#8 tracks the
-    surgical re-index redesign). If the user just created or
-    modified one, prefer the deriva_ml_list_* tools or the
-    detail resources for that one over rag_search.
+    Indexed by this plugin per-user-per-RID. Fresh on first
+    connect AND surgically refreshed on every mutation: each
+    deriva_ml_create_* / deriva_ml_update_* / deriva_ml_delete_*
+    / deriva_ml_commit_execution / etc. tool refreshes just the
+    affected source(s) before returning. So a freshly created or
+    modified row is searchable via rag_search on the very next
+    call from the same user.
+
+    Cross-user freshness is still imperfect: user A's mutation
+    does NOT refresh user B's per-user sources, so user B sees
+    A's change only at next first-connect (deriva-ml-mcp#9 tracks
+    the cross-user invalidation work for v1.4).
 
 MUTATION: WORKFLOW -> EXECUTION -> OUTPUTS
 ------------------------------------------

--- a/src/deriva_ml_mcp/resources/rag.py
+++ b/src/deriva_ml_mcp/resources/rag.py
@@ -1,19 +1,24 @@
 """Per-user RAG indexing + vocab indexing + DerivaML docs source for deriva-ml-mcp.
 
-Phase 6.3 wired three things into the RAG subsystem; v1.1 adds a
-fourth (vocabularies):
+Phase 6.3 wired three things into the RAG subsystem; v1.1 added a
+fourth (vocabularies); v1.3 (this file) reshapes the per-user trio into
+per-user-per-RID surgical indexers:
 
 1. **One GitHub doc source** -- ``informatics-isi-edu/deriva-ml`` ``docs/``
    (declared synchronously via ``ctx.rag_github_source``). The indexer
    crawls it once when RAG is enabled.
 
-2. **Three per-user ``on_catalog_connect`` hooks** -- one each for
-   ``Dataset``, ``Workflow``, and ``Execution`` rows. Each hook resolves
-   the calling user's identity, fetches rows under that user's
-   credential, and upserts into the vector store with a user-scoped
-   source name (``data:{host}:{cat}:{user_id}``). The fetch path goes
+2. **Three per-user-per-RID ``on_catalog_connect`` hooks** -- one each
+   for ``Dataset``, ``Workflow``, and ``Execution`` rows. Each hook
+   resolves the calling user's identity, fetches rows under that user's
+   credential, and writes one source per (user, table, RID) tuple to
+   the vector store under
+   ``data:{host}:{cat}:{user_id}:{table}:{rid}``. The fetch path goes
    through the plugin's existing ``_list_*_impl`` helpers, so ACL
-   behavior matches the read tools.
+   behavior matches the read tools. The per-RID source naming lets
+   mutating tools surgically refresh just the affected source via
+   ``_reindex_<entity>(...)`` immediately after the catalog mutation,
+   so ``rag_search`` finds the change on the very next call.
 
 3. **One catalog-public ``on_catalog_connect`` hook for vocabularies**
    (v1.1) -- discovers all vocabulary tables via
@@ -32,14 +37,22 @@ fourth (vocabularies):
    (``_VocabSerializer``), each producing rich Markdown sections for
    the LLM (header, fields, subsections; empties omitted FaceBase-style).
 
-Why hooks + ``index_table_data`` for the per-user trio (not
-``ctx.rag_dataset_indexer``)? ``rag_dataset_indexer`` produces a single
-global enriched source shared across all users (the enricher fires
-under whichever credential happens to connect first). For ML data with
-per-user ACLs that would leak rows across users. The per-user pattern
-here partitions the source name by user identity and fetches under the
-calling user's credential -- same posture as every other tool in this
-plugin.
+Why per-user hooks (not ``ctx.rag_dataset_indexer``)?
+``rag_dataset_indexer`` produces a single global enriched source shared
+across all users (the enricher fires under whichever credential happens
+to connect first). For ML data with per-user ACLs that would leak rows
+across users. The per-user pattern here partitions the source name by
+user identity and fetches under the calling user's credential -- same
+posture as every other tool in this plugin.
+
+Why direct store writes for the per-user trio (not ``index_table_data``)?
+``index_table_data``'s source naming is hardcoded to
+``data:{host}:{cat}:{user_id}`` (one source per user, all rows lumped
+together). v1.3's surgical re-index needs one source per (user, table,
+RID) so a single RID's chunk can be replaced without touching the rest
+of the user's index. Direct ``store.delete_source + store.add`` per
+row gives us that. Source-name shape stays under the ``data:`` prefix
+so upstream's ``rag_search`` user-id filter continues to gate access.
 
 Why direct store writes (not ``index_table_data``) for vocabularies?
 ``index_table_data``'s source naming is hardcoded to
@@ -77,14 +90,14 @@ from typing import TYPE_CHECKING, Any
 from deriva_mcp_core.context import resolve_user_identity
 from deriva_mcp_core.rag import get_rag_store
 from deriva_mcp_core.rag.chunker import chunk_markdown
-from deriva_mcp_core.rag.data import RowSerializer, index_table_data
+from deriva_mcp_core.rag.data import RowSerializer
 from deriva_mcp_core.rag.store import Chunk
 
 from deriva_ml_mcp._helpers import _MAX_LIMIT, _table_qname
 from deriva_ml_mcp.ml_context import get_ml
-from deriva_ml_mcp.tools.dataset import _list_datasets_impl
-from deriva_ml_mcp.tools.execution import _list_executions_impl
-from deriva_ml_mcp.tools.workflow import _list_workflows_impl
+from deriva_ml_mcp.tools.dataset import _list_datasets_impl, _summarize_dataset
+from deriva_ml_mcp.tools.execution import _list_executions_impl, _summarize_execution
+from deriva_ml_mcp.tools.workflow import _list_workflows_impl, _summarize_workflow
 
 if TYPE_CHECKING:
     from deriva_mcp_core.plugin.api import PluginContext
@@ -104,6 +117,15 @@ _GITHUB_DOCS_DOC_TYPE = "ml-docs"
 _DATASET_TABLE = "Dataset"
 _WORKFLOW_TABLE = "Workflow"
 _EXECUTION_TABLE = "Execution"
+
+# URL-safe slug used as the {table} routing key inside per-RID source
+# names ``data:{host}:{cat}:{user_id}:{table}:{rid}``. Distinct from the
+# ERMrest-cased catalog table names above so the source name stays a
+# stable identifier even if a future table rename shifts the catalog
+# label.
+_DATASET_TOKEN = "dataset"
+_WORKFLOW_TOKEN = "workflow"
+_EXECUTION_TOKEN = "execution"
 
 
 # ---------------------------------------------------------------------------
@@ -313,42 +335,277 @@ def _fetch_execution_rows(hostname: str, catalog_id: str) -> list[dict[str, Any]
 def _coerce_for_index(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Round-trip rows through JSON to drop non-serializable values.
 
-    The execution summary contains ``datetime`` objects that
-    ``index_table_data`` does not need (the serializer renders them
-    directly), but other downstream consumers may. The cheapest way to
-    keep the rows JSON-friendly is to round-trip through ``json.dumps``
-    + ``json.loads`` with ``default=str``. Datasets and workflows pass
+    The execution summary contains ``datetime`` objects; the serializer
+    renders them directly via ``str()`` but the round-trip leaves
+    everything as plain JSON-compatible scalars before chunking, which
+    keeps the per-row write path simple. Datasets and workflows pass
     through unchanged.
     """
     return [json.loads(json.dumps(r, default=str)) for r in rows]
 
 
 # ---------------------------------------------------------------------------
-# Hook factory
+# Per-RID source naming + single-row write (v1.3 surgical re-index path)
+# ---------------------------------------------------------------------------
+
+
+def _row_source_name(
+    hostname: str,
+    catalog_id: str,
+    user_id: str,
+    table_token: str,
+    rid: str,
+) -> str:
+    """Build the canonical per-RID ``data:`` source name for one user-table-RID tuple.
+
+    The trailing ``{table}:{rid}`` segment is what makes the per-user
+    trio's source naming surgical: each row lands in its own source so
+    a mutating tool can replace just that one source via
+    ``store.delete_source + store.add`` without touching the rest of
+    the user's index.
+
+    The ``data:{host}:{cat}:{user_id}`` prefix is preserved (verbatim)
+    so upstream's ``rag_search`` user-id filter (which accepts both the
+    bulk form ``data:{host}:{cat}:{user_id}`` and prefix-match on
+    ``data:{host}:{cat}:{user_id}:`` for the per-RID form) continues
+    to gate access correctly.
+
+    Args:
+        hostname: Deriva hostname.
+        catalog_id: Catalog ID or alias.
+        user_id: Subject identifier (``sub`` claim) for the calling user.
+        table_token: One of ``_DATASET_TOKEN`` / ``_WORKFLOW_TOKEN`` /
+            ``_EXECUTION_TOKEN``. URL-safe slug, distinct from the
+            ERMrest-cased catalog table name.
+        rid: RID of the row (e.g. ``"1-AAAA"``).
+
+    Returns:
+        ``f"data:{hostname}:{catalog_id}:{user_id}:{table_token}:{rid}"``.
+
+    Example:
+        >>> _row_source_name("h", "1", "u", "dataset", "1-AAAA")
+        'data:h:1:u:dataset:1-AAAA'
+    """
+    return f"data:{hostname}:{catalog_id}:{user_id}:{table_token}:{rid}"
+
+
+async def _write_row_chunk(
+    store: VectorStore,
+    source: str,
+    table_name: str,
+    row: dict[str, Any],
+    serializer: RowSerializer,
+) -> int:
+    """Render one row and replace the existing source with its chunks.
+
+    Pattern: ``delete_source`` (idempotent -- drains any prior version
+    of this RID's chunks if present); render the row via the serializer;
+    chunk via ``chunk_markdown``; ``store.add`` the resulting chunks.
+    Mirrors ``_write_vocab_chunks`` from v1.1 but for a single row.
+
+    Args:
+        store: An active ``VectorStore`` (call site checks for ``None``).
+        source: Canonical per-RID source name from ``_row_source_name``.
+        table_name: ERMrest-cased catalog table name. Passed through to
+            the serializer for dispatch.
+        row: A single summary-shape row dict (the form
+            ``_summarize_dataset`` / ``_summarize_workflow`` /
+            ``_summarize_execution`` produce).
+        serializer: The ``RowSerializer`` for the row's table.
+
+    Returns:
+        Count of chunks actually written (typically 1 -- one summary
+        renders to one chunk under the 800-token chunk budget). 0 if
+        the serializer returned None for the row.
+    """
+    await store.delete_source(source)
+    rendered = serializer.serialize(table_name, row)
+    if rendered is None:
+        return 0
+    chunks: list[Chunk] = []
+    chunk_index = 0
+    # TODO(upstream-rag-doctype): tracked as deriva-mcp-core#2.
+    # Once chunks can carry a domain-specific doc_type, switch to
+    # "ml-dataset" / "ml-workflow" / "ml-execution" so
+    # rag_search(doc_type=...) can distinguish these from generic
+    # catalog-data chunks.
+    for c in chunk_markdown(rendered, source=source, doc_type="catalog-data"):
+        chunks.append(
+            Chunk(
+                text=c.text,
+                source=source,
+                doc_type="catalog-data",
+                section_heading=c.section_heading,
+                heading_hierarchy=c.heading_hierarchy,
+                chunk_index=chunk_index,
+            )
+        )
+        chunk_index += 1
+    if chunks:
+        await store.add(chunks)
+    return len(chunks)
+
+
+# ---------------------------------------------------------------------------
+# Surgical per-RID re-index entry points called inline from mutating tools
+# ---------------------------------------------------------------------------
+
+
+async def _reindex_dataset(hostname: str, catalog_id: str, dataset_rid: str) -> int:
+    """Refresh just one Dataset row's chunk for the calling user.
+
+    Best-effort: any failure (fetch, render, store I/O) is logged and
+    swallowed -- a re-index hiccup must not propagate to the calling
+    tool's success path (the catalog mutation already succeeded). On
+    failure returns 0; the next first-connect for this user picks the
+    row up via the bulk path.
+
+    Args:
+        hostname: Deriva hostname.
+        catalog_id: Catalog ID or alias.
+        dataset_rid: RID of the dataset to refresh.
+
+    Returns:
+        Count of chunks written (typically 1; 0 on best-effort failure
+        or when RAG is disabled).
+    """
+    store = get_rag_store()
+    if store is None:
+        return 0
+    try:
+        ml = get_ml(hostname, catalog_id)
+        ds = ml.lookup_dataset(dataset_rid)
+        row = _summarize_dataset(ds)
+        # Round-trip through json so any stray non-serializable values
+        # (e.g. Pydantic versions) become plain strings before chunking.
+        row = json.loads(json.dumps(row, default=str))
+        user_id = resolve_user_identity(hostname)
+        source = _row_source_name(hostname, catalog_id, user_id, _DATASET_TOKEN, dataset_rid)
+        return await _write_row_chunk(store, source, _DATASET_TABLE, row, _DatasetSerializer())
+    except Exception:  # noqa: BLE001 -- best-effort cache refresh
+        logger.exception(
+            "deriva-ml RAG: surgical re-index failed for dataset %s in %s/%s",
+            dataset_rid,
+            hostname,
+            catalog_id,
+        )
+        return 0
+
+
+async def _reindex_workflow(hostname: str, catalog_id: str, workflow_rid: str) -> int:
+    """Refresh just one Workflow row's chunk for the calling user.
+
+    Best-effort; see ``_reindex_dataset`` for the failure-handling contract.
+    """
+    store = get_rag_store()
+    if store is None:
+        return 0
+    try:
+        ml = get_ml(hostname, catalog_id)
+        wf = ml.lookup_workflow(workflow_rid)
+        row = _summarize_workflow(wf)
+        row = json.loads(json.dumps(row, default=str))
+        user_id = resolve_user_identity(hostname)
+        source = _row_source_name(hostname, catalog_id, user_id, _WORKFLOW_TOKEN, workflow_rid)
+        return await _write_row_chunk(store, source, _WORKFLOW_TABLE, row, _WorkflowSerializer())
+    except Exception:  # noqa: BLE001 -- best-effort cache refresh
+        logger.exception(
+            "deriva-ml RAG: surgical re-index failed for workflow %s in %s/%s",
+            workflow_rid,
+            hostname,
+            catalog_id,
+        )
+        return 0
+
+
+async def _reindex_execution(hostname: str, catalog_id: str, execution_rid: str) -> int:
+    """Refresh just one Execution row's chunk for the calling user.
+
+    Best-effort; see ``_reindex_dataset`` for the failure-handling contract.
+    """
+    store = get_rag_store()
+    if store is None:
+        return 0
+    try:
+        ml = get_ml(hostname, catalog_id)
+        record = ml.lookup_execution(execution_rid)
+        row = _summarize_execution(record)
+        row = json.loads(json.dumps(row, default=str))
+        user_id = resolve_user_identity(hostname)
+        source = _row_source_name(hostname, catalog_id, user_id, _EXECUTION_TOKEN, execution_rid)
+        return await _write_row_chunk(store, source, _EXECUTION_TABLE, row, _ExecutionSerializer())
+    except Exception:  # noqa: BLE001 -- best-effort cache refresh
+        logger.exception(
+            "deriva-ml RAG: surgical re-index failed for execution %s in %s/%s",
+            execution_rid,
+            hostname,
+            catalog_id,
+        )
+        return 0
+
+
+async def _delete_dataset_source(hostname: str, catalog_id: str, dataset_rid: str) -> bool:
+    """Drop a single Dataset's per-RID source from the calling user's index.
+
+    Used by ``deriva_ml_delete_dataset`` -- the row is gone from the
+    catalog, so its chunk should not survive in RAG either. Best-effort:
+    a delete failure is logged and swallowed.
+
+    Args:
+        hostname: Deriva hostname.
+        catalog_id: Catalog ID or alias.
+        dataset_rid: RID of the dataset whose source should be dropped.
+
+    Returns:
+        True on success, False on failure or when RAG is disabled.
+    """
+    store = get_rag_store()
+    if store is None:
+        return False
+    try:
+        user_id = resolve_user_identity(hostname)
+        source = _row_source_name(hostname, catalog_id, user_id, _DATASET_TOKEN, dataset_rid)
+        await store.delete_source(source)
+        return True
+    except Exception:  # noqa: BLE001 -- best-effort cache refresh
+        logger.exception(
+            "deriva-ml RAG: failed to drop source for deleted dataset %s in %s/%s",
+            dataset_rid,
+            hostname,
+            catalog_id,
+        )
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Hook factory (first-connect bulk index, per-RID source naming)
 # ---------------------------------------------------------------------------
 
 
 def _make_hook(
     fetch_fn: Callable[[str, str], list[dict[str, Any]]],
     table_name: str,
+    table_token: str,
     serializer: RowSerializer,
 ) -> Callable[[str, str, str, dict], Awaitable[None]]:
-    """Build an ``on_catalog_connect`` hook that indexes ``table_name`` per-user.
+    """Build an ``on_catalog_connect`` hook that indexes ``table_name`` per-user-per-RID.
 
     The returned coroutine fetches rows under the caller's credential,
-    resolves the calling user's identity, and upserts the rendered chunks
-    into the vector store with a user-scoped source name. Adding a
-    fourth indexed table is a one-liner at the call site.
+    resolves the calling user's identity, and writes one source per
+    (user, table_token, RID) tuple to the vector store. Same total
+    chunk count as v1.0/v1.1's bulk pattern; the difference is that
+    they land in N sources instead of 1, so individual rows can later
+    be replaced surgically by ``_reindex_<entity>``.
 
     Behavior contract:
 
     - Wraps the fetch in ``try/except`` so a deriva-ml read failure is
-      logged with table context but does not propagate. The framework's
-      ``_safe_call`` wraps the index step on its own, so we don't double
-      up there -- letting ``index_table_data`` raise gives the framework
-      a clean traceback to log.
+      logged with table context but does not propagate.
     - Skips silently (debug log) when ``get_rag_store()`` returns
       ``None`` -- i.e. when RAG is disabled in this deployment.
+    - Per-row write failures are isolated: a bad row is logged and the
+      loop continues with the rest, so one degenerate row does not
+      poison the whole user's first-connect index pass.
     - Logs a debug success line including row count + resolved user_id
       so an operator can investigate "why isn't user X's data showing up?"
       by flipping on debug logging without overwhelming production logs.
@@ -356,8 +613,11 @@ def _make_hook(
     Args:
         fetch_fn: Callable that takes ``(hostname, catalog_id)`` and
             returns summary-shape row dicts.
-        table_name: Catalog table the rows belong to. Used as both the
-            serializer dispatch key and the chunk header.
+        table_name: Catalog table the rows belong to (ERMrest case).
+            Used as the serializer dispatch key.
+        table_token: URL-safe slug for the source-name routing segment
+            (one of ``_DATASET_TOKEN`` / ``_WORKFLOW_TOKEN`` /
+            ``_EXECUTION_TOKEN``).
         serializer: The ``RowSerializer`` to render each row.
 
     Returns:
@@ -365,12 +625,6 @@ def _make_hook(
         ``(hostname, catalog_id, schema_hash, schema_json) -> None``.
     """
 
-    # TODO(upstream-rag-doctype): tracked as deriva-mcp-core#2
-    # (https://github.com/informatics-isi-edu/deriva-mcp-core/issues/2).
-    # Once index_table_data accepts a doc_type param, pass
-    # "ml-dataset" / "ml-workflow" / "ml-execution" so
-    # rag_search(doc_type=...) can distinguish these from generic
-    # catalog-data chunks. See docs/coverage.md "Upstream gaps".
     # schema_hash + schema_json are received because deriva-mcp-core's
     # _dispatch_catalog_connect signature requires them. We deliberately
     # ignore both: indexing depends only on (host, catalog_id, user_id,
@@ -394,20 +648,33 @@ def _make_hook(
             return
         store = get_rag_store()
         if store is None:
-            logger.debug("rag store unavailable, skipping %s index", table_name)
+            logger.debug("rag store unavailable, skipping %s first-connect index", table_name)
             return
         user_id = resolve_user_identity(hostname)
-        await index_table_data(
-            store,
-            hostname,
-            catalog_id,
-            table_name,
-            rows,
-            user_id=user_id,
-            serializer=serializer,
-        )
+        for row in rows:
+            rid = row.get("rid")
+            if not rid:
+                # Defensive: a row without a RID can't get a stable
+                # per-RID source name; skip with a debug log rather
+                # than silently dropping it under an empty-RID source.
+                logger.debug(
+                    "skipping %s first-connect row with empty rid: %r",
+                    table_name,
+                    row,
+                )
+                continue
+            source = _row_source_name(hostname, catalog_id, user_id, table_token, rid)
+            try:
+                await _write_row_chunk(store, source, table_name, row, serializer)
+            except Exception:  # noqa: BLE001 -- one bad row should not poison the pass
+                logger.exception(
+                    "deriva-ml RAG: failed to first-connect index %s row %s",
+                    table_name,
+                    rid,
+                )
+                continue
         logger.debug(
-            "indexed %d %s rows for user=%s host=%s catalog=%s",
+            "first-connect indexed %d %s rows for user=%s host=%s catalog=%s",
             len(rows),
             table_name,
             user_id,
@@ -600,12 +867,16 @@ def register_rag_sources(ctx: PluginContext) -> None:
 
     Hooks fire in registration order on every catalog connect:
 
-    1. Dataset (per-user, ``data:`` source prefix)
-    2. Workflow (per-user, ``data:`` source prefix)
-    3. Execution (per-user, ``data:`` source prefix)
+    1. Dataset (per-user-per-RID, ``data:{host}:{cat}:{user_id}:dataset:{rid}``)
+    2. Workflow (per-user-per-RID, ``data:{host}:{cat}:{user_id}:workflow:{rid}``)
+    3. Execution (per-user-per-RID, ``data:{host}:{cat}:{user_id}:execution:{rid}``)
     4. Vocabularies (catalog-public, custom ``vocab:`` source prefix --
        v1.1; bypasses upstream's ``data:`` user-id filter, served to
        all users in the catalog)
+
+    The first three are first-connect bulk indexers but write under
+    per-RID source names so mutating tools can later replace just one
+    affected source via the ``_reindex_<entity>`` helpers.
 
     Called from ``plugin.register(ctx)``. Safe to call without any RAG
     config -- ``ctx.rag_github_source`` is a no-op when RAG is
@@ -631,9 +902,15 @@ def register_rag_sources(ctx: PluginContext) -> None:
         path_prefix=_GITHUB_DOCS_PATH_PREFIX,
         doc_type=_GITHUB_DOCS_DOC_TYPE,
     )
-    ctx.on_catalog_connect(_make_hook(_fetch_dataset_rows, _DATASET_TABLE, _DatasetSerializer()))
-    ctx.on_catalog_connect(_make_hook(_fetch_workflow_rows, _WORKFLOW_TABLE, _WorkflowSerializer()))
     ctx.on_catalog_connect(
-        _make_hook(_fetch_execution_rows, _EXECUTION_TABLE, _ExecutionSerializer())
+        _make_hook(_fetch_dataset_rows, _DATASET_TABLE, _DATASET_TOKEN, _DatasetSerializer())
+    )
+    ctx.on_catalog_connect(
+        _make_hook(_fetch_workflow_rows, _WORKFLOW_TABLE, _WORKFLOW_TOKEN, _WorkflowSerializer())
+    )
+    ctx.on_catalog_connect(
+        _make_hook(
+            _fetch_execution_rows, _EXECUTION_TABLE, _EXECUTION_TOKEN, _ExecutionSerializer()
+        )
     )
     ctx.on_catalog_connect(_make_vocab_hook())

--- a/src/deriva_ml_mcp/tools/dataset/complex.py
+++ b/src/deriva_ml_mcp/tools/dataset/complex.py
@@ -508,23 +508,28 @@ def register(ctx: PluginContext) -> None:
                 # child datasets and links them via Dataset_Dataset
                 # relations. Refresh the source dataset (relations
                 # changed), the parent split, and each child so all
-                # affected per-RID sources get fresh chunks.
-                try:
-                    from deriva_ml_mcp.resources.rag import _reindex_dataset
+                # affected per-RID sources get fresh chunks. Per-RID
+                # try/except so one failed re-index doesn't cancel the
+                # rest -- defense in depth (the helper itself swallows,
+                # but if the lazy import fails or the iteration raises,
+                # we still want the other RIDs refreshed).
+                from deriva_ml_mcp.resources.rag import _reindex_dataset
 
-                    affected_rids: list[str] = [source_dataset_rid]
-                    split_meta = payload.get("split") or {}
-                    for entry in (split_meta, training, testing, validation):
-                        rid = entry.get("rid") if entry else None
-                        if rid:
-                            affected_rids.append(rid)
-                    for rid in affected_rids:
+                affected_rids: list[str] = [source_dataset_rid]
+                split_meta = payload.get("split") or {}
+                for entry in (split_meta, training, testing, validation):
+                    rid = entry.get("rid") if entry else None
+                    if rid:
+                        affected_rids.append(rid)
+                for rid in affected_rids:
+                    try:
                         await _reindex_dataset(hostname, catalog_id, rid)
-                except Exception:  # noqa: BLE001 -- best-effort cache refresh
-                    logger.exception(
-                        "re-index failed for one or more datasets after split_dataset (source=%s)",
-                        source_dataset_rid,
-                    )
+                    except Exception:  # noqa: BLE001 -- best-effort, per-RID
+                        logger.exception(
+                            "re-index failed for dataset %s after split_dataset (source=%s)",
+                            rid,
+                            source_dataset_rid,
+                        )
             return json.dumps({"status": "success", **payload}, default=str)
         except Exception as exc:
             return _error_envelope(

--- a/src/deriva_ml_mcp/tools/dataset/complex.py
+++ b/src/deriva_ml_mcp/tools/dataset/complex.py
@@ -25,10 +25,13 @@ from __future__ import annotations
 
 import itertools
 import json
+import logging
 from typing import TYPE_CHECKING, Any
 
 from deriva_mcp_core import deriva_call
 from deriva_ml.dataset.aux_classes import DatasetSpec
+
+logger = logging.getLogger(__name__)
 
 # See the header note in ``mutate.py`` for why ``audit_event``,
 # ``get_ml``, and ``_split_dataset`` are accessed via attribute lookup
@@ -501,6 +504,27 @@ def register(ctx: PluginContext) -> None:
                     testing_count=testing.get("count") if testing else None,
                     validation_count=validation.get("count") if validation else None,
                 )
+                # v1.3 surgical re-index: split creates a parent + 2-3
+                # child datasets and links them via Dataset_Dataset
+                # relations. Refresh the source dataset (relations
+                # changed), the parent split, and each child so all
+                # affected per-RID sources get fresh chunks.
+                try:
+                    from deriva_ml_mcp.resources.rag import _reindex_dataset
+
+                    affected_rids: list[str] = [source_dataset_rid]
+                    split_meta = payload.get("split") or {}
+                    for entry in (split_meta, training, testing, validation):
+                        rid = entry.get("rid") if entry else None
+                        if rid:
+                            affected_rids.append(rid)
+                    for rid in affected_rids:
+                        await _reindex_dataset(hostname, catalog_id, rid)
+                except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                    logger.exception(
+                        "re-index failed for one or more datasets after split_dataset (source=%s)",
+                        source_dataset_rid,
+                    )
             return json.dumps({"status": "success", **payload}, default=str)
         except Exception as exc:
             return _error_envelope(

--- a/src/deriva_ml_mcp/tools/dataset/mutate.py
+++ b/src/deriva_ml_mcp/tools/dataset/mutate.py
@@ -27,10 +27,13 @@ captured every success-path emission in one shot.
 from __future__ import annotations
 
 import json
+import logging
 from typing import TYPE_CHECKING, Any, Literal
 
 from deriva_mcp_core import deriva_call
 from deriva_ml.dataset.aux_classes import DatasetVersion, VersionPart
+
+logger = logging.getLogger(__name__)
 
 # Note on patchable names (``audit_event``, ``get_ml``, ``Dataset``):
 # the package ``__init__.py`` imports each of these at module level and
@@ -124,6 +127,21 @@ def register(ctx: PluginContext) -> None:
                 dataset_types=dataset_types or [],
                 version=summary["current_version"],
             )
+            # v1.3 surgical re-index: refresh just the new dataset's
+            # per-RID source so rag_search picks it up on the next call
+            # from this user. Best-effort -- a re-index hiccup must NOT
+            # propagate to the tool's success path (the catalog mutation
+            # already succeeded). Lazy import to avoid the resources/rag
+            # <-> tools/dataset module-load cycle.
+            try:
+                from deriva_ml_mcp.resources.rag import _reindex_dataset
+
+                await _reindex_dataset(hostname, catalog_id, new_ds.dataset_rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index failed for dataset %s after create_dataset",
+                    new_ds.dataset_rid,
+                )
             return json.dumps({"status": "created", **summary, "execution_rid": execution_rid})
         except Exception as exc:
             return _error_envelope(
@@ -178,6 +196,19 @@ def register(ctx: PluginContext) -> None:
                 dataset_rid=dataset_rid,
                 recursive=recurse,
             )
+            # v1.3 surgical re-index: drop the dataset's per-RID source so
+            # rag_search no longer surfaces a row that's been soft-deleted.
+            # Best-effort -- failure to drop is logged but does not affect
+            # the tool's success envelope.
+            try:
+                from deriva_ml_mcp.resources.rag import _delete_dataset_source
+
+                await _delete_dataset_source(hostname, catalog_id, dataset_rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index drop failed for dataset %s after delete_dataset",
+                    dataset_rid,
+                )
             return json.dumps(
                 {
                     "status": "deleted",
@@ -278,6 +309,16 @@ def register(ctx: PluginContext) -> None:
                 added_count=added_count,
                 new_version=new_version,
             )
+            # v1.3 surgical re-index: member-count + version changed.
+            try:
+                from deriva_ml_mcp.resources.rag import _reindex_dataset
+
+                await _reindex_dataset(hostname, catalog_id, dataset_rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index failed for dataset %s after add_dataset_members",
+                    dataset_rid,
+                )
             return json.dumps(
                 {
                     "status": "success",
@@ -352,6 +393,16 @@ def register(ctx: PluginContext) -> None:
                 removed_count=removed_count,
                 new_version=new_version,
             )
+            # v1.3 surgical re-index: member-count + version changed.
+            try:
+                from deriva_ml_mcp.resources.rag import _reindex_dataset
+
+                await _reindex_dataset(hostname, catalog_id, dataset_rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index failed for dataset %s after delete_dataset_members",
+                    dataset_rid,
+                )
             return json.dumps(
                 {
                     "status": "success",
@@ -494,6 +545,16 @@ def register(ctx: PluginContext) -> None:
                 removed=removes_requested,
                 new_version=new_version,
             )
+            # v1.3 surgical re-index: types and/or description changed.
+            try:
+                from deriva_ml_mcp.resources.rag import _reindex_dataset
+
+                await _reindex_dataset(hostname, catalog_id, dataset_rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index failed for dataset %s after update_dataset",
+                    dataset_rid,
+                )
             payload: dict[str, Any] = {
                 "status": "updated",
                 "dataset_rid": dataset_rid,
@@ -644,6 +705,16 @@ def register(ctx: PluginContext) -> None:
                 previous_version=previous_version,
                 new_version=new_version_str,
             )
+            # v1.3 surgical re-index: version field in the chunk changed.
+            try:
+                from deriva_ml_mcp.resources.rag import _reindex_dataset
+
+                await _reindex_dataset(hostname, catalog_id, dataset_rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index failed for dataset %s after increment_dataset_version",
+                    dataset_rid,
+                )
             return json.dumps(
                 {
                     "status": "success",

--- a/src/deriva_ml_mcp/tools/execution.py
+++ b/src/deriva_ml_mcp/tools/execution.py
@@ -1235,18 +1235,27 @@ def register(ctx: PluginContext) -> None:
             )
             # v1.3 surgical re-index: a new dataset row landed AND the
             # parent execution's outputs view changed; refresh both.
-            try:
-                from deriva_ml_mcp.resources.rag import (
-                    _reindex_dataset,
-                    _reindex_execution,
-                )
+            # Per-target try/except so if dataset re-index fails, the
+            # execution re-index still runs (and vice versa) -- defense
+            # in depth against the helper's own try/except being
+            # bypassed by an unexpected outer raise.
+            from deriva_ml_mcp.resources.rag import (
+                _reindex_dataset,
+                _reindex_execution,
+            )
 
+            try:
                 await _reindex_dataset(hostname, catalog_id, dataset_rid)
-                await _reindex_execution(hostname, catalog_id, execution_rid)
-            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+            except Exception:  # noqa: BLE001 -- best-effort, per-target
                 logger.exception(
-                    "re-index failed for dataset %s / execution %s after create_execution_dataset",
+                    "re-index failed for dataset %s after create_execution_dataset",
                     dataset_rid,
+                )
+            try:
+                await _reindex_execution(hostname, catalog_id, execution_rid)
+            except Exception:  # noqa: BLE001 -- best-effort, per-target
+                logger.exception(
+                    "re-index failed for execution %s after create_execution_dataset",
                     execution_rid,
                 )
             return json.dumps(

--- a/src/deriva_ml_mcp/tools/execution.py
+++ b/src/deriva_ml_mcp/tools/execution.py
@@ -22,12 +22,15 @@ where the call would put it.
 from __future__ import annotations
 
 import json
+import logging
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from deriva_mcp_core import deriva_call
 from deriva_mcp_core.telemetry import audit_event
 from deriva_ml.execution.execution import ExecutionStatus
+
+logger = logging.getLogger(__name__)
 
 # Note on testing audit_event: see ``make_patch_audit("execution")`` in
 # tests/_helpers.py. Single-patch facade is impossible due to Python's
@@ -749,6 +752,17 @@ def register(ctx: PluginContext) -> None:
                     dataset_count=len(ds_list),
                     asset_count=len(as_list),
                 )
+                # v1.3 surgical re-index. Best-effort -- catalog mutation
+                # already succeeded; a re-index hiccup must not propagate.
+                try:
+                    from deriva_ml_mcp.resources.rag import _reindex_execution
+
+                    await _reindex_execution(hostname, catalog_id, execution_rid)
+                except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                    logger.exception(
+                        "re-index failed for execution %s after create_execution",
+                        execution_rid,
+                    )
             return json.dumps(
                 {
                     "status": "created",
@@ -838,6 +852,16 @@ def register(ctx: PluginContext) -> None:
                 catalog_id=catalog_id,
                 execution_rid=execution_rid,
             )
+            # v1.3 surgical re-index: status field changed in the chunk.
+            try:
+                from deriva_ml_mcp.resources.rag import _reindex_execution
+
+                await _reindex_execution(hostname, catalog_id, execution_rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index failed for execution %s after start_execution",
+                    execution_rid,
+                )
             return json.dumps(
                 {
                     "status": "running",
@@ -948,6 +972,16 @@ def register(ctx: PluginContext) -> None:
                 total_failed=summary["total_failed"],
                 retry_failed=retry_failed,
             )
+            # v1.3 surgical re-index: status + stop_time + duration changed.
+            try:
+                from deriva_ml_mcp.resources.rag import _reindex_execution
+
+                await _reindex_execution(hostname, catalog_id, execution_rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index failed for execution %s after commit_execution",
+                    execution_rid,
+                )
             return json.dumps(
                 {
                     "status": "uploaded",
@@ -1035,6 +1069,16 @@ def register(ctx: PluginContext) -> None:
                 execution_rid=execution_rid,
                 updated_fields=updated_fields,
             )
+            # v1.3 surgical re-index: description field changed in the chunk.
+            try:
+                from deriva_ml_mcp.resources.rag import _reindex_execution
+
+                await _reindex_execution(hostname, catalog_id, execution_rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index failed for execution %s after update_execution",
+                    execution_rid,
+                )
             return json.dumps(
                 {
                     "status": "updated",
@@ -1109,6 +1153,16 @@ def register(ctx: PluginContext) -> None:
                 execution_rid=execution_rid,
                 reason=reason,
             )
+            # v1.3 surgical re-index: status field changed (now Aborted).
+            try:
+                from deriva_ml_mcp.resources.rag import _reindex_execution
+
+                await _reindex_execution(hostname, catalog_id, execution_rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index failed for execution %s after abort_execution",
+                    execution_rid,
+                )
             return json.dumps(
                 {
                     "status": "aborted",
@@ -1179,6 +1233,22 @@ def register(ctx: PluginContext) -> None:
                 dataset_rid=dataset_rid,
                 dataset_types=types_list,
             )
+            # v1.3 surgical re-index: a new dataset row landed AND the
+            # parent execution's outputs view changed; refresh both.
+            try:
+                from deriva_ml_mcp.resources.rag import (
+                    _reindex_dataset,
+                    _reindex_execution,
+                )
+
+                await _reindex_dataset(hostname, catalog_id, dataset_rid)
+                await _reindex_execution(hostname, catalog_id, execution_rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index failed for dataset %s / execution %s after create_execution_dataset",
+                    dataset_rid,
+                    execution_rid,
+                )
             return json.dumps(
                 {
                     "status": "created",
@@ -1246,6 +1316,16 @@ def register(ctx: PluginContext) -> None:
                 child_rid=child_execution_rid,
                 sequence=sequence,
             )
+            # v1.3 surgical re-index: parent's children view changed.
+            try:
+                from deriva_ml_mcp.resources.rag import _reindex_execution
+
+                await _reindex_execution(hostname, catalog_id, parent_execution_rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index failed for parent execution %s after add_nested_execution",
+                    parent_execution_rid,
+                )
             return json.dumps(
                 {
                     "status": "added",

--- a/src/deriva_ml_mcp/tools/workflow.py
+++ b/src/deriva_ml_mcp/tools/workflow.py
@@ -16,12 +16,15 @@ them in. We never run server-side git introspection on the MCP host.
 from __future__ import annotations
 
 import json
+import logging
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from deriva_mcp_core import deriva_call
 from deriva_mcp_core.telemetry import audit_event
 from deriva_ml.core.exceptions import DerivaMLException
+
+logger = logging.getLogger(__name__)
 
 # Note on testing audit_event: see ``make_patch_audit("workflow")`` in
 # tests/conftest.py. Single-patch facade is impossible due to Python's
@@ -406,6 +409,18 @@ def register(ctx: PluginContext) -> None:
                 workflow_type=normalized_types,
                 status=status,
             )
+            # v1.3 surgical re-index. Best-effort -- catalog mutation
+            # already succeeded; a re-index hiccup must not propagate
+            # to the tool's success path.
+            try:
+                from deriva_ml_mcp.resources.rag import _reindex_workflow
+
+                await _reindex_workflow(hostname, catalog_id, rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index failed for workflow %s after create_workflow",
+                    rid,
+                )
             return json.dumps(
                 {
                     "status": status,
@@ -503,6 +518,17 @@ def register(ctx: PluginContext) -> None:
                 updated_fields=updated_fields,
                 workflow_type=workflow_type,
             )
+            # v1.3 surgical re-index: description and/or workflow_type
+            # tags appear in the chunk; refresh after the catalog write.
+            try:
+                from deriva_ml_mcp.resources.rag import _reindex_workflow
+
+                await _reindex_workflow(hostname, catalog_id, workflow_rid)
+            except Exception:  # noqa: BLE001 -- best-effort cache refresh
+                logger.exception(
+                    "re-index failed for workflow %s after update_workflow",
+                    workflow_rid,
+                )
             return json.dumps(
                 {
                     "status": "updated",

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1724,3 +1724,75 @@ async def test_split_dataset_error_path(dataset_ctx, capturing_mcp, mock_ml):
     assert failed
     assert failed[0].kwargs["source_dataset_rid"] == "1-AAAA"
     assert failed[0].kwargs["dry_run"] is False
+
+
+# ---------------------------------------------------------------------------
+# v1.3: surgical RAG re-index wired into mutating dataset tools
+# ---------------------------------------------------------------------------
+
+
+async def test_create_dataset_triggers_surgical_reindex(dataset_ctx, capturing_mcp, mock_ml):
+    """``deriva_ml_create_dataset`` calls ``_reindex_dataset`` with the new RID."""
+    from unittest.mock import AsyncMock
+
+    new_ds = _make_dataset_mock("1-NEW", "desc", ["Training"], "1.0.0")
+    fake_reindex = AsyncMock(return_value=1)
+    with (
+        patch("deriva_ml_mcp.tools.dataset.Dataset") as mock_dataset_cls,
+        patch("deriva_ml_mcp.resources.rag._reindex_dataset", new=fake_reindex),
+        _patch_audit(),
+    ):
+        mock_dataset_cls.create_dataset.return_value = new_ds
+        await capturing_mcp.tools["deriva_ml_create_dataset"](
+            hostname="h",
+            catalog_id="1",
+            execution_rid="EXEC-1",
+            description="d",
+        )
+    fake_reindex.assert_awaited_once_with("h", "1", "1-NEW")
+
+
+async def test_delete_dataset_triggers_surgical_drop(dataset_ctx, capturing_mcp, mock_ml):
+    """``deriva_ml_delete_dataset`` calls ``_delete_dataset_source`` with the RID."""
+    from unittest.mock import AsyncMock
+
+    fake_drop = AsyncMock(return_value=True)
+    with (
+        patch("deriva_ml_mcp.resources.rag._delete_dataset_source", new=fake_drop),
+        _patch_audit(),
+    ):
+        await capturing_mcp.tools["deriva_ml_delete_dataset"](
+            hostname="h", catalog_id="1", dataset_rid="1-AAAA"
+        )
+    fake_drop.assert_awaited_once_with("h", "1", "1-AAAA")
+
+
+async def test_create_dataset_reindex_failure_does_not_fail_tool(
+    dataset_ctx, capturing_mcp, mock_ml
+):
+    """A re-index exception is logged but the success envelope is still returned."""
+    from unittest.mock import AsyncMock
+
+    new_ds = _make_dataset_mock("1-NEW", "desc", ["Training"], "1.0.0")
+    fake_reindex = AsyncMock(side_effect=RuntimeError("rag boom"))
+    with (
+        patch("deriva_ml_mcp.tools.dataset.Dataset") as mock_dataset_cls,
+        patch("deriva_ml_mcp.resources.rag._reindex_dataset", new=fake_reindex),
+        _patch_audit() as mock_audit,
+    ):
+        mock_dataset_cls.create_dataset.return_value = new_ds
+        out = json.loads(
+            await capturing_mcp.tools["deriva_ml_create_dataset"](
+                hostname="h",
+                catalog_id="1",
+                execution_rid="EXEC-1",
+                description="d",
+            )
+        )
+    # Catalog mutation succeeded -- response is the success envelope, not an error.
+    assert out["status"] == "created"
+    assert out["rid"] == "1-NEW"
+    assert "error" not in out
+    # The success audit fired despite the re-index failure.
+    success = _success_calls(mock_audit, "deriva_ml_create_dataset")
+    assert success

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -766,3 +766,77 @@ async def test_add_nested_execution_failure_emits_failed_audit(
     assert "error" in payload
     failed = _success_calls(mock_audit, "deriva_ml_add_nested_execution_failed")
     assert failed
+
+
+# ---------------------------------------------------------------------------
+# v1.3: surgical RAG re-index wired into mutating execution tools
+# ---------------------------------------------------------------------------
+
+
+async def test_create_execution_triggers_surgical_reindex(execution_ctx, capturing_mcp, mock_ml):
+    """``deriva_ml_create_execution`` calls ``_reindex_execution`` with the new RID."""
+    from unittest.mock import AsyncMock
+
+    new_exec = _make_execution_mock(execution_rid="1-NEW")
+    mock_ml.create_execution.return_value = new_exec
+    fake_reindex = AsyncMock(return_value=1)
+    with (
+        patch("deriva_ml_mcp.resources.rag._reindex_execution", new=fake_reindex),
+        _patch_execution_audit(),
+    ):
+        await capturing_mcp.tools["deriva_ml_create_execution"](
+            hostname="h",
+            catalog_id="1",
+            workflow_rid="1-WF",
+            description="run",
+        )
+    fake_reindex.assert_awaited_once_with("h", "1", "1-NEW")
+
+
+async def test_create_execution_dry_run_skips_reindex(execution_ctx, capturing_mcp, mock_ml):
+    """A dry_run create skips both audit AND surgical re-index (no catalog change)."""
+    from unittest.mock import AsyncMock
+
+    new_exec = _make_execution_mock(execution_rid="DRY-RUN-RID")
+    mock_ml.create_execution.return_value = new_exec
+    fake_reindex = AsyncMock(return_value=1)
+    with (
+        patch("deriva_ml_mcp.resources.rag._reindex_execution", new=fake_reindex),
+        _patch_execution_audit(),
+    ):
+        await capturing_mcp.tools["deriva_ml_create_execution"](
+            hostname="h",
+            catalog_id="1",
+            workflow_rid="1-WF",
+            description="run",
+            dry_run=True,
+        )
+    fake_reindex.assert_not_awaited()
+
+
+async def test_create_execution_dataset_triggers_both_reindexes(
+    execution_ctx, capturing_mcp, mock_ml
+):
+    """``deriva_ml_create_execution_dataset`` re-indexes BOTH the dataset and the parent execution."""
+    from unittest.mock import AsyncMock
+
+    fake_execution = MagicMock()
+    fake_dataset = MagicMock()
+    fake_dataset.rid = "1-NEWDS"
+    fake_execution.create_dataset.return_value = fake_dataset
+    mock_ml.resume_execution.return_value = fake_execution
+    fake_reindex_ds = AsyncMock(return_value=1)
+    fake_reindex_ex = AsyncMock(return_value=1)
+    with (
+        patch("deriva_ml_mcp.resources.rag._reindex_dataset", new=fake_reindex_ds),
+        patch("deriva_ml_mcp.resources.rag._reindex_execution", new=fake_reindex_ex),
+        _patch_execution_audit(),
+    ):
+        await capturing_mcp.tools["deriva_ml_create_execution_dataset"](
+            hostname="h",
+            catalog_id="1",
+            execution_rid="1-EXEC",
+            description="d",
+        )
+    fake_reindex_ds.assert_awaited_once_with("h", "1", "1-NEWDS")
+    fake_reindex_ex.assert_awaited_once_with("h", "1", "1-EXEC")

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -840,3 +840,42 @@ async def test_create_execution_dataset_triggers_both_reindexes(
         )
     fake_reindex_ds.assert_awaited_once_with("h", "1", "1-NEWDS")
     fake_reindex_ex.assert_awaited_once_with("h", "1", "1-EXEC")
+
+
+async def test_create_execution_dataset_dataset_reindex_failure_does_not_skip_execution(
+    execution_ctx, capturing_mcp, mock_ml
+):
+    """If the dataset re-index raises, the execution re-index must STILL run.
+
+    Pins the per-target try/except isolation in
+    ``deriva_ml_create_execution_dataset``'s re-index block (v1.3 review S2:
+    a single try/except wrapping both calls would silently skip the second
+    re-index when the first raises, defeating defense-in-depth).
+    """
+    from unittest.mock import AsyncMock
+
+    fake_execution = MagicMock()
+    fake_dataset = MagicMock()
+    fake_dataset.rid = "1-NEWDS"
+    fake_execution.create_dataset.return_value = fake_dataset
+    mock_ml.resume_execution.return_value = fake_execution
+    fake_reindex_ds = AsyncMock(side_effect=RuntimeError("dataset reindex boom"))
+    fake_reindex_ex = AsyncMock(return_value=1)
+    with (
+        patch("deriva_ml_mcp.resources.rag._reindex_dataset", new=fake_reindex_ds),
+        patch("deriva_ml_mcp.resources.rag._reindex_execution", new=fake_reindex_ex),
+        _patch_execution_audit(),
+    ):
+        result = await capturing_mcp.tools["deriva_ml_create_execution_dataset"](
+            hostname="h",
+            catalog_id="1",
+            execution_rid="1-EXEC",
+            description="d",
+        )
+    payload = json.loads(result)
+    # Tool returns success (the catalog mutation succeeded; re-index is best-effort).
+    assert "error" not in payload
+    # Both re-indexes were attempted -- the dataset failure didn't short-circuit
+    # the execution call.
+    fake_reindex_ds.assert_awaited_once_with("h", "1", "1-NEWDS")
+    fake_reindex_ex.assert_awaited_once_with("h", "1", "1-EXEC")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -387,3 +387,64 @@ def test_vocab_hook_writes_to_vocab_prefix_not_data_prefix(ctx):
             assert not chunk.source.startswith("data:"), (
                 f"vocab hook accidentally routed through data: prefix: {chunk.source!r}"
             )
+
+
+def test_data_sources_use_per_rid_naming(ctx):
+    """v1.3 pin: per-user trio chunks land under ``data:{h}:{c}:{user_id}:{table}:{rid}``.
+
+    The pre-v1.3 source-name shape was ``data:{host}:{cat}:{user_id}``
+    (one source per user, all rows lumped together). v1.3's surgical
+    re-index requires per-RID source naming so a single mutating tool
+    can refresh just one source via ``_reindex_<entity>``. This test
+    pins that source-naming shape end-to-end at the plugin level: fire
+    each hook with mocked fetchers + a captured ``_write_row_chunk``,
+    then assert every captured source name matches the v1.3 shape AND
+    starts with the user-id prefix that upstream's filter gates on.
+    """
+    from unittest.mock import MagicMock, patch
+
+    captured: list[tuple[str, str]] = []
+
+    async def fake_write(store, source, table_name, row, serializer):
+        captured.append((table_name, source))
+        return 1
+
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    user_id = "https://auth.example.org/sub/u1"
+    user_prefix = f"data:h.example:1:{user_id}"
+
+    # Patch the fetchers BEFORE register(ctx) -- the hook factory
+    # captures the fetch fn at registration time, so any post-register
+    # patch.object on the module-level fetch name has no effect on the
+    # already-captured closure reference.
+    with (
+        patch.object(rag_module, "_fetch_dataset_rows", return_value=[{"rid": "1-DSAA"}]),
+        patch.object(rag_module, "_fetch_workflow_rows", return_value=[{"rid": "1-WFAA"}]),
+        patch.object(rag_module, "_fetch_execution_rows", return_value=[{"rid": "1-EXAA"}]),
+        patch.object(rag_module, "resolve_user_identity", return_value=user_id),
+        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
+        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write),
+    ):
+        register(ctx)
+        dataset_hook = ctx._catalog_connect_hooks[0]
+        workflow_hook = ctx._catalog_connect_hooks[1]
+        execution_hook = ctx._catalog_connect_hooks[2]
+
+        import asyncio
+
+        asyncio.run(dataset_hook("h.example", "1", "hash", {}))
+        asyncio.run(workflow_hook("h.example", "1", "hash", {}))
+        asyncio.run(execution_hook("h.example", "1", "hash", {}))
+
+    # Every source carries the user-id prefix (so upstream's user-id
+    # filter still gates correctly) AND the per-RID shape.
+    assert captured == [
+        ("Dataset", f"{user_prefix}:dataset:1-DSAA"),
+        ("Workflow", f"{user_prefix}:workflow:1-WFAA"),
+        ("Execution", f"{user_prefix}:execution:1-EXAA"),
+    ]
+    for _, source in captured:
+        assert source.startswith(user_prefix + ":"), (
+            f"per-RID source must extend user-id prefix; got {source!r}"
+        )

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -3,18 +3,21 @@
 Two surfaces under test:
 
 1. ``register_rag_sources(ctx)`` -- declarative wiring: one
-   ``rag_github_source`` declaration plus three ``on_catalog_connect``
+   ``rag_github_source`` declaration plus four ``on_catalog_connect``
    callbacks.
 
-2. The serializers and per-user hook bodies -- rich Markdown rendering
-   for Dataset / Workflow / Execution rows, fall-through to the generic
-   serializer for unknown tables, and best-effort exception handling
-   inside hooks (a hook that raises must not propagate).
+2. The serializers, per-user hook bodies, and v1.3 surgical re-index
+   helpers -- rich Markdown rendering for Dataset / Workflow / Execution
+   rows, fall-through to the generic serializer for unknown tables,
+   per-row write isolation inside the first-connect hooks (one bad row
+   doesn't poison the rest), and best-effort failure handling inside
+   ``_reindex_<entity>`` (the catalog mutation already succeeded; a
+   re-index hiccup must not propagate).
 
-All tests are fully mocked. ``index_table_data`` is patched so we can
-assert on ``user_id`` without touching a real vector store; the row
-fetchers are patched to keep the hook tests independent of the underlying
-``_list_*_impl`` shape.
+All tests are fully mocked. ``_write_row_chunk`` is patched in the
+hook-flow tests so we can assert on per-RID source naming without
+touching a real vector store; the row fetchers are patched to keep
+the hook tests independent of the underlying ``_list_*_impl`` shape.
 """
 
 from __future__ import annotations
@@ -286,85 +289,98 @@ def test_execution_serializer_returns_none_for_other_table() -> None:
 _USER_ID = "https://auth.example.org/sub/test-user-1"
 
 
-def test_dataset_hook_calls_index_table_data_with_resolved_user_id() -> None:
-    """The Dataset hook resolves the caller's user_id and forwards it."""
+def test_dataset_hook_writes_one_per_rid_source_per_row() -> None:
+    """First-connect Dataset hook writes one per-RID source per row for the caller.
+
+    Each row's chunk lands under
+    ``data:{host}:{cat}:{user_id}:dataset:{rid}`` (the v1.3 surgical
+    naming) so a later mutating tool can refresh that one source via
+    ``_reindex_dataset`` without touching anything else.
+    """
     from deriva_ml_mcp.resources import rag as rag_module
 
-    captured: dict[str, Any] = {}
-    rows = [{"rid": "1-DSAA", "name": "x"}]
+    captured_calls: list[dict[str, Any]] = []
+    rows = [{"rid": "1-DSAA", "name": "x"}, {"rid": "1-DSBB", "name": "y"}]
 
-    async def fake_index_table_data(
-        store, hostname, catalog_id, table_name, the_rows, *, user_id, serializer, **_kw
-    ):
-        captured["user_id"] = user_id
-        captured["table_name"] = table_name
-        captured["rows"] = the_rows
-        captured["hostname"] = hostname
-        captured["catalog_id"] = catalog_id
+    async def fake_write_row_chunk(store, source, table_name, row, serializer):
+        captured_calls.append(
+            {
+                "source": source,
+                "table_name": table_name,
+                "row_rid": row["rid"],
+            }
+        )
+        return 1
 
     with (
         patch.object(rag_module, "_fetch_dataset_rows", return_value=rows),
         patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
         patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "index_table_data", side_effect=fake_index_table_data),
+        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write_row_chunk),
     ):
         _run(_hook_at(_DATASET_HOOK_IDX)("h.example", "1", "hash", {}))
 
-    assert captured["user_id"] == _USER_ID
-    assert captured["table_name"] == "Dataset"
-    assert captured["hostname"] == "h.example"
-    assert captured["catalog_id"] == "1"
-    assert captured["rows"] == rows
+    assert len(captured_calls) == 2
+    expected_sources = {
+        f"data:h.example:1:{_USER_ID}:dataset:1-DSAA",
+        f"data:h.example:1:{_USER_ID}:dataset:1-DSBB",
+    }
+    assert {c["source"] for c in captured_calls} == expected_sources
+    assert all(c["table_name"] == "Dataset" for c in captured_calls)
 
 
-def test_workflow_hook_calls_index_table_data_with_resolved_user_id() -> None:
-    """The Workflow hook resolves the caller's user_id and forwards it."""
+def test_workflow_hook_writes_one_per_rid_source_per_row() -> None:
+    """First-connect Workflow hook writes one per-RID source per row for the caller."""
     from deriva_ml_mcp.resources import rag as rag_module
 
-    captured: dict[str, Any] = {}
+    captured_calls: list[dict[str, Any]] = []
     rows = [{"rid": "1-WFAA", "name": "y"}]
 
-    async def fake_index_table_data(
-        store, hostname, catalog_id, table_name, the_rows, *, user_id, serializer, **_kw
-    ):
-        captured["user_id"] = user_id
-        captured["table_name"] = table_name
+    async def fake_write_row_chunk(store, source, table_name, row, serializer):
+        captured_calls.append({"source": source, "table_name": table_name})
+        return 1
 
     with (
         patch.object(rag_module, "_fetch_workflow_rows", return_value=rows),
         patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
         patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "index_table_data", side_effect=fake_index_table_data),
+        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write_row_chunk),
     ):
         _run(_hook_at(_WORKFLOW_HOOK_IDX)("h.example", "1", "hash", {}))
 
-    assert captured["user_id"] == _USER_ID
-    assert captured["table_name"] == "Workflow"
+    assert captured_calls == [
+        {
+            "source": f"data:h.example:1:{_USER_ID}:workflow:1-WFAA",
+            "table_name": "Workflow",
+        }
+    ]
 
 
-def test_execution_hook_calls_index_table_data_with_resolved_user_id() -> None:
-    """The Execution hook resolves the caller's user_id and forwards it."""
+def test_execution_hook_writes_one_per_rid_source_per_row() -> None:
+    """First-connect Execution hook writes one per-RID source per row for the caller."""
     from deriva_ml_mcp.resources import rag as rag_module
 
-    captured: dict[str, Any] = {}
+    captured_calls: list[dict[str, Any]] = []
     rows = [{"rid": "1-EXAA", "workflow_rid": "1-WFAA", "status": "Created"}]
 
-    async def fake_index_table_data(
-        store, hostname, catalog_id, table_name, the_rows, *, user_id, serializer, **_kw
-    ):
-        captured["user_id"] = user_id
-        captured["table_name"] = table_name
+    async def fake_write_row_chunk(store, source, table_name, row, serializer):
+        captured_calls.append({"source": source, "table_name": table_name})
+        return 1
 
     with (
         patch.object(rag_module, "_fetch_execution_rows", return_value=rows),
         patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
         patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "index_table_data", side_effect=fake_index_table_data),
+        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write_row_chunk),
     ):
         _run(_hook_at(_EXECUTION_HOOK_IDX)("h.example", "1", "hash", {}))
 
-    assert captured["user_id"] == _USER_ID
-    assert captured["table_name"] == "Execution"
+    assert captured_calls == [
+        {
+            "source": f"data:h.example:1:{_USER_ID}:execution:1-EXAA",
+            "table_name": "Execution",
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -382,76 +398,116 @@ def test_dataset_hook_swallows_fetch_exception() -> None:
     """
     from deriva_ml_mcp.resources import rag as rag_module
 
-    fake_index = AsyncMock()
+    fake_write = AsyncMock()
     with (
         patch.object(rag_module, "_fetch_dataset_rows", side_effect=RuntimeError("boom")),
         patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
         patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "index_table_data", new=fake_index),
+        patch.object(rag_module, "_write_row_chunk", new=fake_write),
     ):
         # Must not raise
         _run(_hook_at(_DATASET_HOOK_IDX)("h.example", "1", "hash", {}))
 
-    fake_index.assert_not_called()
+    fake_write.assert_not_called()
 
 
-def test_workflow_hook_propagates_index_exception() -> None:
-    """If index_table_data raises, the hook lets it propagate.
+def test_workflow_hook_isolates_per_row_write_failures(caplog) -> None:
+    """If one row's write raises, the hook logs and continues with the rest.
 
-    Phase 6.3 follow-on: the redundant index-side ``try/except`` was
-    dropped. The framework's ``_safe_call`` already wraps every dispatched
-    hook, so a duplicated suppression here added nothing -- only stripped
-    the traceback. The contract is now: fetch errors are swallowed with
-    table-name context; index errors propagate to the framework.
+    v1.3 contract: per-row writes are independently wrapped so one
+    degenerate row cannot poison the whole user's first-connect index.
+    The previous v1.0 contract (let ``index_table_data`` raise out)
+    no longer applies: the hook now drives N writes, and a single bad
+    row is the most likely failure shape.
     """
     from deriva_ml_mcp.resources import rag as rag_module
 
-    rows = [{"rid": "1-WFAA"}]
+    rows = [{"rid": "1-WFAA"}, {"rid": "1-WFBB"}, {"rid": "1-WFCC"}]
+    write_calls: list[str] = []
+
+    async def fake_write(store, source, table_name, row, serializer):
+        write_calls.append(source)
+        if row["rid"] == "1-WFBB":
+            raise RuntimeError("boom on middle row")
+        return 1
+
     with (
         patch.object(rag_module, "_fetch_workflow_rows", return_value=rows),
         patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
         patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "index_table_data", side_effect=RuntimeError("boom")),
-        pytest.raises(RuntimeError, match="boom"),
+        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write),
+        caplog.at_level("ERROR", logger="deriva_ml_mcp.resources.rag"),
     ):
+        # Must not raise -- the hook isolates the bad row.
         _run(_hook_at(_WORKFLOW_HOOK_IDX)("h.example", "1", "hash", {}))
+
+    # All three rows attempted (the bad one in the middle did not abort the loop).
+    assert len(write_calls) == 3
+    assert any("1-WFBB" in record.message for record in caplog.records)
 
 
 def test_hook_short_circuits_when_rag_store_is_none() -> None:
     """When RAG is disabled (get_rag_store -> None), the hook does nothing."""
     from deriva_ml_mcp.resources import rag as rag_module
 
-    fake_index = AsyncMock()
+    fake_write = AsyncMock()
     rows = [{"rid": "1-DSAA"}]
     with (
         patch.object(rag_module, "_fetch_dataset_rows", return_value=rows),
         patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
         patch.object(rag_module, "get_rag_store", return_value=None),
-        patch.object(rag_module, "index_table_data", new=fake_index),
+        patch.object(rag_module, "_write_row_chunk", new=fake_write),
     ):
         _run(_hook_at(_DATASET_HOOK_IDX)("h.example", "1", "hash", {}))
 
-    fake_index.assert_not_called()
+    fake_write.assert_not_called()
+
+
+def test_dataset_hook_skips_rows_without_rid() -> None:
+    """Rows with empty/missing rid are skipped (cannot form a stable per-RID source)."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    rows = [{"rid": "1-DSAA"}, {"rid": "", "name": "broken"}, {"name": "no-rid-key"}]
+    captured_sources: list[str] = []
+
+    async def fake_write(store, source, table_name, row, serializer):
+        captured_sources.append(source)
+        return 1
+
+    with (
+        patch.object(rag_module, "_fetch_dataset_rows", return_value=rows),
+        patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
+        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
+        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write),
+    ):
+        _run(_hook_at(_DATASET_HOOK_IDX)("h.example", "1", "hash", {}))
+
+    assert captured_sources == [f"data:h.example:1:{_USER_ID}:dataset:1-DSAA"]
 
 
 def test_dataset_hook_partitions_per_user() -> None:
     """Two consecutive calls under different identities partition by user_id.
 
-    The contract under test: same hostname/catalog_id, two different
-    callers, two distinct ``user_id`` values forwarded into
-    ``index_table_data`` -- one per call. This pins the per-user
-    partitioning that keeps user A's rows out of user B's index.
+    v1.3 update: the partition is now visible in the per-RID source
+    name shape (``data:h:c:userA:dataset:RID`` vs
+    ``data:h:c:userB:dataset:RID``). Same contract as v1.0 (user A's
+    rows must not bleed into user B's index); the assertion just
+    targets the new naming.
     """
     from deriva_ml_mcp.resources import rag as rag_module
 
     rows = [{"rid": "1-DSAA", "name": "shared"}]
-    fake_index = AsyncMock()
+    captured: list[str] = []
+
+    async def fake_write(store, source, table_name, row, serializer):
+        captured.append(source)
+        return 1
 
     with (
         patch.object(rag_module, "_fetch_dataset_rows", return_value=rows),
         patch.object(rag_module, "resolve_user_identity", side_effect=["userA", "userB"]),
         patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "index_table_data", new=fake_index),
+        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write),
     ):
         # Build the hook inside the patch context so the factory's closure
         # captures the patched fetch fn rather than the real one.
@@ -459,9 +515,10 @@ def test_dataset_hook_partitions_per_user() -> None:
         _run(hook("h.example", "1", "hash", {}))
         _run(hook("h.example", "1", "hash", {}))
 
-    assert fake_index.call_count == 2
-    assert fake_index.call_args_list[0].kwargs["user_id"] == "userA"
-    assert fake_index.call_args_list[1].kwargs["user_id"] == "userB"
+    assert captured == [
+        "data:h.example:1:userA:dataset:1-DSAA",
+        "data:h.example:1:userB:dataset:1-DSAA",
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -822,3 +879,267 @@ def test_write_vocab_chunks_empty_terms_drains_only() -> None:
     assert count == 0
     fake_store.delete_source.assert_awaited_once_with("vocab:h:1:s.t")
     fake_store.add.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 11. v1.3 _row_source_name + _write_row_chunk
+# ---------------------------------------------------------------------------
+
+
+def test_row_source_name_concatenates_segments() -> None:
+    """``_row_source_name`` produces ``data:{host}:{cat}:{user_id}:{table}:{rid}``."""
+    from deriva_ml_mcp.resources.rag import _row_source_name
+
+    assert (
+        _row_source_name("h.example", "1", "userA", "dataset", "1-AAAA")
+        == "data:h.example:1:userA:dataset:1-AAAA"
+    )
+    # Source name is a strict superset of the user-id-only prefix so
+    # upstream's filter (which prefix-matches on data:host:cat:user_id:)
+    # still gates correctly.
+    src = _row_source_name("h.example", "1", "userA", "execution", "1-EXAA")
+    assert src.startswith("data:h.example:1:userA:")
+
+
+def test_write_row_chunk_deletes_then_adds() -> None:
+    """``_write_row_chunk`` drains the source and writes the rendered chunks."""
+    from deriva_ml_mcp.resources.rag import _DatasetSerializer, _write_row_chunk
+
+    fake_store = MagicMock()
+    fake_store.delete_source = AsyncMock()
+    fake_store.add = AsyncMock()
+    row = {
+        "rid": "1-DSAA",
+        "name": "x",
+        "description": "demo",
+        "dataset_types": ["Training"],
+        "current_version": "1.0.0",
+        "member_count": 10,
+    }
+
+    count = _run(
+        _write_row_chunk(
+            fake_store,
+            "data:h:1:userA:dataset:1-DSAA",
+            "Dataset",
+            row,
+            _DatasetSerializer(),
+        )
+    )
+
+    assert count >= 1
+    fake_store.delete_source.assert_awaited_once_with("data:h:1:userA:dataset:1-DSAA")
+    assert fake_store.add.await_count == 1
+    chunks = fake_store.add.await_args.args[0]
+    assert all(c.source == "data:h:1:userA:dataset:1-DSAA" for c in chunks)
+    assert all(c.doc_type == "catalog-data" for c in chunks)
+
+
+def test_write_row_chunk_serializer_returns_none_drains_only() -> None:
+    """A serializer that returns None still drains the prior source but writes nothing."""
+    from deriva_ml_mcp.resources.rag import _DatasetSerializer, _write_row_chunk
+
+    fake_store = MagicMock()
+    fake_store.delete_source = AsyncMock()
+    fake_store.add = AsyncMock()
+
+    # Dataset serializer returns None for non-Dataset tables.
+    count = _run(
+        _write_row_chunk(
+            fake_store,
+            "data:h:1:userA:workflow:1-WFAA",
+            "Workflow",
+            {"rid": "1-WFAA"},
+            _DatasetSerializer(),
+        )
+    )
+
+    assert count == 0
+    fake_store.delete_source.assert_awaited_once_with("data:h:1:userA:workflow:1-WFAA")
+    fake_store.add.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 12. v1.3 _reindex_<entity> surgical helpers
+# ---------------------------------------------------------------------------
+
+
+def test_reindex_dataset_writes_one_per_rid_source() -> None:
+    """``_reindex_dataset`` looks up the row + writes one source for the caller."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    fake_ml = MagicMock()
+    fake_ds = MagicMock()
+    fake_ds.dataset_rid = "1-DSAA"
+    fake_ds.description = "x"
+    fake_ds.dataset_types = ["Training"]
+    fake_ds.current_version = "1.0.0"
+    fake_ml.lookup_dataset.return_value = fake_ds
+
+    captured: dict[str, Any] = {}
+
+    async def fake_write(store, source, table_name, row, serializer):
+        captured["source"] = source
+        captured["table_name"] = table_name
+        captured["row_rid"] = row.get("rid")
+        return 1
+
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
+        patch.object(rag_module, "get_ml", return_value=fake_ml),
+        patch.object(rag_module, "resolve_user_identity", return_value="userA"),
+        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write),
+    ):
+        n = _run(rag_module._reindex_dataset("h.example", "1", "1-DSAA"))
+
+    assert n == 1
+    assert captured["source"] == "data:h.example:1:userA:dataset:1-DSAA"
+    assert captured["table_name"] == "Dataset"
+    assert captured["row_rid"] == "1-DSAA"
+    fake_ml.lookup_dataset.assert_called_once_with("1-DSAA")
+
+
+def test_reindex_workflow_writes_one_per_rid_source() -> None:
+    """``_reindex_workflow`` looks up the row + writes one source for the caller."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    fake_ml = MagicMock()
+    fake_wf = MagicMock()
+    fake_wf.rid = "1-WFAA"
+    fake_wf.name = "MyPipe"
+    fake_wf.url = "https://example/repo"
+    fake_wf.checksum = "abc"
+    fake_wf.version = "1.0.0"
+    fake_wf.workflow_type = ["Model_Training"]
+    fake_wf.description = "demo"
+    fake_ml.lookup_workflow.return_value = fake_wf
+
+    captured: dict[str, Any] = {}
+
+    async def fake_write(store, source, table_name, row, serializer):
+        captured["source"] = source
+        captured["table_name"] = table_name
+        return 1
+
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
+        patch.object(rag_module, "get_ml", return_value=fake_ml),
+        patch.object(rag_module, "resolve_user_identity", return_value="userA"),
+        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write),
+    ):
+        n = _run(rag_module._reindex_workflow("h.example", "1", "1-WFAA"))
+
+    assert n == 1
+    assert captured["source"] == "data:h.example:1:userA:workflow:1-WFAA"
+    assert captured["table_name"] == "Workflow"
+
+
+def test_reindex_execution_writes_one_per_rid_source() -> None:
+    """``_reindex_execution`` looks up the row + writes one source for the caller."""
+    from deriva_ml.execution.execution import ExecutionStatus
+
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    fake_ml = MagicMock()
+    fake_record = MagicMock()
+    fake_record.execution_rid = "1-EXAA"
+    fake_record.workflow_rid = "1-WFAA"
+    fake_record.status = ExecutionStatus.Created
+    fake_record.description = "demo"
+    fake_record.start_time = None
+    fake_record.stop_time = None
+    fake_record.duration = None
+    fake_ml.lookup_execution.return_value = fake_record
+
+    captured: dict[str, Any] = {}
+
+    async def fake_write(store, source, table_name, row, serializer):
+        captured["source"] = source
+        captured["table_name"] = table_name
+        return 1
+
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
+        patch.object(rag_module, "get_ml", return_value=fake_ml),
+        patch.object(rag_module, "resolve_user_identity", return_value="userA"),
+        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write),
+    ):
+        n = _run(rag_module._reindex_execution("h.example", "1", "1-EXAA"))
+
+    assert n == 1
+    assert captured["source"] == "data:h.example:1:userA:execution:1-EXAA"
+    assert captured["table_name"] == "Execution"
+
+
+def test_reindex_dataset_short_circuits_when_store_none() -> None:
+    """``_reindex_dataset`` returns 0 (no ml call) when RAG is disabled."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    fake_ml = MagicMock()  # must not be touched
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=None),
+        patch.object(rag_module, "get_ml", return_value=fake_ml),
+    ):
+        n = _run(rag_module._reindex_dataset("h.example", "1", "1-DSAA"))
+
+    assert n == 0
+    fake_ml.lookup_dataset.assert_not_called()
+
+
+def test_reindex_dataset_swallows_lookup_failure(caplog) -> None:
+    """A best-effort failure (lookup raise) returns 0 + logs without propagating."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    fake_ml = MagicMock()
+    fake_ml.lookup_dataset.side_effect = RuntimeError("not found")
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
+        patch.object(rag_module, "get_ml", return_value=fake_ml),
+        patch.object(rag_module, "resolve_user_identity", return_value="userA"),
+        caplog.at_level("ERROR", logger="deriva_ml_mcp.resources.rag"),
+    ):
+        n = _run(rag_module._reindex_dataset("h.example", "1", "1-DSAA"))
+
+    assert n == 0
+    assert any("1-DSAA" in record.message for record in caplog.records)
+
+
+def test_delete_dataset_source_drops_per_rid_source() -> None:
+    """``_delete_dataset_source`` calls ``store.delete_source`` for the row's source."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    fake_store = MagicMock()
+    fake_store.delete_source = AsyncMock()
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=fake_store),
+        patch.object(rag_module, "resolve_user_identity", return_value="userA"),
+    ):
+        ok = _run(rag_module._delete_dataset_source("h.example", "1", "1-DSAA"))
+
+    assert ok is True
+    fake_store.delete_source.assert_awaited_once_with("data:h.example:1:userA:dataset:1-DSAA")
+
+
+def test_delete_dataset_source_short_circuits_when_store_none() -> None:
+    """``_delete_dataset_source`` returns False when RAG is disabled."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    with patch.object(rag_module, "get_rag_store", return_value=None):
+        assert _run(rag_module._delete_dataset_source("h.example", "1", "1-DSAA")) is False
+
+
+def test_delete_dataset_source_swallows_failure(caplog) -> None:
+    """A delete failure returns False + logs without propagating."""
+    from deriva_ml_mcp.resources import rag as rag_module
+
+    fake_store = MagicMock()
+    fake_store.delete_source = AsyncMock(side_effect=RuntimeError("boom"))
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=fake_store),
+        patch.object(rag_module, "resolve_user_identity", return_value="userA"),
+        caplog.at_level("ERROR", logger="deriva_ml_mcp.resources.rag"),
+    ):
+        ok = _run(rag_module._delete_dataset_source("h.example", "1", "1-DSAA"))
+
+    assert ok is False
+    assert any("1-DSAA" in record.message for record in caplog.records)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -418,3 +418,31 @@ async def test_update_workflow_failure_emits_failed_audit(workflow_ctx, capturin
     assert kwargs["workflow_rid"] == "1-MISSING"
     assert kwargs["updated_fields"] == []
     assert kwargs["error_type"] == "RuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# v1.3: surgical RAG re-index wired into mutating workflow tools
+# ---------------------------------------------------------------------------
+
+
+async def test_create_workflow_triggers_surgical_reindex(workflow_ctx, capturing_mcp, mock_ml):
+    """``deriva_ml_create_workflow`` calls ``_reindex_workflow`` with the new RID."""
+    from unittest.mock import AsyncMock
+
+    mock_ml.lookup_workflow_by_url.side_effect = DerivaMLException("no match")
+    new_wf = _make_workflow_mock(rid=None)
+    mock_ml.create_workflow.return_value = new_wf
+    mock_ml._add_workflow.return_value = "1-NEW"
+    fake_reindex = AsyncMock(return_value=1)
+    with (
+        patch("deriva_ml_mcp.resources.rag._reindex_workflow", new=fake_reindex),
+        _patch_workflow_audit(),
+    ):
+        await capturing_mcp.tools["deriva_ml_create_workflow"](
+            hostname="h",
+            catalog_id="1",
+            name="P",
+            workflow_type="Model_Training",
+            url="https://github.com/x/r/blob/abc/main.py",
+        )
+    fake_reindex.assert_awaited_once_with("h", "1", "1-NEW")


### PR DESCRIPTION
Closes #8.

## What changed

Refactors v1.0's per-user bulk indexers (one source per user across all of Dataset/Workflow/Execution) into per-user-per-RID surgical indexers (one source per (user, table, RID) tuple). Wires inline `_reindex_<entity>` calls into every mutating tool that affects one of those rows.

**Source naming evolution:**
- Old: `data:{host}:{cat}:{user_id}` — bulk per-user
- New: `data:{host}:{cat}:{user_id}:{table}:{rid}` — per-RID

The `data:` prefix is preserved so upstream's `rag_search` user-id filter continues to gate access. The companion upstream change (deriva-mcp-core#4, merged) extends the filter to also accept the per-RID shape via `(own_data + ":")` prefix-match.

## What problem this closes

The dominant freshness gap surfaced during v1.0 ML-developer review:

> "Today the answer to 'I just created a dataset, why doesn't `rag_search` find it?' is 'wait for the server to restart.'"

Post-v1.3: `rag_search` finds the new/modified row on the next call from the same user. No restart, no per-user lag.

## Inline re-index call sites (16 total)

| Module | Tool | Re-index target |
|---|---|---|
| dataset/mutate | `deriva_ml_create_dataset` | new dataset_rid |
| dataset/mutate | `deriva_ml_delete_dataset` | dataset_rid (delete_source) |
| dataset/mutate | `deriva_ml_add_dataset_members` | dataset_rid |
| dataset/mutate | `deriva_ml_delete_dataset_members` | dataset_rid |
| dataset/mutate | `deriva_ml_update_dataset` | dataset_rid |
| dataset/mutate | `deriva_ml_increment_dataset_version` | dataset_rid |
| dataset/complex | `deriva_ml_split_dataset` | source + parent + each child (per-RID try/except) |
| workflow | `deriva_ml_create_workflow` | new workflow_rid |
| workflow | `deriva_ml_update_workflow` | workflow_rid |
| execution | `deriva_ml_create_execution` | new execution_rid |
| execution | `deriva_ml_start_execution` | execution_rid |
| execution | `deriva_ml_commit_execution` | execution_rid |
| execution | `deriva_ml_abort_execution` | execution_rid |
| execution | `deriva_ml_update_execution` | execution_rid |
| execution | `deriva_ml_create_execution_dataset` | dataset_rid + execution_rid (per-target try/except) |
| execution | `deriva_ml_add_nested_execution` | parent_execution_rid |

NOT in the list (correctly excluded):
- `deriva_ml_cache_dataset` — local cache only, no catalog change
- `deriva_ml_add_dataset_element_type` — catalog-wide registration of a domain table as a valid member type, NOT a mutation of a specific dataset row

Pattern at every call site: `audit_event` fires first (so the audit captures the mutation regardless of re-index outcome), then a best-effort `_reindex_<entity>` call wrapped in try/except (so a re-index failure doesn't propagate to the user as if the catalog mutation failed).

## Cross-user freshness

Still imperfect. When user A creates a dataset visible to user B, B's per-user RAG sources don't update until B reconnects. **Tracked separately as #9 for v1.4.** v1.3's prompt update flags this honestly.

## Implementation note: lazy imports

Tools modules can't import `_reindex_*` at module top because `resources/rag.py` imports `_list_*_impl` from tools modules (circular). Each call site uses a lazy `from deriva_ml_mcp.resources.rag import _reindex_<entity>` inside the tool body — same pattern `tools/vocabulary.py` uses for `_index_vocabularies` (documented at vocabulary.py:96-98).

## Reviews

- **Spec compliance review**: ✅ 32/32 pass, no failures, no scope creep
- **Code-quality review**: ✅ approved with 2 actionable suggested follow-ups (S1 + S2: per-target try/except isolation in `split_dataset` and `create_execution_dataset`'s multi-RID loops). Both folded inline as commit `516da9b`.

## Tests

- 274 unit tests pass (was 253 baseline; +21: 20 from main commit + 1 from polish for the per-target isolation pin)
- 14 integration tests pass against live demo catalog (~37s)
- ruff check + format clean

## Commits

1. `dd04605` feat(rag): surgical per-RID re-indexing for Dataset/Workflow/Execution
2. `516da9b` fix(rag): per-target try/except in multi-RID re-index call sites

## Out-of-scope follow-up

The optional `test_dataset_mutate_then_rag_search` end-to-end integration test (would prove the freshness gap is closed by exercising the full RAG-enabled round-trip) is deferred to a follow-up commit. Requires `DERIVA_MCP_RAG_ENABLED=true` + chromadb available + temp-dir RAG store setup. The unit test surface (274 tests) already pins the correct behavior of every helper, every call site, and the new source-naming shape; the upstream filter PR has its own pinning tests for the search-side. End-to-end via integration is bonus, not blocker.