### PR TITLE
v2.3.0: Replace ad-hoc dict payloads with named Pydantic models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,14 +232,28 @@ to use `.model_dump(mode="json")` (replaces the v1.x
 `json.loads(json.dumps(row, default=str))` round-trip; cleaner
 single-call coercion of datetimes etc.).
 
-Future v2.x sweeps (each its own PR):
+v2.3 retired the four ad-hoc payload sites listed in the v2.2 note.
+Each wrapper now constructs a named Pydantic model and serializes
+via `.model_dump_json(by_alias=True)`:
 
-- v2.3: ad-hoc payload Pydantic models. The list_dataset_relations,
-  find_workflow_executions, list_execution_children, and
-  list_execution_parents wrappers each build inline
-  `{<plural>: [...], count, ...}` shapes with one-off context fields
-  that should become named models. v2.2's `.model_dump()` bridge
-  gets replaced by directly constructing the model.
+- `deriva_ml_find_workflow_executions` reuses `ExecutionListResponse`
+  (its response is shape-identical to `_list_executions_impl`'s,
+  just filtered by workflow).
+- `deriva_ml_list_execution_children` returns `ExecutionChildrenResponse`
+  (`{parent_rid, recurse, count, children: list[ExecutionSummary]}`).
+- `deriva_ml_list_execution_parents` returns `ExecutionParentsResponse`
+  (`{child_rid, recurse, count, parents: list[ExecutionSummary]}`).
+- `deriva_ml_list_dataset_relations` returns `DatasetRelationsResponse`
+  with all-optional fields (`parents`, `parents_truncated`,
+  `children`, `children_truncated`, `warning`). The wrapper passes
+  `exclude_none=True` to `model_dump_json` so the v1.x wire shape
+  is preserved -- when `direction="parents"` the response has no
+  `children`/`children_truncated` keys at all (not present as
+  `null`). The conditional-key contract is documented on the model
+  docstring.
+
+Future v3.x sweep:
+
 - v3.0 (PR 3 of #6): mutating-tool response shapes (currently
   heterogeneous: `{"status": "created", ...}`, `{"status": "deleted",
   ...}`, partial-result shapes for failures). Their own coherent

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -273,6 +273,38 @@ class DatasetMembersSummaryResponse(BaseModel):
     tables: list[str]
 
 
+class DatasetRelationsResponse(BaseModel):
+    """Response shape for ``deriva_ml_list_dataset_relations``.
+
+    The wrapper supports three directions: ``parents``, ``children``,
+    or ``both``. Each direction populates the corresponding
+    ``parents`` / ``children`` list and its ``parents_truncated`` /
+    ``children_truncated`` flag. When the caller requested only one
+    direction, the other side's fields are absent (None on the wire).
+
+    The ``warning`` field is set when the caller passed ``after_rid``
+    with ``direction="both"`` -- the single cursor is incoherent
+    because parents and children RIDs aren't synchronized, so we
+    drop the cursor and warn rather than silently mis-paginating.
+
+    All fields use Optional shapes (``= None``) to mirror the v1.x
+    "field omitted when not relevant" wire shape. Pydantic's
+    ``exclude_none=True`` on serialization could drop the absent
+    fields, but the v1.x wire used dict literal omission -- we
+    replicate that with ``model_dump_json(exclude_none=True,
+    by_alias=True)`` at the call site to preserve the v1.x wire
+    shape exactly.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    parents: list[DatasetSummary] | None = None
+    parents_truncated: bool | None = None
+    children: list[DatasetSummary] | None = None
+    children_truncated: bool | None = None
+    warning: str | None = None
+
+
 # ---------------------------------------------------------------------------
 # Workflow response models
 # ---------------------------------------------------------------------------
@@ -442,9 +474,50 @@ class ExecutionDetail(ExecutionSummary):
 
 
 class ExecutionListResponse(_PaginationFields):
-    """Paginated list of Executions. Produced by ``_list_executions_impl``."""
+    """Paginated list of Executions. Produced by ``_list_executions_impl``.
+
+    Also returned by ``deriva_ml_find_workflow_executions`` (since v2.3),
+    which reuses this shape -- it's a paginated list of executions
+    filtered by workflow.
+    """
 
     executions: list[ExecutionSummary]
+
+
+class ExecutionChildrenResponse(BaseModel):
+    """Response shape for ``deriva_ml_list_execution_children``.
+
+    Returns descendants of an execution (children, optionally
+    recursively all descendants). Distinct from
+    ``ExecutionListResponse`` because:
+
+    - Not paginated -- the relation graph is bounded per execution.
+    - Carries the parent's RID + the recurse flag as context so the
+      caller can introspect the query parameters from the response.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    parent_rid: str
+    recurse: bool
+    count: int
+    children: list[ExecutionSummary]
+
+
+class ExecutionParentsResponse(BaseModel):
+    """Response shape for ``deriva_ml_list_execution_parents``.
+
+    Returns ancestors of an execution. Symmetric with
+    ``ExecutionChildrenResponse`` but with ``child_rid`` and
+    ``parents`` instead of ``parent_rid`` and ``children``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    child_rid: str
+    recurse: bool
+    count: int
+    parents: list[ExecutionSummary]
 
 
 # ---------------------------------------------------------------------------

--- a/src/deriva_ml_mcp/tools/dataset/read.py
+++ b/src/deriva_ml_mcp/tools/dataset/read.py
@@ -47,6 +47,7 @@ from deriva_ml_mcp._response_models import (
     DatasetListResponse,
     DatasetMemberRef,
     DatasetMembersSummaryResponse,
+    DatasetRelationsResponse,
     DatasetSummary,
     DatasetVersionEntry,
     PreflightCountResponse,
@@ -524,7 +525,7 @@ def register(ctx: PluginContext) -> None:
                     "To page both sides, call once per direction with "
                     "that side's own after_rid."
                 )
-            result: dict[str, Any] = {}
+            kwargs: dict[str, Any] = {}
             with deriva_call():
                 ml = _pkg.get_ml(hostname, catalog_id)
                 ds = ml.lookup_dataset(dataset_rid)
@@ -540,13 +541,8 @@ def register(ctx: PluginContext) -> None:
                         limit=capped,
                         key=partial(_read_rid, rid_key="dataset_rid"),
                     )
-                    # Note: ad-hoc payload pre-v2.3 -- the
-                    # ``list_dataset_relations`` response shape will get its
-                    # own ``DatasetRelationsResponse`` Pydantic model in v2.3.
-                    # For v2.2 we just .model_dump() each summary so the
-                    # surrounding json.dumps() can serialize them.
-                    result["parents"] = [_summarize_dataset(p).model_dump() for p in page]
-                    result["parents_truncated"] = truncated
+                    kwargs["parents"] = [_summarize_dataset(p) for p in page]
+                    kwargs["parents_truncated"] = truncated
 
                 if direction in ("children", "both"):
                     children = sorted(
@@ -559,13 +555,19 @@ def register(ctx: PluginContext) -> None:
                         limit=capped,
                         key=partial(_read_rid, rid_key="dataset_rid"),
                     )
-                    result["children"] = [_summarize_dataset(c).model_dump() for c in page]
-                    result["children_truncated"] = truncated
+                    kwargs["children"] = [_summarize_dataset(c) for c in page]
+                    kwargs["children_truncated"] = truncated
 
             if warning is not None:
-                result["warning"] = warning
+                kwargs["warning"] = warning
 
-            return json.dumps(result)
+            # ``exclude_none=True`` preserves the v1.x wire shape where the
+            # opposite-direction fields are *omitted* (not serialized as
+            # ``null``). When ``direction="parents"`` the response has no
+            # ``children`` / ``children_truncated`` keys at all.
+            return DatasetRelationsResponse(**kwargs).model_dump_json(
+                by_alias=True, exclude_none=True
+            )
         except Exception as exc:
             # Read-only tool: log+return without an audit row (I-2 fix).
             return _error_envelope(

--- a/src/deriva_ml_mcp/tools/execution.py
+++ b/src/deriva_ml_mcp/tools/execution.py
@@ -46,12 +46,14 @@ from deriva_ml_mcp._helpers import (
 )
 from deriva_ml_mcp._response_models import (
     ExecutionAssetRef,
+    ExecutionChildrenResponse,
     ExecutionDetail,
     ExecutionExperiment,
     ExecutionInputDatasetRef,
     ExecutionInputs,
     ExecutionListResponse,
     ExecutionOutputs,
+    ExecutionParentsResponse,
     ExecutionSummary,
     PreflightCountResponse,
 )
@@ -532,20 +534,15 @@ def register(ctx: PluginContext) -> None:
                 limit=capped,
                 key=partial(_read_rid, rid_key="execution_rid"),
             )
-            # Note: ad-hoc payload pre-v2.3 -- the
-            # ``find_workflow_executions`` response shape will get its
-            # own Pydantic model in v2.3. For v2.2 we just .model_dump()
-            # each summary so the surrounding json.dumps() can serialize
-            # them.
-            return json.dumps(
-                {
-                    "executions": [_summarize_execution(e).model_dump() for e in page],
-                    "count": len(page),
-                    "truncated": truncated,
-                    "next_after_rid": next_after,
-                },
-                default=str,
-            )
+            # v2.3 reuses ExecutionListResponse here -- the
+            # find_workflow_executions response is shape-identical to
+            # _list_executions_impl's response (filtered by workflow).
+            return ExecutionListResponse(
+                executions=[_summarize_execution(e) for e in page],
+                count=len(page),
+                truncated=truncated,
+                next_after_rid=next_after,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -595,18 +592,12 @@ def register(ctx: PluginContext) -> None:
                 ml = get_ml(hostname, catalog_id)
                 record = ml.lookup_execution(execution_rid)
                 children = list(record.list_execution_children(recurse=recurse))
-            # Note: ad-hoc payload pre-v2.3 -- see comment above
-            # ``find_workflow_executions``. Each child gets .model_dump()
-            # so the surrounding json.dumps() can serialize them.
-            return json.dumps(
-                {
-                    "parent_rid": execution_rid,
-                    "recurse": recurse,
-                    "count": len(children),
-                    "children": [_summarize_execution(c).model_dump() for c in children],
-                },
-                default=str,
-            )
+            return ExecutionChildrenResponse(
+                parent_rid=execution_rid,
+                recurse=recurse,
+                count=len(children),
+                children=[_summarize_execution(c) for c in children],
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -650,17 +641,12 @@ def register(ctx: PluginContext) -> None:
                 ml = get_ml(hostname, catalog_id)
                 record = ml.lookup_execution(execution_rid)
                 parents = list(record.list_execution_parents(recurse=recurse))
-            # Note: ad-hoc payload pre-v2.3 -- see comment above
-            # ``find_workflow_executions``.
-            return json.dumps(
-                {
-                    "child_rid": execution_rid,
-                    "recurse": recurse,
-                    "count": len(parents),
-                    "parents": [_summarize_execution(p).model_dump() for p in parents],
-                },
-                default=str,
-            )
+            return ExecutionParentsResponse(
+                child_rid=execution_rid,
+                recurse=recurse,
+                count=len(parents),
+                parents=[_summarize_execution(p) for p in parents],
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,


### PR DESCRIPTION
## Summary

Final sweep of the response-shape Pydantic migration for read tools (#6).
The four wrapper sites that v2.2 left bridged via `.model_dump()` now
construct named Pydantic response models directly:

- `deriva_ml_find_workflow_executions` reuses `ExecutionListResponse`
  (response is shape-identical to `_list_executions_impl`, just filtered
  by workflow).
- `deriva_ml_list_execution_children` → new `ExecutionChildrenResponse`
  (`{parent_rid, recurse, count, children: list[ExecutionSummary]}`).
- `deriva_ml_list_execution_parents` → new `ExecutionParentsResponse`
  (`{child_rid, recurse, count, parents: list[ExecutionSummary]}`).
- `deriva_ml_list_dataset_relations` → new `DatasetRelationsResponse`
  with all-optional fields, serialized via
  `model_dump_json(by_alias=True, exclude_none=True)` so the v1.x
  conditional-key wire shape is preserved (when
  `direction="parents"`, the response has no `children` /
  `children_truncated` keys at all — not present as `null`).

## Wire shape

**Unchanged for all four sites.** All 287 tests pass without
modification. The conditional-key contract for `list_dataset_relations`
is documented on the new model's docstring.

## Follow-up

This closes the v2.x sprint for read-tool response shapes. The
remaining work in #6 is **v3.0** — mutating-tool response shapes
(currently heterogeneous `{"status": "created", ...}` /
`{"status": "deleted", ...}` / partial-failure shapes); deferred to
its own coherent design pass.

## Test plan
- [x] `uv run pytest` (287 passed)
- [x] `uv run ruff check src tests` (clean)
- [x] `uv run ruff format --check src tests` (clean)
- [x] CLAUDE.md updated to mark v2.3 shipped and remove from
      future-sweeps list

🤖 Generated with [Claude Code](https://claude.com/claude-code)