### PR TITLE
v2.2.0: _summarize_* full Pydantic sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,19 +211,39 @@ and shipped two breaking wire-shape changes:
   unifies the tool + resource shapes so consumers can switch freely
   between them.
 
+v2.1 introduced `PreflightCountResponse` — one shared model used by
+the `preflight_count=True` branch of every paginated tool. Removes
+the DRY violation where each paginated tool built the same
+`{total_count, entities_fetched, action_required}` dict inline.
+The model uses `extra="allow"` to permit per-call-site context
+fields (`element_table`, `mode`, `dataset_rid`).
+
+v2.2 swept the `_summarize_*` building-block helpers to return
+Pydantic instances (`DatasetSummary`, `WorkflowSummary`,
+`ExecutionSummary`, `FeatureSummary`, `AssetSummary`). Consumers
+that previously dict-accessed the summary now use attribute access
+or call `.model_dump()` to get a plain dict back. Ad-hoc payload
+sites (parents/children in `deriva_ml_list_dataset_relations`,
+inline sub-payloads in `deriva_ml_find_workflow_executions` /
+`_list_execution_children` / `_list_execution_parents`) call
+`.model_dump()` to bridge to the surrounding `json.dumps(...)`. The
+RAG indexer's `_fetch_*_rows` and `_reindex_*` helpers were updated
+to use `.model_dump(mode="json")` (replaces the v1.x
+`json.loads(json.dumps(row, default=str))` round-trip; cleaner
+single-call coercion of datetimes etc.).
+
 Future v2.x sweeps (each its own PR):
 
-- `_summarize_*` building-block helpers still return `dict[str, Any]`.
-  Pydantic-izing them requires touching every ad-hoc consumer call
-  site (parents/children blocks in `deriva_ml_list_dataset_relations`,
-  inline sub-payloads in `deriva_ml_find_workflow_executions` /
-  `_list_execution_children` / `_list_execution_parents`,
-  description-update wrapper response shapes, etc.).
-- Ad-hoc preflight-count responses (`{total_count, entities_fetched,
-  action_required}`) are duplicated across every paginated tool.
-  Worth a shared `PreflightCountResponse` model.
-- Mutating-tool response shapes (insert/update/delete) are still
-  ad-hoc dicts. Their own coherent design pass (PR 3 of #6).
+- v2.3: ad-hoc payload Pydantic models. The list_dataset_relations,
+  find_workflow_executions, list_execution_children, and
+  list_execution_parents wrappers each build inline
+  `{<plural>: [...], count, ...}` shapes with one-off context fields
+  that should become named models. v2.2's `.model_dump()` bridge
+  gets replaced by directly constructing the model.
+- v3.0 (PR 3 of #6): mutating-tool response shapes (currently
+  heterogeneous: `{"status": "created", ...}`, `{"status": "deleted",
+  ...}`, partial-result shapes for failures). Their own coherent
+  design pass.
 
 ## Coverage Report
 

--- a/src/deriva_ml_mcp/resources/rag.py
+++ b/src/deriva_ml_mcp/resources/rag.py
@@ -303,20 +303,21 @@ class _VocabSerializer(RowSerializer):
 def _fetch_dataset_rows(hostname: str, catalog_id: str) -> list[dict[str, Any]]:
     """Fetch up to ``_MAX_LIMIT`` Dataset summary rows under the caller's credential.
 
-    Wraps ``_list_datasets_impl`` and pulls the ``"datasets"`` array. The
-    helper already returns JSON-friendly dicts so no shape conversion is
-    needed before passing to the serializer.
+    Wraps ``_list_datasets_impl`` and pulls the ``"datasets"`` array.
+    Since v2.2 the helper returns a ``DatasetListResponse`` Pydantic
+    instance; ``.model_dump(mode="json")`` produces JSON-serializable
+    dicts (datetimes coerced) for the chunk serializer.
     """
     ml = get_ml(hostname, catalog_id)
     payload = _list_datasets_impl(ml, after_rid=None, limit=_MAX_LIMIT)
-    return list(payload.get("datasets", []))
+    return [d.model_dump(mode="json") for d in payload.datasets]
 
 
 def _fetch_workflow_rows(hostname: str, catalog_id: str) -> list[dict[str, Any]]:
     """Fetch up to ``_MAX_LIMIT`` Workflow summary rows under the caller's credential."""
     ml = get_ml(hostname, catalog_id)
     payload = _list_workflows_impl(ml, after_rid=None, limit=_MAX_LIMIT)
-    return list(payload.get("workflows", []))
+    return [w.model_dump(mode="json") for w in payload.workflows]
 
 
 def _fetch_execution_rows(hostname: str, catalog_id: str) -> list[dict[str, Any]]:
@@ -329,7 +330,7 @@ def _fetch_execution_rows(hostname: str, catalog_id: str) -> list[dict[str, Any]
         after_rid=None,
         limit=_MAX_LIMIT,
     )
-    return list(payload.get("executions", []))
+    return [e.model_dump(mode="json") for e in payload.executions]
 
 
 def _coerce_for_index(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -475,10 +476,11 @@ async def _reindex_dataset(hostname: str, catalog_id: str, dataset_rid: str) -> 
     try:
         ml = get_ml(hostname, catalog_id)
         ds = ml.lookup_dataset(dataset_rid)
-        row = _summarize_dataset(ds)
-        # Round-trip through json so any stray non-serializable values
-        # (e.g. Pydantic versions) become plain strings before chunking.
-        row = json.loads(json.dumps(row, default=str))
+        # _summarize_dataset returns a Pydantic ``DatasetSummary`` (since v2.2);
+        # ``model_dump(mode="json")`` produces a JSON-serializable dict
+        # (datetimes etc. coerced) -- equivalent to the old
+        # ``json.loads(json.dumps(row, default=str))`` round-trip.
+        row = _summarize_dataset(ds).model_dump(mode="json")
         user_id = resolve_user_identity(hostname)
         source = _row_source_name(hostname, catalog_id, user_id, _DATASET_TOKEN, dataset_rid)
         return await _write_row_chunk(store, source, _DATASET_TABLE, row, _DatasetSerializer())
@@ -503,8 +505,8 @@ async def _reindex_workflow(hostname: str, catalog_id: str, workflow_rid: str) -
     try:
         ml = get_ml(hostname, catalog_id)
         wf = ml.lookup_workflow(workflow_rid)
-        row = _summarize_workflow(wf)
-        row = json.loads(json.dumps(row, default=str))
+        # See _reindex_dataset for the v2.2 ``model_dump(mode="json")`` rationale.
+        row = _summarize_workflow(wf).model_dump(mode="json")
         user_id = resolve_user_identity(hostname)
         source = _row_source_name(hostname, catalog_id, user_id, _WORKFLOW_TOKEN, workflow_rid)
         return await _write_row_chunk(store, source, _WORKFLOW_TABLE, row, _WorkflowSerializer())
@@ -529,8 +531,8 @@ async def _reindex_execution(hostname: str, catalog_id: str, execution_rid: str)
     try:
         ml = get_ml(hostname, catalog_id)
         record = ml.lookup_execution(execution_rid)
-        row = _summarize_execution(record)
-        row = json.loads(json.dumps(row, default=str))
+        # See _reindex_dataset for the v2.2 ``model_dump(mode="json")`` rationale.
+        row = _summarize_execution(record).model_dump(mode="json")
         user_id = resolve_user_identity(hostname)
         source = _row_source_name(hostname, catalog_id, user_id, _EXECUTION_TOKEN, execution_rid)
         return await _write_row_chunk(store, source, _EXECUTION_TABLE, row, _ExecutionSerializer())

--- a/src/deriva_ml_mcp/tools/asset.py
+++ b/src/deriva_ml_mcp/tools/asset.py
@@ -88,16 +88,20 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-def _summarize_asset(asset: Any) -> dict[str, Any]:
-    """Render an Asset object into the JSON-friendly summary used by list endpoints.
+def _summarize_asset(asset: Any) -> AssetSummary:
+    """Render an Asset object into the validated summary used by list endpoints.
 
     Args:
         asset: A ``deriva_ml.asset.asset.Asset`` instance.
 
     Returns:
-        Dict matching the ``AssetSummary`` Pydantic model shape. Kept
-        dict-returning to preserve PR 1 scope -- consumers that build
-        list responses construct the model from these dicts.
+        ``AssetSummary`` Pydantic instance -- see
+        ``deriva_ml_mcp._response_models``.
+
+    Note:
+        v2.2 sweep: this helper now returns Pydantic. Consumers that
+        previously dict-accessed must use attribute access or call
+        ``.model_dump()`` to get a plain dict back.
 
     Example:
         >>> from unittest.mock import MagicMock
@@ -108,17 +112,17 @@ def _summarize_asset(asset: Any) -> dict[str, Any]:
         >>> a.md5 = "abc"
         >>> a.asset_table = "Image"
         >>> a.asset_types = ["Training_Data"]
-        >>> _summarize_asset(a)["rid"]
+        >>> _summarize_asset(a).rid
         '1-AAAA'
     """
-    return {
-        "rid": asset.asset_rid,
-        "filename": asset.filename,
-        "length": asset.length,
-        "md5": asset.md5,
-        "asset_table": asset.asset_table,
-        "asset_types": list(asset.asset_types) if asset.asset_types else [],
-    }
+    return AssetSummary(
+        rid=asset.asset_rid,
+        filename=asset.filename,
+        length=asset.length,
+        md5=asset.md5,
+        asset_table=asset.asset_table,
+        asset_types=list(asset.asset_types) if asset.asset_types else [],
+    )
 
 
 def _list_asset_tables_impl(ml: Any) -> AssetTablesResponse:
@@ -334,7 +338,7 @@ def register(ctx: PluginContext) -> None:
                     key=partial(_read_rid, rid_key="asset_rid"),
                 )
             return AssetListResponse(
-                assets=[AssetSummary(**_summarize_asset(a)) for a in page],
+                assets=[_summarize_asset(a) for a in page],
                 count=len(page),
                 truncated=truncated,
                 next_after_rid=next_after,

--- a/src/deriva_ml_mcp/tools/dataset/mutate.py
+++ b/src/deriva_ml_mcp/tools/dataset/mutate.py
@@ -123,7 +123,7 @@ def register(ctx: PluginContext) -> None:
                 execution_rid=execution_rid,
                 dataset_rid=new_ds.dataset_rid,
                 dataset_types=dataset_types or [],
-                version=summary["current_version"],
+                version=summary.current_version,
             )
             # v1.3 surgical re-index: refresh just the new dataset's
             # per-RID source so rag_search picks it up on the next call
@@ -140,7 +140,9 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for dataset %s after create_dataset",
                     new_ds.dataset_rid,
                 )
-            return json.dumps({"status": "created", **summary, "execution_rid": execution_rid})
+            return json.dumps(
+                {"status": "created", **summary.model_dump(), "execution_rid": execution_rid}
+            )
         except Exception as exc:
             return _error_envelope(
                 exc,

--- a/src/deriva_ml_mcp/tools/dataset/read.py
+++ b/src/deriva_ml_mcp/tools/dataset/read.py
@@ -56,31 +56,28 @@ if TYPE_CHECKING:
     from deriva_mcp_core.plugin.api import PluginContext
 
 
-def _summarize_dataset(ds: Any) -> dict[str, Any]:
-    """Render a Dataset object into the JSON-friendly summary used by list endpoints.
+def _summarize_dataset(ds: Any) -> DatasetSummary:
+    """Render a Dataset object into the validated summary used by list endpoints.
 
     Args:
         ds: A ``deriva_ml.dataset.dataset.Dataset`` instance.
 
     Returns:
-        Dict matching the ``DatasetSummary`` Pydantic model shape. The
-        Pydantic model lives in ``deriva_ml_mcp._response_models`` and
-        is the validated form -- ``_list_datasets_impl`` constructs
-        the model from the dicts this helper produces. We keep this
-        helper dict-returning because it's called from ad-hoc payload
-        sites (e.g. parents/children blocks in
-        ``deriva_ml_list_dataset_relations``) that don't want a
-        validated Pydantic instance, and converting at every call
-        site would expand v1.6's scope. Those sites get tightened in
-        PR 2 (v2.0).
+        ``DatasetSummary`` Pydantic instance -- see
+        ``deriva_ml_mcp._response_models``.
+
+    Note:
+        v2.2 sweep: this helper now returns Pydantic. Consumers that
+        previously dict-accessed must use attribute access or call
+        ``.model_dump()`` to get a plain dict back.
     """
     current = ds.current_version
-    return {
-        "rid": ds.dataset_rid,
-        "description": ds.description,
-        "dataset_types": list(ds.dataset_types) if ds.dataset_types else [],
-        "current_version": str(current) if current is not None else None,
-    }
+    return DatasetSummary(
+        rid=ds.dataset_rid,
+        description=ds.description,
+        dataset_types=list(ds.dataset_types) if ds.dataset_types else [],
+        current_version=str(current) if current is not None else None,
+    )
 
 
 def _list_datasets_impl(
@@ -112,7 +109,7 @@ def _list_datasets_impl(
         key=partial(_read_rid, rid_key="dataset_rid"),
     )
     return DatasetListResponse(
-        datasets=[DatasetSummary(**_summarize_dataset(d)) for d in page],
+        datasets=[_summarize_dataset(d) for d in page],
         count=len(page),
         truncated=truncated,
         next_after_rid=next_after,
@@ -148,7 +145,7 @@ def _get_dataset_detail_impl(ml: Any, dataset_rid: str) -> DatasetDetail:
         for h in ds.dataset_history()
     ]
     return DatasetDetail(
-        **summary,
+        **summary.model_dump(),
         chaise_url=ds.get_chaise_url(),
         version_history=version_history,
     )
@@ -335,7 +332,7 @@ def register(ctx: PluginContext) -> None:
                     ds = ml.lookup_dataset(dataset_rid)
                     summary = _summarize_dataset(ds)
                     payload = DatasetDetail(
-                        **summary,
+                        **summary.model_dump(),
                         chaise_url=ds.get_chaise_url(),
                         version_history=[],
                     )
@@ -543,7 +540,12 @@ def register(ctx: PluginContext) -> None:
                         limit=capped,
                         key=partial(_read_rid, rid_key="dataset_rid"),
                     )
-                    result["parents"] = [_summarize_dataset(p) for p in page]
+                    # Note: ad-hoc payload pre-v2.3 -- the
+                    # ``list_dataset_relations`` response shape will get its
+                    # own ``DatasetRelationsResponse`` Pydantic model in v2.3.
+                    # For v2.2 we just .model_dump() each summary so the
+                    # surrounding json.dumps() can serialize them.
+                    result["parents"] = [_summarize_dataset(p).model_dump() for p in page]
                     result["parents_truncated"] = truncated
 
                 if direction in ("children", "both"):
@@ -557,7 +559,7 @@ def register(ctx: PluginContext) -> None:
                         limit=capped,
                         key=partial(_read_rid, rid_key="dataset_rid"),
                     )
-                    result["children"] = [_summarize_dataset(c) for c in page]
+                    result["children"] = [_summarize_dataset(c).model_dump() for c in page]
                     result["children_truncated"] = truncated
 
             if warning is not None:

--- a/src/deriva_ml_mcp/tools/execution.py
+++ b/src/deriva_ml_mcp/tools/execution.py
@@ -96,8 +96,8 @@ _COMMIT_ALLOWED_STATES = {
 }
 
 
-def _summarize_execution(record: Any) -> dict[str, Any]:
-    """Render an ``ExecutionRecord`` (or ``Execution``) into the JSON list shape.
+def _summarize_execution(record: Any) -> ExecutionSummary:
+    """Render an ``ExecutionRecord`` (or ``Execution``) into the validated summary.
 
     Tolerates both ``ExecutionRecord`` (returned by ``lookup_execution``
     / ``find_executions``) and ``Execution`` (returned by
@@ -108,10 +108,13 @@ def _summarize_execution(record: Any) -> dict[str, Any]:
         record: An ``ExecutionRecord`` (preferred) or ``Execution`` mock.
 
     Returns:
-        Dict matching the ``ExecutionSummary`` Pydantic model shape.
-        ``_list_executions_impl`` constructs the model from these
-        dicts. Kept dict-returning to avoid touching ad-hoc payload
-        sites in PR 1; PR 2 may switch to Pydantic-throughout.
+        ``ExecutionSummary`` Pydantic instance -- see
+        ``deriva_ml_mcp._response_models``.
+
+    Note:
+        v2.2 sweep: this helper now returns Pydantic. Consumers that
+        previously dict-accessed must use attribute access or call
+        ``.model_dump()`` to get a plain dict back.
 
     Example:
         >>> from unittest.mock import MagicMock
@@ -124,21 +127,21 @@ def _summarize_execution(record: Any) -> dict[str, Any]:
         >>> rec.start_time = None
         >>> rec.stop_time = None
         >>> rec.duration = None
-        >>> _summarize_execution(rec)["rid"]
+        >>> _summarize_execution(rec).rid
         '1-EXEC'
-        >>> _summarize_execution(rec)["status"]
+        >>> _summarize_execution(rec).status
         'Created'
     """
     status = getattr(record, "status", None)
-    return {
-        "rid": getattr(record, "execution_rid", None),
-        "workflow_rid": getattr(record, "workflow_rid", None),
-        "status": status.value if isinstance(status, ExecutionStatus) else status,
-        "description": getattr(record, "description", None),
-        "start_time": getattr(record, "start_time", None),
-        "stop_time": getattr(record, "stop_time", None),
-        "duration": getattr(record, "duration", None),
-    }
+    return ExecutionSummary(
+        rid=getattr(record, "execution_rid", None),
+        workflow_rid=getattr(record, "workflow_rid", None),
+        status=status.value if isinstance(status, ExecutionStatus) else status,
+        description=getattr(record, "description", None),
+        start_time=getattr(record, "start_time", None),
+        stop_time=getattr(record, "stop_time", None),
+        duration=getattr(record, "duration", None),
+    )
 
 
 def _list_executions_impl(
@@ -173,7 +176,7 @@ def _list_executions_impl(
         key=partial(_read_rid, rid_key="execution_rid"),
     )
     return ExecutionListResponse(
-        executions=[ExecutionSummary(**_summarize_execution(e)) for e in page],
+        executions=[_summarize_execution(e) for e in page],
         count=len(page),
         truncated=truncated,
         next_after_rid=next_after,
@@ -291,7 +294,7 @@ def _get_execution_detail_impl(ml: Any, execution_rid: str) -> ExecutionDetail:
         experiment = None
 
     return ExecutionDetail(
-        **summary,
+        **summary.model_dump(),
         inputs=ExecutionInputs(datasets=input_datasets, assets=input_assets),
         outputs=ExecutionOutputs(assets=output_assets),
         experiment=experiment,
@@ -458,7 +461,7 @@ def register(ctx: PluginContext) -> None:
                 ml = get_ml(hostname, catalog_id)
                 record = ml.lookup_execution(execution_rid)
                 summary = _summarize_execution(record)
-            return json.dumps(summary, default=str)
+            return summary.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -529,9 +532,14 @@ def register(ctx: PluginContext) -> None:
                 limit=capped,
                 key=partial(_read_rid, rid_key="execution_rid"),
             )
+            # Note: ad-hoc payload pre-v2.3 -- the
+            # ``find_workflow_executions`` response shape will get its
+            # own Pydantic model in v2.3. For v2.2 we just .model_dump()
+            # each summary so the surrounding json.dumps() can serialize
+            # them.
             return json.dumps(
                 {
-                    "executions": [_summarize_execution(e) for e in page],
+                    "executions": [_summarize_execution(e).model_dump() for e in page],
                     "count": len(page),
                     "truncated": truncated,
                     "next_after_rid": next_after,
@@ -587,12 +595,15 @@ def register(ctx: PluginContext) -> None:
                 ml = get_ml(hostname, catalog_id)
                 record = ml.lookup_execution(execution_rid)
                 children = list(record.list_execution_children(recurse=recurse))
+            # Note: ad-hoc payload pre-v2.3 -- see comment above
+            # ``find_workflow_executions``. Each child gets .model_dump()
+            # so the surrounding json.dumps() can serialize them.
             return json.dumps(
                 {
                     "parent_rid": execution_rid,
                     "recurse": recurse,
                     "count": len(children),
-                    "children": [_summarize_execution(c) for c in children],
+                    "children": [_summarize_execution(c).model_dump() for c in children],
                 },
                 default=str,
             )
@@ -639,12 +650,14 @@ def register(ctx: PluginContext) -> None:
                 ml = get_ml(hostname, catalog_id)
                 record = ml.lookup_execution(execution_rid)
                 parents = list(record.list_execution_parents(recurse=recurse))
+            # Note: ad-hoc payload pre-v2.3 -- see comment above
+            # ``find_workflow_executions``.
             return json.dumps(
                 {
                     "child_rid": execution_rid,
                     "recurse": recurse,
                     "count": len(parents),
-                    "parents": [_summarize_execution(p) for p in parents],
+                    "parents": [_summarize_execution(p).model_dump() for p in parents],
                 },
                 default=str,
             )

--- a/src/deriva_ml_mcp/tools/feature.py
+++ b/src/deriva_ml_mcp/tools/feature.py
@@ -48,25 +48,29 @@ if TYPE_CHECKING:
     from deriva_mcp_core.plugin.api import PluginContext
 
 
-def _summarize_feature(feature: Any) -> dict[str, Any]:
-    """Render a Feature object into the JSON-friendly shape used by list endpoints.
+def _summarize_feature(feature: Any) -> FeatureSummary:
+    """Render a Feature object into the validated summary used by list endpoints.
 
     Args:
         feature: A ``deriva_ml.feature.Feature`` instance.
 
     Returns:
-        Dict matching the ``FeatureSummary`` Pydantic model shape.
-        ``_list_features_impl`` constructs the model from these dicts.
-        Kept dict-returning to preserve PR 1 scope.
+        ``FeatureSummary`` Pydantic instance -- see
+        ``deriva_ml_mcp._response_models``.
+
+    Note:
+        v2.2 sweep: this helper now returns Pydantic. Consumers that
+        previously dict-accessed must use attribute access or call
+        ``.model_dump()`` to get a plain dict back.
     """
-    return {
-        "feature_name": feature.feature_name,
-        "target_table": feature.target_table.name,
-        "feature_table": feature.feature_table.name,
-        "term_columns": [c.name for c in feature.term_columns],
-        "asset_columns": [c.name for c in feature.asset_columns],
-        "value_columns": [c.name for c in feature.value_columns],
-    }
+    return FeatureSummary(
+        feature_name=feature.feature_name,
+        target_table=feature.target_table.name,
+        feature_table=feature.feature_table.name,
+        term_columns=[c.name for c in feature.term_columns],
+        asset_columns=[c.name for c in feature.asset_columns],
+        value_columns=[c.name for c in feature.value_columns],
+    )
 
 
 def _list_features_impl(
@@ -102,7 +106,7 @@ def _list_features_impl(
         key=lambda f: f.feature_table.name,
     )
     return FeatureListResponse(
-        features=[FeatureSummary(**_summarize_feature(f)) for f in page],
+        features=[_summarize_feature(f) for f in page],
         count=len(page),
         truncated=truncated,
         next_after_rid=next_after,
@@ -491,9 +495,9 @@ def register(ctx: PluginContext) -> None:
                 feature_name=feature_name,
                 n_term_cols=len(terms_list),
                 n_asset_cols=len(assets_list),
-                n_value_cols=len(summary["value_columns"]),
+                n_value_cols=len(summary.value_columns),
             )
-            return json.dumps({"status": "created", **summary})
+            return json.dumps({"status": "created", **summary.model_dump()})
         except Exception as exc:
             return _error_envelope(
                 exc,

--- a/src/deriva_ml_mcp/tools/workflow.py
+++ b/src/deriva_ml_mcp/tools/workflow.py
@@ -50,27 +50,34 @@ if TYPE_CHECKING:
     from deriva_mcp_core.plugin.api import PluginContext
 
 
-def _summarize_workflow(wf: Any) -> dict[str, Any]:
-    """Render a Workflow object into the JSON-friendly summary used by list endpoints.
+def _summarize_workflow(wf: Any) -> WorkflowSummary:
+    """Render a Workflow object into the validated summary used by list endpoints.
 
     Args:
         wf: A ``deriva_ml.execution.workflow.Workflow`` instance.
 
     Returns:
-        Dict matching the ``WorkflowSummary`` Pydantic model shape.
-        ``_list_workflows_impl`` constructs the model from these dicts.
-        Kept dict-returning to avoid touching ad-hoc payload sites
-        in PR 1; PR 2 may switch to Pydantic-throughout.
+        ``WorkflowSummary`` Pydantic instance -- see
+        ``deriva_ml_mcp._response_models``. Construction validates
+        the field types; bad data from ``deriva-ml`` raises
+        ``ValidationError`` here rather than surfacing as malformed
+        JSON downstream.
+
+    Note:
+        v2.2 sweep: this helper now returns Pydantic. Consumers that
+        previously dict-accessed (``summary["rid"]``) must use
+        attribute access (``summary.rid``) or call ``.model_dump()``
+        to get a plain dict back.
     """
-    return {
-        "rid": wf.rid,
-        "name": wf.name,
-        "url": wf.url,
-        "checksum": wf.checksum,
-        "version": wf.version,
-        "workflow_type": list(wf.workflow_type) if wf.workflow_type else [],
-        "description": wf.description,
-    }
+    return WorkflowSummary(
+        rid=wf.rid,
+        name=wf.name,
+        url=wf.url,
+        checksum=wf.checksum,
+        version=wf.version,
+        workflow_type=list(wf.workflow_type) if wf.workflow_type else [],
+        description=wf.description,
+    )
 
 
 def _list_workflows_impl(
@@ -97,7 +104,7 @@ def _list_workflows_impl(
         key=partial(_read_rid, rid_key="rid"),
     )
     return WorkflowListResponse(
-        workflows=[WorkflowSummary(**_summarize_workflow(w)) for w in page],
+        workflows=[_summarize_workflow(w) for w in page],
         count=len(page),
         truncated=truncated,
         next_after_rid=next_after,
@@ -116,7 +123,8 @@ def _get_workflow_impl(ml: Any, workflow_rid: str) -> WorkflowDetail:
         (Currently shape-equivalent to ``WorkflowSummary``.)
     """
     wf = ml.lookup_workflow(workflow_rid)
-    return WorkflowDetail(**_summarize_workflow(wf))
+    summary = _summarize_workflow(wf)
+    return WorkflowDetail(**summary.model_dump())
 
 
 def register(ctx: PluginContext) -> None:
@@ -274,7 +282,7 @@ def register(ctx: PluginContext) -> None:
                 ml = get_ml(hostname, catalog_id)
                 wf = ml.lookup_workflow_by_url(url_or_checksum)
                 summary = _summarize_workflow(wf)
-            return json.dumps(summary)
+            return summary.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,


### PR DESCRIPTION
Sweeps the 5 \`_summarize_*\` building-block helpers (dataset, workflow, execution, feature, asset) to return Pydantic instances. Updates 9 ad-hoc consumer call sites that previously dict-accessed the summary.

## Pattern

- Helpers now return ``DatasetSummary`` / ``WorkflowSummary`` / etc. (Pydantic instances) instead of plain dicts.
- Consumers use attribute access (\`.rid\`) or \`.model_dump()\` to bridge to ad-hoc payload sites.
- The RAG indexer's \`_fetch_*_rows\` and \`_reindex_*\` helpers use \`.model_dump(mode=\"json\")\` — replaces v1.x's \`json.loads(json.dumps(row, default=str))\` round-trip with cleaner single-call coercion.

## What this PR does NOT do

- Ad-hoc wrappers (\`list_dataset_relations\`, \`find_workflow_executions\`, \`list_execution_children\`, \`list_execution_parents\`) still build \`json.dumps({...})\` payloads inline. v2.3 will replace these with named Pydantic models.
- Mutating-tool response shapes (PR 3 of #6) untouched. v3.0.

## Wire shape

Preserved. 287 unit tests pass unchanged; 14 integration deselected as usual.

## After merge

\`uv run bump-version minor\` to release v2.1.0 → v2.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)