### PR TITLE
v2.1.0: PreflightCountResponse shared model

### DIFF
--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -108,6 +108,56 @@ from datetime import datetime, timedelta
 from pydantic import BaseModel, ConfigDict, Field
 
 # ---------------------------------------------------------------------------
+# Preflight-count response (shared by every paginated tool's
+# preflight_count=True branch)
+# ---------------------------------------------------------------------------
+
+
+class PreflightCountResponse(BaseModel):
+    """Response shape for the ``preflight_count=True`` branch of any
+    paginated MCP tool.
+
+    Documented once in the ``deriva_ml_getting_started`` prompt's
+    PAGINATION CONTRACT section so individual ``list_*`` tool
+    docstrings don't redocument it. Returned as JSON
+    ``{"total_count": N, "entities_fetched": false,
+    "action_required": "..."}``, optionally with extra context fields
+    like ``element_table`` (added by ``deriva_ml_list_dataset_members``
+    to indicate which element table the preflight is counting).
+
+    ``extra="allow"`` lets call sites attach context fields without
+    needing a separate model per tool. The three required fields
+    (``total_count``, ``entities_fetched``, ``action_required``) are
+    always present.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    total_count: int | None = Field(
+        description=(
+            "Total count of catalog rows matching the (post-filter) selection. "
+            "May be ``None`` for tools that delegate counting to upstream APIs "
+            "that don't always provide an estimate "
+            "(e.g. ``deriva_ml_denormalize_dataset``'s describe step)."
+        ),
+    )
+    entities_fetched: bool = Field(
+        default=False,
+        description=(
+            "Always False for preflight responses. The flag exists so a single "
+            "consumer-side dispatch on the response shape can distinguish "
+            "preflight from a real page."
+        ),
+    )
+    action_required: str = Field(
+        description=(
+            "Human-readable hint telling the LLM what to do next: choose a "
+            "limit and call the tool again with ``preflight_count=False``."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Common pagination envelope (mixed into every *ListResponse)
 # ---------------------------------------------------------------------------
 

--- a/src/deriva_ml_mcp/tools/asset.py
+++ b/src/deriva_ml_mcp/tools/asset.py
@@ -73,6 +73,7 @@ from deriva_ml_mcp._response_models import (
     AssetSummary,
     AssetTableRef,
     AssetTablesResponse,
+    PreflightCountResponse,
 )
 from deriva_ml_mcp.ml_context import get_ml
 
@@ -313,17 +314,14 @@ def register(ctx: PluginContext) -> None:
                 ml = get_ml(hostname, catalog_id)
                 if preflight_count:
                     total = len(list(ml.list_assets(asset_table)))
-                    return json.dumps(
-                        {
-                            "total_count": total,
-                            "entities_fetched": False,
-                            "action_required": (
-                                f"Found {total} assets in {asset_table}. "
-                                "Choose a limit and call again with "
-                                "preflight_count=False."
-                            ),
-                        }
-                    )
+                    return PreflightCountResponse(
+                        total_count=total,
+                        action_required=(
+                            f"Found {total} assets in {asset_table}. "
+                            "Choose a limit and call again with "
+                            "preflight_count=False."
+                        ),
+                    ).model_dump_json(by_alias=True)
                 assets = sorted(
                     ml.list_assets(asset_table),
                     key=lambda a: getattr(a, "asset_rid", "") or "",

--- a/src/deriva_ml_mcp/tools/dataset/complex.py
+++ b/src/deriva_ml_mcp/tools/dataset/complex.py
@@ -45,6 +45,7 @@ from deriva_ml_mcp._helpers import (
     _paginate,
     _row_rid_for,
 )
+from deriva_ml_mcp._response_models import PreflightCountResponse
 
 if TYPE_CHECKING:
     from deriva_mcp_core.plugin.api import PluginContext
@@ -320,16 +321,12 @@ def register(ctx: PluginContext) -> None:
                         f"Estimated {total} rows for the denormalized view. "
                         "Choose a limit and call again with preflight_count=False."
                     )
-                return json.dumps(
-                    {
-                        "mode": "dataset_preflight",
-                        "dataset_rid": dataset_rid,
-                        "total_count": total,
-                        "entities_fetched": False,
-                        "action_required": action,
-                    },
-                    default=str,
-                )
+                return PreflightCountResponse(
+                    total_count=total,
+                    action_required=action,
+                    mode="dataset_preflight",
+                    dataset_rid=dataset_rid,
+                ).model_dump_json(by_alias=True)
 
             if rows is None:
                 return json.dumps(

--- a/src/deriva_ml_mcp/tools/dataset/read.py
+++ b/src/deriva_ml_mcp/tools/dataset/read.py
@@ -49,6 +49,7 @@ from deriva_ml_mcp._response_models import (
     DatasetMembersSummaryResponse,
     DatasetSummary,
     DatasetVersionEntry,
+    PreflightCountResponse,
 )
 
 if TYPE_CHECKING:
@@ -253,16 +254,13 @@ def register(ctx: PluginContext) -> None:
                 ml = _pkg.get_ml(hostname, catalog_id)
                 if preflight_count:
                     total = len(list(ml.find_datasets(deleted=include_deleted)))
-                    return json.dumps(
-                        {
-                            "total_count": total,
-                            "entities_fetched": False,
-                            "action_required": (
-                                f"Found {total} datasets. Choose a limit and call "
-                                "again with preflight_count=False."
-                            ),
-                        }
-                    )
+                    return PreflightCountResponse(
+                        total_count=total,
+                        action_required=(
+                            f"Found {total} datasets. Choose a limit and call "
+                            "again with preflight_count=False."
+                        ),
+                    ).model_dump_json(by_alias=True)
 
                 capped = min(max(limit, 0), _MAX_LIMIT)
                 payload = _list_datasets_impl(
@@ -437,17 +435,14 @@ def register(ctx: PluginContext) -> None:
             rows = sorted(members[element_table], key=lambda r: r.get("RID", ""))
 
             if preflight_count:
-                return json.dumps(
-                    {
-                        "element_table": element_table,
-                        "total_count": len(rows),
-                        "entities_fetched": False,
-                        "action_required": (
-                            f"{len(rows)} rows in '{element_table}'. Choose a "
-                            "limit and call again with preflight_count=False."
-                        ),
-                    }
-                )
+                return PreflightCountResponse(
+                    total_count=len(rows),
+                    action_required=(
+                        f"{len(rows)} rows in '{element_table}'. Choose a "
+                        "limit and call again with preflight_count=False."
+                    ),
+                    element_table=element_table,
+                ).model_dump_json(by_alias=True)
 
             capped = min(max(limit, 0), _MAX_LIMIT)
             page, truncated, next_after = _paginate(

--- a/src/deriva_ml_mcp/tools/execution.py
+++ b/src/deriva_ml_mcp/tools/execution.py
@@ -53,6 +53,7 @@ from deriva_ml_mcp._response_models import (
     ExecutionListResponse,
     ExecutionOutputs,
     ExecutionSummary,
+    PreflightCountResponse,
 )
 from deriva_ml_mcp.ml_context import get_ml
 
@@ -402,16 +403,13 @@ def register(ctx: PluginContext) -> None:
                 if preflight_count:
                     status_enum = ExecutionStatus(status) if status else None
                     total = len(list(ml.find_executions(workflow=workflow_rid, status=status_enum)))
-                    return json.dumps(
-                        {
-                            "total_count": total,
-                            "entities_fetched": False,
-                            "action_required": (
-                                f"Found {total} executions. Choose a limit and call "
-                                "again with preflight_count=False."
-                            ),
-                        }
-                    )
+                    return PreflightCountResponse(
+                        total_count=total,
+                        action_required=(
+                            f"Found {total} executions. Choose a limit and call "
+                            "again with preflight_count=False."
+                        ),
+                    ).model_dump_json(by_alias=True)
                 capped = min(max(limit, 0), _MAX_LIMIT)
                 payload = _list_executions_impl(
                     ml,
@@ -516,16 +514,13 @@ def register(ctx: PluginContext) -> None:
 
             if preflight_count:
                 total = len(executions)
-                return json.dumps(
-                    {
-                        "total_count": total,
-                        "entities_fetched": False,
-                        "action_required": (
-                            f"Found {total} executions for workflow {workflow_rid}. "
-                            "Choose a limit and call again with preflight_count=False."
-                        ),
-                    }
-                )
+                return PreflightCountResponse(
+                    total_count=total,
+                    action_required=(
+                        f"Found {total} executions for workflow {workflow_rid}. "
+                        "Choose a limit and call again with preflight_count=False."
+                    ),
+                ).model_dump_json(by_alias=True)
 
             capped = min(max(limit, 0), _MAX_LIMIT)
             page, truncated, next_after = _paginate(

--- a/src/deriva_ml_mcp/tools/feature.py
+++ b/src/deriva_ml_mcp/tools/feature.py
@@ -40,6 +40,7 @@ from deriva_ml_mcp._helpers import (
 from deriva_ml_mcp._response_models import (
     FeatureListResponse,
     FeatureSummary,
+    PreflightCountResponse,
 )
 from deriva_ml_mcp.ml_context import get_ml
 
@@ -169,16 +170,13 @@ def register(ctx: PluginContext) -> None:
                 ml = get_ml(hostname, catalog_id)
                 if preflight_count:
                     total = len(list(ml.find_features(table=table)))
-                    return json.dumps(
-                        {
-                            "total_count": total,
-                            "entities_fetched": False,
-                            "action_required": (
-                                f"Found {total} features. Choose a limit and "
-                                "call again with preflight_count=False."
-                            ),
-                        }
-                    )
+                    return PreflightCountResponse(
+                        total_count=total,
+                        action_required=(
+                            f"Found {total} features. Choose a limit and "
+                            "call again with preflight_count=False."
+                        ),
+                    ).model_dump_json(by_alias=True)
 
                 capped = min(max(limit, 0), _MAX_LIMIT)
                 payload = _list_features_impl(
@@ -384,17 +382,14 @@ def register(ctx: PluginContext) -> None:
 
             if preflight_count:
                 total = len(records)
-                return json.dumps(
-                    {
-                        "total_count": total,
-                        "entities_fetched": False,
-                        "action_required": (
-                            f"Found {total} feature records. Choose a "
-                            "limit and call again with "
-                            "preflight_count=False."
-                        ),
-                    }
-                )
+                return PreflightCountResponse(
+                    total_count=total,
+                    action_required=(
+                        f"Found {total} feature records. Choose a "
+                        "limit and call again with "
+                        "preflight_count=False."
+                    ),
+                ).model_dump_json(by_alias=True)
 
             # Sort by RID for stable pagination. Records are pydantic
             # FeatureRecord instances; their RID lives at the .RID

--- a/src/deriva_ml_mcp/tools/workflow.py
+++ b/src/deriva_ml_mcp/tools/workflow.py
@@ -39,6 +39,7 @@ from deriva_ml_mcp._helpers import (
     _read_rid,
 )
 from deriva_ml_mcp._response_models import (
+    PreflightCountResponse,
     WorkflowDetail,
     WorkflowListResponse,
     WorkflowSummary,
@@ -173,16 +174,13 @@ def register(ctx: PluginContext) -> None:
                 ml = get_ml(hostname, catalog_id)
                 if preflight_count:
                     total = len(list(ml.find_workflows()))
-                    return json.dumps(
-                        {
-                            "total_count": total,
-                            "entities_fetched": False,
-                            "action_required": (
-                                f"Found {total} workflows. Choose a limit and call "
-                                "again with preflight_count=False."
-                            ),
-                        }
-                    )
+                    return PreflightCountResponse(
+                        total_count=total,
+                        action_required=(
+                            f"Found {total} workflows. Choose a limit and call "
+                            "again with preflight_count=False."
+                        ),
+                    ).model_dump_json(by_alias=True)
 
                 capped = min(max(limit, 0), _MAX_LIMIT)
                 payload = _list_workflows_impl(ml, after_rid=after_rid, limit=capped)


### PR DESCRIPTION
Removes a DRY violation: every paginated tool's \`preflight_count=True\` branch built the same \`{total_count, entities_fetched, action_required}\` dict inline. Now they all use a shared \`PreflightCountResponse\` Pydantic model.

## What ships

- New \`PreflightCountResponse\` model in \`_response_models.py\`. \`extra=\"allow\"\` permits call-site context fields (\`element_table\`, \`mode\`, \`dataset_rid\`) without per-tool subclasses.
- 8 wrapper sites swept across 6 modules.

## Wire shape

Preserved. JSON field-ordering inside one site (\`list_dataset_members\`'s preflight branch) changes \`element_table\`-first → \`total_count\`-first, but JSON dicts have no guaranteed order and tests assert on dict keys after \`json.loads\`, not on wire-string equality. Non-breaking.

## What this PR does NOT do

- The \"limit-too-small warning\" branch in \`tools/dataset/complex.py\` is a different shape (no \`total_count\`; has \`estimated_row_count\` / \`requested_limit\`). Left as ad-hoc dict; would warrant its own \`LimitTooSmallWarning\` model in a future sweep.
- Tool docstrings still inline the wire shape. The \`deriva_ml_getting_started\` prompt's PAGINATION CONTRACT section remains the canonical source.

## Validation

- 287 unit tests pass
- \`uv run ruff check\` clean
- \`uv run ruff format --check\` clean

## Three-stage rollout after v2.0

- ✅ v2.1.0 (this): PreflightCountResponse
- v2.2.0 (next): _summarize_* full Pydantic sweep
- v2.3.0 (later): ad-hoc relation/lineage payload models
- v3.0.0 / PR 3 of #6: mutating-tool response shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)