### PR TITLE
v2.0.0: ExecutionDetail Pydantic-ize + get_dataset wire unification (PR 2 of #6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,17 +194,36 @@ When adding a new shared helper:
    construct the model from the dicts these helpers produce:
    `DatasetSummary(**_summarize_dataset(d))`.
 
-Two `_*_impl` helpers are intentionally NOT Pydantic-ized in v1.6 because
-their wire shapes warrant their own design pass:
+v2.0 (PR 2 of #6) extended the Pydantic coverage to two more shapes
+and shipped two breaking wire-shape changes:
 
-- `_get_execution_detail_impl` — complex nested-dict shape with
-  `inputs.datasets`, `inputs.assets`, `outputs.assets`, optional
-  `experiment`. PR 2 (v2.0) is expected to redesign this.
-- The `deriva_ml_get_dataset` tool wrapper — uses an inline mini-detail
-  shape with `history` (list of 4-key dicts). PR 2 will unify the tool
-  and resource shapes (resource uses `version_history`).
+- `_get_execution_detail_impl` is now Pydantic-typed (`ExecutionDetail`
+  with `ExecutionInputs` / `ExecutionOutputs` / `ExecutionExperiment`
+  sub-models). Wire shape: same nested structure as v1.x, but the
+  `experiment` field is now ALWAYS present (set to `null` when the
+  execution is not a Hydra-driven experiment) instead of conditionally
+  omitted. Consumers that did `if "experiment" in payload:` should
+  switch to `if payload.get("experiment") is not None:`.
+- The `deriva_ml_get_dataset` tool wrapper now returns the same wire
+  shape as the `deriva://catalog/{h}/{c}/ml/dataset/{rid}` resource:
+  the field is `version_history` (was `history` in v1.x), and it's
+  always present (empty list when `include_history=False`). This
+  unifies the tool + resource shapes so consumers can switch freely
+  between them.
 
-Both keep returning `dict[str, Any]` until PR 2.
+Future v2.x sweeps (each its own PR):
+
+- `_summarize_*` building-block helpers still return `dict[str, Any]`.
+  Pydantic-izing them requires touching every ad-hoc consumer call
+  site (parents/children blocks in `deriva_ml_list_dataset_relations`,
+  inline sub-payloads in `deriva_ml_find_workflow_executions` /
+  `_list_execution_children` / `_list_execution_parents`,
+  description-update wrapper response shapes, etc.).
+- Ad-hoc preflight-count responses (`{total_count, entities_fetched,
+  action_required}`) are duplicated across every paginated tool.
+  Worth a shared `PreflightCountResponse` model.
+- Mutating-tool response shapes (insert/update/delete) are still
+  ad-hoc dicts. Their own coherent design pass (PR 3 of #6).
 
 ## Coverage Report
 

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -294,14 +294,101 @@ class ExecutionSummary(BaseModel):
     duration: timedelta | str | None
 
 
-# NOTE: ExecutionDetail is intentionally NOT modeled in PR 1 (v1.6).
-# The v1.x wire shape from ``_get_execution_detail_impl`` is a complex
-# nested-dict payload (``inputs.datasets``, ``inputs.assets``,
-# ``outputs.assets``, optional ``experiment``) that warrants its own
-# design pass. PR 2 (v2.0) will redesign the wire shape and add the
-# corresponding Pydantic model. Until then the helper returns
-# ``dict[str, Any]`` and the wrapper / resource serialize via plain
-# ``json.dumps(..., default=str)``.
+class ExecutionInputDatasetRef(BaseModel):
+    """One input dataset on an Execution detail's ``inputs.datasets`` list."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rid: str
+    version: str | None
+
+
+class ExecutionAssetRef(BaseModel):
+    """One asset on an Execution detail's ``inputs.assets`` / ``outputs.assets``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rid: str | None
+    filename: str | None
+
+
+class ExecutionInputs(BaseModel):
+    """Inputs grouping on an Execution detail.
+
+    Datasets and assets are intentionally separate lists -- a dataset
+    is a typed bundle of catalog rows (with a version), an asset is a
+    single file. Treating them uniformly would lose type information
+    that consumers care about (e.g. version pinning).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    datasets: list[ExecutionInputDatasetRef] = Field(default_factory=list)
+    assets: list[ExecutionAssetRef] = Field(default_factory=list)
+
+
+class ExecutionOutputs(BaseModel):
+    """Outputs grouping on an Execution detail.
+
+    Outputs are asset-only today -- DerivaML doesn't currently model
+    "this execution produced this dataset" as a first-class output
+    relationship (datasets are produced by features that link back to
+    their producing execution; the relationship is reachable but not
+    direct). Kept as a single-key dict for forward compatibility with
+    a possible future ``outputs.datasets`` field.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    assets: list[ExecutionAssetRef] = Field(default_factory=list)
+
+
+class ExecutionExperiment(BaseModel):
+    """Experiment association on an Execution detail.
+
+    Present only when the execution is part of a Hydra-driven
+    experiment run. The ``model_config`` field name conflicts with
+    Pydantic's reserved attribute, so it's aliased to ``model_cfg``
+    in Python while the wire JSON key remains ``"model_config"``.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, protected_namespaces=())
+
+    name: str | None
+    config_choices: dict[str, str | int | float | bool | None] = Field(default_factory=dict)
+    # Aliased: Python attribute is ``model_cfg``; wire key is ``"model_config"``
+    # to preserve the v1.x wire shape. Pydantic's protected_namespaces=() above
+    # is needed because ``model_*`` is a reserved prefix.
+    model_cfg: dict[str, str | int | float | bool | None] = Field(
+        default_factory=dict, alias="model_config"
+    )
+
+
+class ExecutionDetail(ExecutionSummary):
+    """Full Execution detail: summary + inputs + outputs + optional experiment.
+
+    Produced by ``_get_execution_detail_impl``. Used by the
+    ``deriva://catalog/{h}/{c}/ml/execution/{rid}`` resource.
+
+    The ``experiment`` key is None when the execution is not a
+    Hydra-driven experiment (the common case). The ``inputs.datasets``
+    list is best-effort -- if ``record.list_input_datasets()`` raises
+    (e.g. record not bound to a catalog), the list comes back empty
+    rather than aborting the whole detail payload. Same best-effort
+    semantics for ``inputs.assets`` and ``outputs.assets``.
+
+    The ``metadata`` key from the v1.x design (Deriva_Config /
+    Execution_Config / Hydra_Config / Runtime_Env) is intentionally
+    OMITTED until upstream provides a generic enumerator -- see the
+    TODO comment in ``_get_execution_detail_impl``.
+
+    v2.0 wire shape: identical to v1.x (this PR Pydantic-izes the
+    contract; there's no field rename or restructure on this model).
+    """
+
+    inputs: ExecutionInputs = Field(default_factory=ExecutionInputs)
+    outputs: ExecutionOutputs = Field(default_factory=ExecutionOutputs)
+    experiment: ExecutionExperiment | None = None
 
 
 class ExecutionListResponse(_PaginationFields):

--- a/src/deriva_ml_mcp/resources/ml.py
+++ b/src/deriva_ml_mcp/resources/ml.py
@@ -267,7 +267,7 @@ def register(ctx: PluginContext) -> None:
             with deriva_call():
                 ml = get_ml(hostname, catalog_id)
                 payload = _get_execution_detail_impl(ml, execution_rid)
-            return json.dumps(payload, default=str)
+            return payload.model_dump_json(by_alias=True)
         except Exception as exc:  # noqa: BLE001
             return _error_envelope(
                 exc,

--- a/src/deriva_ml_mcp/tools/dataset/read.py
+++ b/src/deriva_ml_mcp/tools/dataset/read.py
@@ -293,18 +293,24 @@ def register(ctx: PluginContext) -> None:
 
         Args:
             dataset_rid: The RID of the dataset to retrieve.
-            include_history: If True, include the dataset's version history.
+            include_history: If True, populate the ``version_history``
+                field with the full dataset version history. When
+                False, ``version_history`` is present but empty.
 
         Returns:
-            JSON string with the full dataset summary:
-            ``{"rid", "description", "dataset_types", "current_version",
-            "chaise_url", "history": [...] | omitted}``.
+            ``DatasetDetail`` JSON shape -- see
+            ``deriva_ml_mcp._response_models``.
 
         Note:
-            The tool's ``history`` key and the resource's
-            ``version_history`` key carry the same data. The two will
-            be unified to ``version_history`` in v2.0; v1.x preserves
-            the legacy ``history`` key for backward compatibility.
+            v2.0 wire change vs v1.x: the field key is
+            ``version_history`` (was ``history`` in v1.x). This unifies
+            the tool's wire shape with the resource's wire shape (the
+            ``deriva://catalog/{h}/{c}/ml/dataset/{rid}`` resource has
+            always used ``version_history``). The two surfaces now
+            return identical wire shapes; consumers can switch freely
+            between tool and resource without re-mapping field names.
+            The field is always present (was conditionally omitted in
+            v1.x); when ``include_history=False`` it's an empty list.
 
         Raises:
             RuntimeError: If the dataset RID doesn't exist, propagated from
@@ -314,25 +320,28 @@ def register(ctx: PluginContext) -> None:
         Example:
             ``{"rid": "1-AAAA", "description": "Training set",
             "dataset_types": ["Training"], "current_version": "1.0.0",
-            "chaise_url": "https://example.org/chaise/..."}``.
+            "chaise_url": "https://example.org/chaise/...",
+            "version_history": []}``.
         """
         try:
             with deriva_call():
                 ml = _pkg.get_ml(hostname, catalog_id)
-                ds = ml.lookup_dataset(dataset_rid)
-                summary = _summarize_dataset(ds)
-                summary["chaise_url"] = ds.get_chaise_url()
                 if include_history:
-                    summary["history"] = [
-                        {
-                            "version": str(h.dataset_version),
-                            "snapshot": h.snapshot,
-                            "description": h.description,
-                            "execution_rid": h.execution_rid,
-                        }
-                        for h in ds.dataset_history()
-                    ]
-            return json.dumps(summary)
+                    payload = _get_dataset_detail_impl(ml, dataset_rid)
+                else:
+                    # Skip the dataset_history() call entirely when not
+                    # requested -- it can be expensive on long-lived
+                    # datasets. Construct a DatasetDetail with an empty
+                    # version_history list to preserve the unified wire
+                    # shape.
+                    ds = ml.lookup_dataset(dataset_rid)
+                    summary = _summarize_dataset(ds)
+                    payload = DatasetDetail(
+                        **summary,
+                        chaise_url=ds.get_chaise_url(),
+                        version_history=[],
+                    )
+            return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             # Read-only tool: log+return without an audit row (I-2 fix).
             return _error_envelope(

--- a/src/deriva_ml_mcp/tools/execution.py
+++ b/src/deriva_ml_mcp/tools/execution.py
@@ -45,7 +45,13 @@ from deriva_ml_mcp._helpers import (
     _read_rid,
 )
 from deriva_ml_mcp._response_models import (
+    ExecutionAssetRef,
+    ExecutionDetail,
+    ExecutionExperiment,
+    ExecutionInputDatasetRef,
+    ExecutionInputs,
     ExecutionListResponse,
+    ExecutionOutputs,
     ExecutionSummary,
 )
 from deriva_ml_mcp.ml_context import get_ml
@@ -173,7 +179,7 @@ def _list_executions_impl(
     )
 
 
-def _get_execution_detail_impl(ml: Any, execution_rid: str) -> dict[str, Any]:
+def _get_execution_detail_impl(ml: Any, execution_rid: str) -> ExecutionDetail:
     """Build the execution detail payload (summary + inputs + outputs + experiment).
 
     Used by the ``deriva://catalog/{h}/{c}/ml/execution/{rid}`` resource.
@@ -203,91 +209,92 @@ def _get_execution_detail_impl(ml: Any, execution_rid: str) -> dict[str, Any]:
         execution_rid: The RID of the execution to look up.
 
     Returns:
-        Dict with keys: ``rid``, ``workflow_rid``, ``status``,
-        ``description``, ``start_time``, ``stop_time``, ``duration``,
-        ``inputs`` (``{datasets, assets}`` nested), ``outputs``
-        (``{assets}`` nested), and optional ``experiment``
-        (``{name, config_choices, model_config}``).
+        ``ExecutionDetail`` Pydantic model -- see
+        ``deriva_ml_mcp._response_models``. Wire shape matches v1.x
+        verbatim: ``{...summary fields..., "inputs": {"datasets":
+        [...], "assets": [...]}, "outputs": {"assets": [...]},
+        "experiment": {...} | null}``.
 
-        Note: PR 1 (v1.6) leaves this helper dict-returning. The
-        ``ExecutionDetail`` Pydantic model in ``_response_models.py``
-        currently models a flat-list ``inputs/outputs`` shape that
-        does NOT match this helper's nested-dict output -- the model
-        is positioned for PR 2 (v2.0) to redesign the wire shape.
-        Until then, this helper preserves the v1.x wire format.
+        v2.0 wire change vs v1.x: the ``experiment`` key is now
+        always present (set to ``null`` when the execution is not a
+        Hydra-driven experiment). v1.x omitted the key entirely. This
+        is a small breaking change but the typed contract makes
+        introspection easier.
     """
     record = ml.lookup_execution(execution_rid)
-    payload = _summarize_execution(record)
+    summary = _summarize_execution(record)
 
     # Inputs: datasets + input assets.
-    input_datasets: list[dict[str, Any]] = []
+    input_datasets: list[ExecutionInputDatasetRef] = []
     try:
         for ds in record.list_input_datasets():
             current = getattr(ds, "current_version", None)
             input_datasets.append(
-                {
-                    "rid": ds.dataset_rid,
-                    "version": str(current) if current is not None else None,
-                }
+                ExecutionInputDatasetRef(
+                    rid=ds.dataset_rid,
+                    version=str(current) if current is not None else None,
+                )
             )
     except Exception:  # noqa: BLE001 -- record may not be bound on all paths
         input_datasets = []
 
-    input_assets: list[dict[str, Any]] = []
-    output_assets: list[dict[str, Any]] = []
+    input_assets: list[ExecutionAssetRef] = []
+    output_assets: list[ExecutionAssetRef] = []
     try:
         for asset in record.list_assets(asset_role="Input"):
             input_assets.append(
-                {
-                    "rid": getattr(asset, "asset_rid", None),
-                    "filename": getattr(asset, "filename", None),
-                }
+                ExecutionAssetRef(
+                    rid=getattr(asset, "asset_rid", None),
+                    filename=getattr(asset, "filename", None),
+                )
             )
         for asset in record.list_assets(asset_role="Output"):
             output_assets.append(
-                {
-                    "rid": getattr(asset, "asset_rid", None),
-                    "filename": getattr(asset, "filename", None),
-                }
+                ExecutionAssetRef(
+                    rid=getattr(asset, "asset_rid", None),
+                    filename=getattr(asset, "filename", None),
+                )
             )
     except Exception:  # noqa: BLE001 -- assets are optional
         pass
-
-    payload["inputs"] = {
-        "datasets": input_datasets,
-        "assets": input_assets,
-    }
-    payload["outputs"] = {
-        "assets": output_assets,
-    }
 
     # TODO(deriva-ml-execution-metadata-api): no generic API on
     # ExecutionRecord to enumerate Execution_Metadata files by role
     # (Deriva_Config / Execution_Config / Hydra_Config / Runtime_Env --
     # they're stored as Asset rows joined through Execution_Metadata,
     # not under list_assets's asset_role filter which only handles
-    # Input/Output). Until an upstream enumerator exists, omit the
-    # metadata key entirely rather than emit four hard-coded nulls
-    # that promise a contract we can't deliver. The Experiment-bound
-    # hydra_config below covers the most common reader use case.
+    # Input/Output). Until an upstream enumerator exists, no metadata
+    # field on ExecutionDetail -- the Experiment-bound hydra_config
+    # below covers the most common reader use case.
 
     # Experiment: try lookup_experiment(execution_rid). The deriva-ml
     # API raises if the execution has no Experiment row; treat that as
-    # "not an experiment" and omit the key. When present, surface the
-    # cheap fields (name + config_choices + model_config) but NOT the
-    # full hydra_config payload -- it can be 10-100 KB and a caller
-    # wanting it should fetch the metadata asset directly.
+    # "not an experiment" and set experiment=None. When present,
+    # surface the cheap fields (name + config_choices + model_config)
+    # but NOT the full hydra_config payload -- it can be 10-100 KB and
+    # a caller wanting it should fetch the metadata asset directly.
+    experiment: ExecutionExperiment | None = None
     try:
         exp = ml.lookup_experiment(execution_rid)
-        payload["experiment"] = {
-            "name": getattr(exp, "name", None),
-            "config_choices": getattr(exp, "config_choices", {}) or {},
-            "model_config": getattr(exp, "model_config", {}) or {},
-        }
+        experiment = ExecutionExperiment.model_validate(
+            {
+                "name": getattr(exp, "name", None),
+                "config_choices": getattr(exp, "config_choices", {}) or {},
+                # The wire key is "model_config" (alias) -- pass the dict
+                # under the wire-key form to take advantage of model_validate's
+                # alias-aware construction.
+                "model_config": getattr(exp, "model_config", {}) or {},
+            }
+        )
     except Exception:  # noqa: BLE001 -- absent experiment is the common case
-        pass
+        experiment = None
 
-    return payload
+    return ExecutionDetail(
+        **summary,
+        inputs=ExecutionInputs(datasets=input_datasets, assets=input_assets),
+        outputs=ExecutionOutputs(assets=output_assets),
+        experiment=experiment,
+    )
 
 
 def _summarize_upload_dict(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -143,6 +143,11 @@ async def test_get_dataset_success(dataset_ctx, capturing_mcp, mock_ml):
 
 
 async def test_get_dataset_with_history(dataset_ctx, capturing_mcp, mock_ml):
+    """v2.0 wire change: ``deriva_ml_get_dataset`` returns ``version_history``
+    (was ``history`` in v1.x). The tool now shares the wire shape with the
+    ``deriva://catalog/{h}/{c}/ml/dataset/{rid}`` resource so consumers can
+    switch between tool and resource without re-mapping fields.
+    """
     ds = _make_dataset_mock("1-AAAA")
     history_entry = MagicMock()
     history_entry.dataset_version = "1.0.0"
@@ -160,7 +165,7 @@ async def test_get_dataset_with_history(dataset_ctx, capturing_mcp, mock_ml):
             include_history=True,
         )
     )
-    assert out["history"] == [
+    assert out["version_history"] == [
         {
             "version": "1.0.0",
             "snapshot": "snap1",

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -429,8 +429,11 @@ async def test_ml_execution_detail_includes_inputs_outputs(resource_ctx, capturi
     # No metadata bucket (omit-when-no-upstream-API; see TODO in
     # _get_execution_detail_impl).
     assert "metadata" not in out
-    # No experiment key when the execution is not an Experiment.
-    assert "experiment" not in out
+    # v2.0 wire change: experiment is always present, set to None when
+    # the execution is not a Hydra-driven Experiment. v1.x omitted the
+    # key entirely; the typed contract from PR 2 (#6) now surfaces it
+    # explicitly so consumers can introspect without a KeyError.
+    assert out["experiment"] is None
 
 
 async def test_ml_execution_detail_includes_experiment_when_present(


### PR DESCRIPTION
PR 2 of three for #6. Ships the two breaking wire-shape changes I committed to in v1.6's PR description as deferred. v2.0.0 major bump.

## Breaking changes

### 1. \`experiment\` always-present on ExecutionDetail

The \`deriva://catalog/{h}/{c}/ml/execution/{rid}\` resource now always includes an \`experiment\` key (set to \`null\` when the execution is not a Hydra-driven experiment). v1.x conditionally omitted the key.

Migration: \`if \"experiment\" in payload\` -> \`if payload.get(\"experiment\") is not None\`.

### 2. \`deriva_ml_get_dataset\` returns \`version_history\` (was \`history\`)

The tool's wire shape is now identical to the resource's wire shape. Both use \`version_history\`; both always include the field (empty list when not requested).

Migration: \`payload.get(\"history\", [])\` -> \`payload[\"version_history\"]\`.

This was the main driver for cutting v2.0 — consumers can now switch between tool and resource without re-mapping fields.

## What ships

- New Pydantic models in \`_response_models.py\`: \`ExecutionInputDatasetRef\`, \`ExecutionAssetRef\`, \`ExecutionInputs\`, \`ExecutionOutputs\`, \`ExecutionExperiment\`, \`ExecutionDetail\`.
- \`_get_execution_detail_impl\` returns the typed \`ExecutionDetail\`. Wire structure preserved (inputs.datasets / inputs.assets / outputs.assets nested as before) — just typed and validated.
- \`deriva_ml_get_dataset\` wrapper consolidated to call \`_get_dataset_detail_impl()\` directly. Legacy \`history\` key removed.
- 2 test updates (1 in test_dataset.py, 1 in test_resources.py) for the wire-shape changes; both carry comments explaining the v2.0 change.
- CLAUDE.md updated.

## Pydantic notes

The \`ExecutionExperiment.model_cfg\` field uses Pydantic's \`alias=\"model_config\"\` to preserve the wire key \`\"model_config\"\` while avoiding Pydantic's reserved \`model_*\` namespace. \`protected_namespaces=()\` lets us declare the field at all.

## Tests

- [x] 287 unit tests pass
- [x] \`uv run ruff check\` clean
- [x] \`uv run ruff format --check\` clean
- [x] Skill bodies surveyed: no skills read \`response[\"history\"]\` or \`response[\"experiment\"]\` directly (those were conceptual references only). No tier-1 / tier-2 skill body changes needed.

## What this PR does NOT do

- \`_summarize_*\` helpers stay dict-returning (sweep deferred).
- Ad-hoc payloads (\`deriva_ml_list_dataset_relations\`, preflight-count branches) stay dict (separate models in future PRs).
- Mutating tools untouched (PR 3 of #6).

Each future sweep is its own PR with its own focused review.

## After merge

\`uv run bump-version major\` to release v1.6.0 -> v2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)