### PR TITLE
v3.0.0: Mutating-tool response models + vocabulary normalization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,12 +252,43 @@ via `.model_dump_json(by_alias=True)`:
   `null`). The conditional-key contract is documented on the model
   docstring.
 
-Future v3.x sweep:
+v3.0 swept the mutating-tool response shapes. Every `mutates=True`
+tool now returns a named Pydantic response model with a
+`Literal[...]` `status` discriminator and `extra="forbid"`. The
+discriminator vocabulary was normalized -- the generic `"success"`
+status was retired in favor of operation-specific verbs (`created`,
+`added`, `removed`, `incremented`, `cached`, `split`). Idempotent
+no-ops on `start_execution` / `abort_execution` are now signaled
+via dedicated status values (`already_running` / `already_aborted`)
+instead of an optional `note` field. `update_dataset`'s
+conditional-key fields (`dataset_types`, `added`, `removed`) are
+now always present (`null` when the description-only branch ran).
+`cache_dataset` nests upstream bag-info keys under a `bag_info`
+field instead of spreading them top-level.
 
-- v3.0 (PR 3 of #6): mutating-tool response shapes (currently
-  heterogeneous: `{"status": "created", ...}`, `{"status": "deleted",
-  ...}`, partial-result shapes for failures). Their own coherent
-  design pass.
+v3.0 wire-break migration map for clients:
+
+- `add_dataset_members`: `status="success"` -> `status="added"`.
+- `delete_dataset_members`: `status="success"` -> `status="removed"`.
+- `add_dataset_element_type`: `status="success"` -> `status="created"`.
+- `increment_dataset_version`: `status="success"` -> `status="incremented"`.
+- `cache_dataset`: `status="success"` -> `status="cached"`; bag-info
+  keys moved from top-level to `payload["bag_info"][<key>]`.
+- `split_dataset`: `status="success"` -> `status="split"`.
+- `start_execution` no-op: `{"status": "running", "note": "already running"}`
+  -> `{"status": "already_running"}`.
+- `abort_execution` no-op: `{"status": "aborted", "note": "already aborted"}`
+  -> `{"status": "already_aborted", "reason": null}`.
+- `update_dataset` description-only edit: `dataset_types` / `added` /
+  `removed` keys are present as `null` instead of being omitted.
+- `abort_execution`: `reason` is always present (`null` when no
+  reason was given) instead of being omitted on the no-op branch.
+- `create_execution_dataset`: `dataset_types` is always present
+  (`null` when omitted by the caller) instead of being omitted.
+
+This closes PR 3 of #6. The response-shape Pydantic migration is
+complete -- every `_*_impl` helper, every list/detail/summary
+shape, and every mutating-tool response is now Pydantic-typed.
 
 ## Coverage Report
 

--- a/docs/superpowers/plans/2026-04-27-v3.0-mutating-tool-response-models.md
+++ b/docs/superpowers/plans/2026-04-27-v3.0-mutating-tool-response-models.md
@@ -1,0 +1,1745 @@
+# v3.0.0 Mutating-Tool Response Models — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the 25 mutating tools' inline `dict` payloads with named Pydantic response models, normalize the `status` discriminator vocabulary, and unify the conditional-key shapes — closing PR 3 of #6 (the response-shape Pydantic migration).
+
+**Architecture:** Add ~25 new Pydantic models to `_response_models.py`, one per tool (with one shared mixin for the three dataset-version-bump tools). Each model has a `Literal[...]` `status` discriminator and `extra="forbid"`. Wrappers replace `return json.dumps({...})` with `return ResponseModel(...).model_dump_json(by_alias=True)`. Wire breaks from this version are documented in CLAUDE.md and announced in the release notes:
+1. Six `status` values normalized (`success` → operation-specific verb).
+2. Two new status values for idempotent no-ops (`already_running`, `already_aborted`) replace the optional `note` field.
+3. Conditional-key fields become always-present-with-`null` defaults (no more "key absent" branches).
+4. `cache_dataset` nests upstream `bag_info` keys under their own field instead of spreading them top-level.
+
+**Tech Stack:** Python 3.13+, Pydantic v2, FastMCP / deriva-mcp-core, pytest.
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/deriva_ml_mcp/_response_models.py` — append a new "Mutating-tool responses (v3.0)" section with ~25 models + 1 mixin + a few nested-detail models (`CommitExecutionReport`, `SplitDatasetPartitions`, `SplitDatasetPartitionInfo`, `CacheDatasetBagInfo`).
+- `src/deriva_ml_mcp/tools/asset.py` — refactor 1 wrapper (`update_asset`).
+- `src/deriva_ml_mcp/tools/workflow.py` — refactor 2 wrappers (`create_workflow`, `update_workflow`).
+- `src/deriva_ml_mcp/tools/feature.py` — refactor 3 wrappers (`create_feature`, `delete_feature`, `add_feature_values`).
+- `src/deriva_ml_mcp/tools/execution.py` — refactor 7 wrappers (create / start / commit / abort / update / create_dataset / add_nested) + delete the `_summarize_upload_dict` shape's dict-typing in favor of Pydantic.
+- `src/deriva_ml_mcp/tools/dataset/mutate.py` — refactor 7 wrappers (create / delete / update / add_members / delete_members / add_element_type / increment_version).
+- `src/deriva_ml_mcp/tools/dataset/complex.py` — refactor 2 wrappers (`cache_dataset`, `split_dataset`).
+- `tests/test_*.py` — update assertions for the breaking changes (status renames, `bag_info` nesting, `note` field removal, always-present-`null` fields).
+- `CLAUDE.md` — mark v3.0 shipped in the response-models section; document the 4 wire-break categories.
+
+**Don't modify:**
+- The error envelope path (`_error_envelope` already returns `{"error": ...}` and is covered by `ErrorEnvelope`).
+- The audit machinery, the re-index machinery, or any read-tool models.
+- The `_summarize_*` helpers — they were already swept in v2.2 and stay as-is.
+
+---
+
+## Status Vocabulary (final)
+
+This is the v3.0 contract. Every mutating-tool response uses exactly one of these `status` values:
+
+| Status | Meaning | Tools |
+|---|---|---|
+| `created` | New entity registered or association made | create_dataset, create_feature, create_workflow, create_execution, create_execution_dataset, **add_dataset_element_type** |
+| `exists` | Idempotent dedup hit — entity already existed | create_workflow alt-branch |
+| `updated` | Mutable fields on an existing entity were changed | update_asset, update_workflow, update_execution, update_dataset |
+| `deleted` | Entity removed | delete_feature, delete_dataset |
+| `not_found` | Idempotent delete — target didn't exist | delete_feature alt-branch |
+| `added` | Items appended to a parent's collection | add_feature_values, add_nested_execution, **add_dataset_members** |
+| `removed` | Items removed from a parent's collection | **delete_dataset_members** |
+| `running` | Execution lifecycle started | start_execution |
+| `already_running` | start_execution called on already-running execution | start_execution alt-branch |
+| `aborted` | Execution lifecycle terminated abnormally | abort_execution |
+| `already_aborted` | abort_execution called on already-aborted execution | abort_execution alt-branch |
+| `uploaded` | Execution lifecycle completed with artifact upload | commit_execution |
+| `incremented` | Dataset version bumped without member change | **increment_dataset_version** |
+| `cached` | Dataset bag fetched/materialized locally | **cache_dataset** |
+| `split` | Dataset partition operation completed | **split_dataset** |
+
+Bold = wire-break (status-value rename).
+
+---
+
+## Wire-break summary (for the v3.0 changelog)
+
+1. **Six tools rename their `status` value:**
+   - `add_dataset_element_type`: `success` → `created`
+   - `add_dataset_members`: `success` → `added`
+   - `delete_dataset_members`: `success` → `removed`
+   - `increment_dataset_version`: `success` → `incremented`
+   - `cache_dataset`: `success` → `cached`
+   - `split_dataset`: `success` → `split`
+
+2. **Idempotent no-op responses replace `note` with new status values:**
+   - `start_execution` no-op: `{"status": "running", ..., "note": "already running"}` → `{"status": "already_running", ...}`.
+   - `abort_execution` no-op: `{"status": "aborted", ..., "note": "already aborted"}` → `{"status": "already_aborted", ...}`. (`reason` stays present in both branches as `null` when not given.)
+
+3. **Conditional-key fields become always-present `null`:**
+   - `update_dataset`: `dataset_types`, `added`, `removed` are now always present (`null` when the description-only branch ran).
+
+4. **`cache_dataset` nests upstream `bag_info` keys:**
+   - Was: `{"status": "cached", "dataset_rid", "version", "materialize", "tables": ..., "total_rows": ..., "total_asset_bytes": ..., "total_asset_size": ..., "cache_status": ..., "cache_path": ...}`.
+   - Now: `{"status": "cached", "dataset_rid", "version", "materialize", "bag_info": {"tables", "total_rows", "total_asset_bytes", "total_asset_size", "cache_status", "cache_path"}}`.
+
+---
+
+## Tasks
+
+### Task 1: Branch + `_response_models.py` mutating-section header
+
+**Files:**
+- Create branch: `feature/v3.0-mutating-tool-response-models`
+- Modify: `src/deriva_ml_mcp/_response_models.py` (append section)
+
+- [ ] **Step 1: Create branch off main**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp
+git checkout main && git pull
+git checkout -b feature/v3.0-mutating-tool-response-models
+```
+
+- [ ] **Step 2: Append section header to `_response_models.py`**
+
+Append at the end of the file (after `class ErrorEnvelope(BaseModel):`):
+
+```python
+
+
+# ---------------------------------------------------------------------------
+# Mutating-tool response models (v3.0)
+#
+# Every ``mutates=True`` tool's success-path response is a Pydantic model
+# in this section. Each model has a ``Literal[...]`` ``status`` field that
+# acts as the discriminator -- consumers can ``match payload["status"]:``
+# without checking which tool produced the response.
+#
+# v3.0 wire-break notes (see ``CLAUDE.md`` for full migration guide):
+#
+# 1. Six tools' ``status`` values were renamed away from the generic
+#    ``"success"`` to operation-specific verbs (``created``, ``added``,
+#    ``removed``, ``incremented``, ``cached``, ``split``).
+# 2. ``start_execution`` and ``abort_execution`` no-op branches now emit
+#    ``status="already_running"`` / ``status="already_aborted"`` instead
+#    of carrying an optional ``note`` string.
+# 3. Conditional-key fields on ``update_dataset`` are now always present
+#    (``null`` when not meaningful) instead of being omitted.
+# 4. ``cache_dataset`` nests upstream bag-info keys under a ``bag_info``
+#    field instead of spreading them top-level.
+# ---------------------------------------------------------------------------
+```
+
+- [ ] **Step 3: Run tests + lint to confirm no regression from the empty section**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp
+uv run pytest && uv run ruff check src tests && uv run ruff format --check src tests
+```
+
+Expected: 287 passed, lint clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/deriva_ml_mcp/_response_models.py
+git commit -m "chore(v3.0): add mutating-tool response section header"
+```
+
+---
+
+### Task 2: Asset mutation model + refactor `update_asset`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/_response_models.py` (add `UpdateAssetResponse`)
+- Modify: `src/deriva_ml_mcp/tools/asset.py` (refactor wrapper at lines ~503-509)
+- Test: `tests/test_asset.py` (verify wire shape unchanged for this tool)
+
+- [ ] **Step 1: Add `UpdateAssetResponse` to `_response_models.py`**
+
+Append below the v3.0 section header:
+
+```python
+class UpdateAssetResponse(BaseModel):
+    """Response from ``deriva_ml_update_asset``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["updated"]
+    asset_rid: str
+    updated_fields: list[str]
+```
+
+- [ ] **Step 2: Update `tools/asset.py` import**
+
+Add `UpdateAssetResponse` to the existing `from deriva_ml_mcp._response_models import (...)` block (alphabetized).
+
+- [ ] **Step 3: Refactor the wrapper return**
+
+Replace lines 503-509:
+
+```python
+return json.dumps(
+    {
+        "status": "updated",
+        "asset_rid": asset_rid,
+        "updated_fields": updated_fields,
+    }
+)
+```
+
+with:
+
+```python
+return UpdateAssetResponse(
+    status="updated",
+    asset_rid=asset_rid,
+    updated_fields=updated_fields,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+uv run pytest tests/test_asset.py -v
+```
+
+Expected: all asset tests pass (wire shape unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml_mcp/_response_models.py src/deriva_ml_mcp/tools/asset.py
+git commit -m "feat(v3.0): UpdateAssetResponse + refactor update_asset wrapper"
+```
+
+---
+
+### Task 3: Workflow mutation models + refactor `create_workflow` & `update_workflow`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/_response_models.py` (add 2 models)
+- Modify: `src/deriva_ml_mcp/tools/workflow.py` (refactor 2 wrappers)
+- Test: `tests/test_workflow.py`
+
+- [ ] **Step 1: Add models**
+
+Append to `_response_models.py`:
+
+```python
+class CreateWorkflowResponse(BaseModel):
+    """Response from ``deriva_ml_create_workflow``.
+
+    ``status="created"`` for new workflows, ``status="exists"`` for the
+    idempotent dedup branch (URL or checksum already registered).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["created", "exists"]
+    workflow_rid: str
+    name: str
+    workflow_type: str
+    url: str
+    checksum: str | None = None
+    version: str | None = None
+
+
+class UpdateWorkflowResponse(BaseModel):
+    """Response from ``deriva_ml_update_workflow``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["updated"]
+    workflow_rid: str
+    updated_fields: list[str]
+```
+
+- [ ] **Step 2: Update `tools/workflow.py` import**
+
+Add `CreateWorkflowResponse, UpdateWorkflowResponse` to the existing import block.
+
+- [ ] **Step 3: Refactor `create_workflow` (lines 413-423)**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": status,
+        "workflow_rid": rid,
+        "name": name,
+        "workflow_type": normalized_types,
+        "url": url,
+        "checksum": checksum,
+        "version": version,
+    }
+)
+```
+
+with:
+
+```python
+return CreateWorkflowResponse(
+    status=status,  # "created" or "exists"
+    workflow_rid=rid,
+    name=name,
+    workflow_type=normalized_types,
+    url=url,
+    checksum=checksum,
+    version=version,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 4: Refactor `update_workflow` (lines 519-525)**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "updated",
+        "workflow_rid": workflow_rid,
+        "updated_fields": updated_fields,
+    }
+)
+```
+
+with:
+
+```python
+return UpdateWorkflowResponse(
+    status="updated",
+    workflow_rid=workflow_rid,
+    updated_fields=updated_fields,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+uv run pytest tests/test_workflow.py -v
+```
+
+Expected: all workflow tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/deriva_ml_mcp/_response_models.py src/deriva_ml_mcp/tools/workflow.py
+git commit -m "feat(v3.0): CreateWorkflowResponse + UpdateWorkflowResponse"
+```
+
+---
+
+### Task 4: Feature mutation models + refactor 3 wrappers
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/_response_models.py`
+- Modify: `src/deriva_ml_mcp/tools/feature.py`
+- Test: `tests/test_feature.py`
+
+- [ ] **Step 1: Add models**
+
+```python
+class CreateFeatureResponse(FeatureSummary):
+    """Response from ``deriva_ml_create_feature``.
+
+    Wraps ``FeatureSummary`` (which the wrapper already builds) and
+    pins the discriminator. The status field comes first in the
+    JSON output thanks to Pydantic's field-order preservation.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["created"]
+
+
+class DeleteFeatureResponse(BaseModel):
+    """Response from ``deriva_ml_delete_feature``.
+
+    ``status="deleted"`` when the feature was removed, ``status="not_found"``
+    on the idempotent no-op when the feature didn't exist.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["deleted", "not_found"]
+    feature_name: str
+    table: str
+
+
+class AddFeatureValuesResponse(BaseModel):
+    """Response from ``deriva_ml_add_feature_values``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["added"]
+    feature_name: str
+    execution_rid: str
+    count: int
+```
+
+Note: `CreateFeatureResponse` extends `FeatureSummary`. Pydantic v2 supports class-level field re-ordering; the `status` field is added by the subclass, so it appears AFTER the `FeatureSummary` fields in the dump. To preserve the v1.x wire shape (`status` first), either (a) accept the change in field order (purely cosmetic — JSON object key order is not significant per RFC 8259), or (b) define the response without inheritance and copy the `FeatureSummary` fields. Use option (a) — the existing test (`tests/test_feature.py`) already uses `json.loads()` and key-based access, so order doesn't matter.
+
+- [ ] **Step 2: Update `tools/feature.py` import**
+
+Add `AddFeatureValuesResponse, CreateFeatureResponse, DeleteFeatureResponse`.
+
+- [ ] **Step 3: Refactor `create_feature` (line 500)**
+
+Replace:
+
+```python
+return json.dumps({"status": "created", **summary.model_dump()})
+```
+
+with:
+
+```python
+return CreateFeatureResponse(
+    status="created",
+    **summary.model_dump(),
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 4: Refactor `delete_feature` (lines 554-560)**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": status,
+        "feature_name": feature_name,
+        "table": table,
+    }
+)
+```
+
+with:
+
+```python
+return DeleteFeatureResponse(
+    status=status,  # "deleted" or "not_found"
+    feature_name=feature_name,
+    table=table,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 5: Refactor `add_feature_values` (lines 673-680)**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "added",
+        "feature_name": feature_name,
+        "execution_rid": execution_rid,
+        "count": added,
+    }
+)
+```
+
+with:
+
+```python
+return AddFeatureValuesResponse(
+    status="added",
+    feature_name=feature_name,
+    execution_rid=execution_rid,
+    count=added,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+uv run pytest tests/test_feature.py -v
+```
+
+Expected: all feature tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/deriva_ml_mcp/_response_models.py src/deriva_ml_mcp/tools/feature.py
+git commit -m "feat(v3.0): Feature mutation response models"
+```
+
+---
+
+### Task 5: Execution lifecycle models — sub-models for `commit_execution`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/_response_models.py`
+
+- [ ] **Step 1: Add `CommitExecutionReport` nested model**
+
+```python
+class CommitExecutionReport(BaseModel):
+    """Per-call upload report nested inside ``CommitExecutionResponse``.
+
+    Mirrors the dict produced by ``_summarize_upload_dict`` in
+    ``tools/execution.py`` (which is internal — consumers see only the
+    Pydantic shape on the wire).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    execution_rids: list[str]
+    total_uploaded: int
+    total_failed: int
+    feature_count: int
+    per_table: dict[str, dict[str, int]]
+    errors: list[str]
+    errors_truncated: bool
+```
+
+- [ ] **Step 2: Verify `_summarize_upload_dict` returns those exact keys**
+
+```bash
+grep -n "_summarize_upload_dict" src/deriva_ml_mcp/tools/execution.py
+```
+
+Read the helper body and confirm the return keys match the model. If a key differs, update the model to match (the helper is the source of truth — it's internal).
+
+- [ ] **Step 3: Run tests + lint after this empty step**
+
+```bash
+uv run pytest && uv run ruff check src tests
+```
+
+Expected: still passing — the model isn't used yet.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/deriva_ml_mcp/_response_models.py
+git commit -m "feat(v3.0): CommitExecutionReport nested model"
+```
+
+---
+
+### Task 6: Execution mutation models + refactor 7 wrappers
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/_response_models.py`
+- Modify: `src/deriva_ml_mcp/tools/execution.py`
+- Test: `tests/test_execution.py`
+
+- [ ] **Step 1: Add the seven response models**
+
+```python
+class CreateExecutionResponse(BaseModel):
+    """Response from ``deriva_ml_create_execution``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["created"]
+    execution_rid: str
+    workflow_rid: str
+    dataset_count: int
+    asset_count: int
+    dry_run: bool
+
+
+class StartExecutionResponse(BaseModel):
+    """Response from ``deriva_ml_start_execution``.
+
+    ``status="running"`` on a real start, ``status="already_running"`` on
+    the idempotent no-op when the execution was already in Running state.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["running", "already_running"]
+    execution_rid: str
+
+
+class CommitExecutionResponse(BaseModel):
+    """Response from ``deriva_ml_commit_execution``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["uploaded"]
+    execution_rid: str
+    report: CommitExecutionReport
+
+
+class UpdateExecutionResponse(BaseModel):
+    """Response from ``deriva_ml_update_execution``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["updated"]
+    execution_rid: str
+    updated_fields: list[str]
+
+
+class AbortExecutionResponse(BaseModel):
+    """Response from ``deriva_ml_abort_execution``.
+
+    ``status="aborted"`` on a real abort, ``status="already_aborted"`` on
+    the idempotent no-op. ``reason`` is always present (``null`` when
+    no reason was given OR when the call was a no-op).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["aborted", "already_aborted"]
+    execution_rid: str
+    reason: str | None = None
+
+
+class CreateExecutionDatasetResponse(BaseModel):
+    """Response from ``deriva_ml_create_execution_dataset``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["created"]
+    dataset_rid: str
+    execution_rid: str
+    dataset_types: list[str]
+    description: str
+
+
+class AddNestedExecutionResponse(BaseModel):
+    """Response from ``deriva_ml_add_nested_execution``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["added"]
+    parent_rid: str
+    child_rid: str
+    sequence: int
+```
+
+- [ ] **Step 2: Update `tools/execution.py` import**
+
+Add to the existing `from deriva_ml_mcp._response_models import (...)` block (alphabetized):
+`AbortExecutionResponse, AddNestedExecutionResponse, CommitExecutionReport, CommitExecutionResponse, CreateExecutionDatasetResponse, CreateExecutionResponse, StartExecutionResponse, UpdateExecutionResponse`.
+
+- [ ] **Step 3: Refactor `create_execution` (lines 764-773)**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "created",
+        "execution_rid": execution_rid,
+        "workflow_rid": workflow_rid,
+        "dataset_count": len(ds_list),
+        "asset_count": len(as_list),
+        "dry_run": dry_run,
+    }
+)
+```
+
+with:
+
+```python
+return CreateExecutionResponse(
+    status="created",
+    execution_rid=execution_rid,
+    workflow_rid=workflow_rid,
+    dataset_count=len(ds_list),
+    asset_count=len(as_list),
+    dry_run=dry_run,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 4: Refactor `start_execution` no-op branch (lines 825-832)**
+
+Replace:
+
+```python
+if current == ExecutionStatus.Running:
+    # Idempotent no-op. No audit.
+    return json.dumps(
+        {
+            "status": "running",
+            "execution_rid": execution_rid,
+            "note": "already running",
+        }
+    )
+```
+
+with:
+
+```python
+if current == ExecutionStatus.Running:
+    # Idempotent no-op. No audit. v3.0: status discriminator carries
+    # the no-op signal (was an optional ``note`` field in v2.x).
+    return StartExecutionResponse(
+        status="already_running",
+        execution_rid=execution_rid,
+    ).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 5: Refactor `start_execution` success branch (lines 861-866)**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "running",
+        "execution_rid": execution_rid,
+    }
+)
+```
+
+with:
+
+```python
+return StartExecutionResponse(
+    status="running",
+    execution_rid=execution_rid,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 6: Update `start_execution` docstring (lines ~801-807)**
+
+Replace the `Returns:` block:
+
+```
+        Returns:
+            JSON string ``{"status": "running", "execution_rid"}`` on
+            transition. ``{"status": "running", "execution_rid", "note":
+            "already running"}`` on idempotent no-op.
+            ``{"error": "cannot start execution in state ..."}`` on
+            terminal state.
+```
+
+with:
+
+```
+        Returns:
+            JSON string ``{"status": "running", "execution_rid"}`` on
+            transition. ``{"status": "already_running", "execution_rid"}``
+            on idempotent no-op (v3.0 -- replaced the optional ``note``
+            field with a discriminator status value).
+            ``{"error": "cannot start execution in state ..."}`` on
+            terminal state.
+```
+
+- [ ] **Step 7: Refactor `commit_execution` (lines 979-986)**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "uploaded",
+        "execution_rid": execution_rid,
+        "report": summary,
+    },
+    default=str,
+)
+```
+
+with:
+
+```python
+return CommitExecutionResponse(
+    status="uploaded",
+    execution_rid=execution_rid,
+    report=CommitExecutionReport(**summary),
+).model_dump_json(by_alias=True)
+```
+
+(The `default=str` was needed for inline `json.dumps` to coerce non-JSON-native types from `summary`. With Pydantic, the `CommitExecutionReport` declares its types explicitly; if `summary` contains a non-coercible value the construction will raise `ValidationError` and the wrapper's `_error_envelope` returns it.)
+
+- [ ] **Step 8: Refactor `update_execution` (lines 1074-1080)**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "updated",
+        "execution_rid": execution_rid,
+        "updated_fields": updated_fields,
+    }
+)
+```
+
+with:
+
+```python
+return UpdateExecutionResponse(
+    status="updated",
+    execution_rid=execution_rid,
+    updated_fields=updated_fields,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 9: Refactor `abort_execution` no-op branch (lines 1129-1135)**
+
+Replace:
+
+```python
+if current == ExecutionStatus.Aborted:
+    return json.dumps(
+        {
+            "status": "aborted",
+            "execution_rid": execution_rid,
+            "note": "already aborted",
+        }
+    )
+```
+
+with:
+
+```python
+if current == ExecutionStatus.Aborted:
+    # v3.0: status discriminator carries the no-op signal (was an
+    # optional ``note`` field in v2.x). ``reason`` is None here --
+    # we didn't actually record an abort reason this call.
+    return AbortExecutionResponse(
+        status="already_aborted",
+        execution_rid=execution_rid,
+        reason=None,
+    ).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 10: Refactor `abort_execution` success branch (lines 1156-1162)**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "aborted",
+        "execution_rid": execution_rid,
+        "reason": reason,
+    }
+)
+```
+
+with:
+
+```python
+return AbortExecutionResponse(
+    status="aborted",
+    execution_rid=execution_rid,
+    reason=reason,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 11: Update `abort_execution` docstring**
+
+Replace the `Returns:` block in the docstring:
+
+```
+        Returns:
+            JSON string ``{"status": "aborted", "execution_rid",
+            "reason"}``. ``{"status": "aborted", "execution_rid",
+            "note": "already aborted"}`` on idempotent no-op.
+```
+
+with:
+
+```
+        Returns:
+            JSON string ``{"status": "aborted", "execution_rid",
+            "reason"}``. ``{"status": "already_aborted", "execution_rid",
+            "reason": null}`` on idempotent no-op (v3.0 -- replaced the
+            optional ``note`` field with a discriminator status value).
+            ``reason`` is always present; ``null`` when no reason was
+            given.
+```
+
+- [ ] **Step 12: Refactor `create_execution_dataset` (lines 1249-1257)**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "created",
+        "dataset_rid": dataset_rid,
+        "execution_rid": execution_rid,
+        "dataset_types": types_list,
+        "description": description,
+    }
+)
+```
+
+with:
+
+```python
+return CreateExecutionDatasetResponse(
+    status="created",
+    dataset_rid=dataset_rid,
+    execution_rid=execution_rid,
+    dataset_types=types_list,
+    description=description,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 13: Refactor `add_nested_execution` (lines 1324-1331)**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "added",
+        "parent_rid": parent_execution_rid,
+        "child_rid": child_execution_rid,
+        "sequence": sequence,
+    }
+)
+```
+
+with:
+
+```python
+return AddNestedExecutionResponse(
+    status="added",
+    parent_rid=parent_execution_rid,
+    child_rid=child_execution_rid,
+    sequence=sequence,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 14: Update test assertions in `tests/test_execution.py` for the no-op renames**
+
+Find tests that assert the old `note` field or the `status="running"`/`status="aborted"` no-op shape. The relevant test names typically contain `idempotent`, `already`, or `noop`. For each:
+
+- Search: `grep -n "already running\|already aborted\|note" tests/test_execution.py`
+- For each assertion:
+  - Old: `assert payload["status"] == "running"` and `assert payload["note"] == "already running"` → New: `assert payload["status"] == "already_running"` and `assert "note" not in payload`.
+  - Old: `assert payload["status"] == "aborted"` (no-op branch) and `assert payload["note"] == "already aborted"` → New: `assert payload["status"] == "already_aborted"` and `assert "note" not in payload` and `assert payload["reason"] is None`.
+
+- [ ] **Step 15: Run tests**
+
+```bash
+uv run pytest tests/test_execution.py -v
+```
+
+Expected: all execution tests pass.
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add src/deriva_ml_mcp/_response_models.py src/deriva_ml_mcp/tools/execution.py tests/test_execution.py
+git commit -m "feat(v3.0): execution lifecycle response models
+
+BREAKING: start_execution no-op now returns status='already_running'
+(was status='running' with note='already running'). Same for
+abort_execution -> 'already_aborted'. abort_execution's reason field
+is now always present (null when not given)."
+```
+
+---
+
+### Task 7: Dataset version-bump mixin + 3 mutation models that use it
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/_response_models.py`
+
+- [ ] **Step 1: Add the mixin and the three models that share it**
+
+```python
+class _DatasetVersionBumpMixin(BaseModel):
+    """Common fields for tools that bump a dataset's version.
+
+    Three tools share this shape: ``add_dataset_members``,
+    ``delete_dataset_members``, and ``increment_dataset_version``. They
+    all return the dataset RID and the post-bump version string.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_rid: str
+    new_version: str
+
+
+class AddDatasetMembersResponse(_DatasetVersionBumpMixin):
+    """Response from ``deriva_ml_add_dataset_members``.
+
+    v3.0: ``status`` was renamed from ``"success"`` to ``"added"`` to
+    match the v3.0 status vocabulary (operation-specific verbs).
+    """
+
+    status: Literal["added"]
+    added_count: int
+
+
+class DeleteDatasetMembersResponse(_DatasetVersionBumpMixin):
+    """Response from ``deriva_ml_delete_dataset_members``.
+
+    v3.0: ``status`` was renamed from ``"success"`` to ``"removed"``.
+    """
+
+    status: Literal["removed"]
+    removed_count: int
+
+
+class IncrementDatasetVersionResponse(_DatasetVersionBumpMixin):
+    """Response from ``deriva_ml_increment_dataset_version``.
+
+    v3.0: ``status`` was renamed from ``"success"`` to ``"incremented"``.
+    """
+
+    status: Literal["incremented"]
+    previous_version: str
+    component: str
+```
+
+- [ ] **Step 2: Run tests + lint**
+
+```bash
+uv run pytest && uv run ruff check src tests
+```
+
+Expected: still passing — models unused yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/deriva_ml_mcp/_response_models.py
+git commit -m "feat(v3.0): dataset version-bump mixin + 3 models"
+```
+
+---
+
+### Task 8: Remaining dataset mutation models + refactor 7 wrappers
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/_response_models.py`
+- Modify: `src/deriva_ml_mcp/tools/dataset/mutate.py`
+- Test: `tests/test_dataset.py`
+
+- [ ] **Step 1: Add the four remaining dataset mutation models**
+
+```python
+class CreateDatasetResponse(DatasetSummary):
+    """Response from ``deriva_ml_create_dataset``.
+
+    Extends ``DatasetSummary`` with the v3.0 status discriminator and
+    the linking ``execution_rid``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["created"]
+    execution_rid: str
+
+
+class DeleteDatasetResponse(BaseModel):
+    """Response from ``deriva_ml_delete_dataset``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["deleted"]
+    dataset_rid: str
+    recursive: bool
+
+
+class UpdateDatasetResponse(BaseModel):
+    """Response from ``deriva_ml_update_dataset``.
+
+    v3.0: the ``dataset_types``, ``added``, and ``removed`` fields are
+    now ALWAYS present in the response (``null`` when the
+    description-only branch ran). v2.x omitted these keys when the
+    description-only branch ran.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["updated"]
+    dataset_rid: str
+    updated_fields: list[str]
+    new_version: str
+    dataset_types: list[str] | None = None
+    added: list[str] | None = None
+    removed: list[str] | None = None
+
+
+class AddDatasetElementTypeResponse(BaseModel):
+    """Response from ``deriva_ml_add_dataset_element_type``.
+
+    v3.0: ``status`` was renamed from ``"success"`` to ``"created"`` --
+    registering an element type IS a creation event (a new association
+    table row).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["created"]
+    table_name: str
+    association_table: str
+```
+
+- [ ] **Step 2: Update `tools/dataset/mutate.py` import**
+
+Add to the existing `from deriva_ml_mcp._response_models import (...)` block:
+`AddDatasetElementTypeResponse, AddDatasetMembersResponse, CreateDatasetResponse, DeleteDatasetMembersResponse, DeleteDatasetResponse, IncrementDatasetVersionResponse, UpdateDatasetResponse`.
+
+- [ ] **Step 3: Refactor `create_dataset` (line 144)**
+
+Replace:
+
+```python
+return json.dumps(
+    {"status": "created", **summary.model_dump(), "execution_rid": execution_rid}
+)
+```
+
+with:
+
+```python
+return CreateDatasetResponse(
+    status="created",
+    **summary.model_dump(),
+    execution_rid=execution_rid,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 4: Refactor `delete_dataset` (lines 210-216)**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "deleted",
+        "dataset_rid": dataset_rid,
+        "recursive": recurse,
+    }
+)
+```
+
+with:
+
+```python
+return DeleteDatasetResponse(
+    status="deleted",
+    dataset_rid=dataset_rid,
+    recursive=recurse,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 5: Refactor `add_dataset_members` (lines 318-325) — STATUS RENAME**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "success",
+        "added_count": added_count,
+        "dataset_rid": dataset_rid,
+        "new_version": new_version,
+    }
+)
+```
+
+with:
+
+```python
+return AddDatasetMembersResponse(
+    status="added",
+    added_count=added_count,
+    dataset_rid=dataset_rid,
+    new_version=new_version,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 6: Refactor `delete_dataset_members` (lines 400-407) — STATUS RENAME**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "success",
+        "removed_count": removed_count,
+        "dataset_rid": dataset_rid,
+        "new_version": new_version,
+    }
+)
+```
+
+with:
+
+```python
+return DeleteDatasetMembersResponse(
+    status="removed",
+    removed_count=removed_count,
+    dataset_rid=dataset_rid,
+    new_version=new_version,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 7: Refactor `update_dataset` (lines 550-560) — CONDITIONAL FIELDS NOW ALWAYS-PRESENT**
+
+Replace:
+
+```python
+payload: dict[str, Any] = {
+    "status": "updated",
+    "dataset_rid": dataset_rid,
+    "updated_fields": updated_fields,
+    "new_version": new_version,
+}
+if "dataset_types" in updated_fields:
+    payload["dataset_types"] = updated_types
+    payload["added"] = adds_requested
+    payload["removed"] = removes_requested
+return json.dumps(payload)
+```
+
+with:
+
+```python
+# v3.0: dataset_types / added / removed are ALWAYS in the response
+# (null when the description-only branch ran). Was conditionally
+# omitted in v2.x.
+if "dataset_types" in updated_fields:
+    response = UpdateDatasetResponse(
+        status="updated",
+        dataset_rid=dataset_rid,
+        updated_fields=updated_fields,
+        new_version=new_version,
+        dataset_types=updated_types,
+        added=adds_requested,
+        removed=removes_requested,
+    )
+else:
+    response = UpdateDatasetResponse(
+        status="updated",
+        dataset_rid=dataset_rid,
+        updated_fields=updated_fields,
+        new_version=new_version,
+    )
+return response.model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 8: Refactor `add_dataset_element_type` (lines 622-628) — STATUS RENAME**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "success",
+        "table_name": table_name,
+        "association_table": association_name,
+    }
+)
+```
+
+with:
+
+```python
+return AddDatasetElementTypeResponse(
+    status="created",
+    table_name=table_name,
+    association_table=association_name,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 9: Refactor `increment_dataset_version` (lines 706-714) — STATUS RENAME**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "success",
+        "dataset_rid": dataset_rid,
+        "previous_version": previous_version,
+        "new_version": new_version_str,
+        "component": component,
+    }
+)
+```
+
+with:
+
+```python
+return IncrementDatasetVersionResponse(
+    status="incremented",
+    dataset_rid=dataset_rid,
+    previous_version=previous_version,
+    new_version=new_version_str,
+    component=component,
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 10: Update test assertions in `tests/test_dataset.py`**
+
+Find tests that assert any of the renamed status values or the conditional-key-omission shape. Search patterns:
+
+```bash
+grep -n '"success"' tests/test_dataset.py
+grep -n 'assert.*not in payload' tests/test_dataset.py
+grep -n '"dataset_types"\|"added"\|"removed"' tests/test_dataset.py
+```
+
+For each match:
+- `assert payload["status"] == "success"` for an add_members call → `assert payload["status"] == "added"`.
+- `assert payload["status"] == "success"` for a delete_members call → `assert payload["status"] == "removed"`.
+- `assert payload["status"] == "success"` for increment_version → `assert payload["status"] == "incremented"`.
+- `assert payload["status"] == "success"` for add_dataset_element_type → `assert payload["status"] == "created"`.
+- `assert "dataset_types" not in payload` for description-only update_dataset → `assert payload["dataset_types"] is None`.
+- Same swap for `"added" not in payload` and `"removed" not in payload` on the description-only branch.
+
+- [ ] **Step 11: Run tests**
+
+```bash
+uv run pytest tests/test_dataset.py -v
+```
+
+Expected: all dataset tests pass.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/deriva_ml_mcp/_response_models.py src/deriva_ml_mcp/tools/dataset/mutate.py tests/test_dataset.py
+git commit -m "feat(v3.0): dataset mutation response models
+
+BREAKING:
+- add_dataset_members: status='success' -> status='added'
+- delete_dataset_members: status='success' -> status='removed'
+- add_dataset_element_type: status='success' -> status='created'
+- increment_dataset_version: status='success' -> status='incremented'
+- update_dataset: dataset_types/added/removed are now always present
+  (null when the description-only branch ran)"
+```
+
+---
+
+### Task 9: Cache + split dataset models — sub-models, refactor 2 wrappers
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/_response_models.py`
+- Modify: `src/deriva_ml_mcp/tools/dataset/complex.py`
+- Test: `tests/test_dataset.py`
+
+- [ ] **Step 1: Add the nested + top-level models**
+
+```python
+class CacheDatasetBagInfo(BaseModel):
+    """Upstream bag-info dict from ``DerivaML.cache_dataset``.
+
+    v3.0: this content is now NESTED under ``CacheDatasetResponse.bag_info``
+    instead of spread top-level. Future DerivaML changes to bag-info
+    can land here without colliding with the v3.0 plugin contract.
+
+    ``extra="allow"`` because we don't own this shape -- DerivaML can
+    add fields. Keys we know about today are typed; unknowns ride along.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    tables: dict[str, int] | None = None
+    total_rows: int | None = None
+    total_asset_bytes: int | None = None
+    total_asset_size: str | None = None
+    cache_status: str | None = None
+    cache_path: str | None = None
+
+
+class CacheDatasetResponse(BaseModel):
+    """Response from ``deriva_ml_cache_dataset``.
+
+    v3.0: bag-info keys are nested under ``bag_info`` (was spread
+    top-level in v2.x). Migration: ``payload["cache_path"]`` -->
+    ``payload["bag_info"]["cache_path"]``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["cached"]
+    dataset_rid: str
+    version: str
+    materialize: bool
+    bag_info: CacheDatasetBagInfo
+
+
+class SplitDatasetPartitionInfo(BaseModel):
+    """One partition in a split (training, testing, or validation)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rid: str | None = None
+    version: str | None = None
+    count: int
+
+
+class SplitDatasetResponse(BaseModel):
+    """Response from ``deriva_ml_split_dataset``.
+
+    v3.0: ``status`` renamed from ``"success"`` to ``"split"``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["split"]
+    source: str
+    split: str
+    training: SplitDatasetPartitionInfo
+    testing: SplitDatasetPartitionInfo
+    validation: SplitDatasetPartitionInfo | None = None
+    strategy: str
+    element_table: str
+    seed: int | None = None
+    dry_run: bool
+```
+
+Note: `validation` is `None` when the split is two-way (just training + testing, no validation set). Always-present-with-`null` per Q2.
+
+- [ ] **Step 2: Update `tools/dataset/complex.py` import**
+
+Add `CacheDatasetBagInfo, CacheDatasetResponse, SplitDatasetPartitionInfo, SplitDatasetResponse` to the import block.
+
+- [ ] **Step 3: Refactor `cache_dataset` (lines 134-143) — STATUS RENAME + BAG_INFO NESTED**
+
+Replace:
+
+```python
+return json.dumps(
+    {
+        "status": "success",
+        "dataset_rid": dataset_rid,
+        "version": used_version,
+        "materialize": materialize,
+        **info,
+    },
+    default=str,
+)
+```
+
+with:
+
+```python
+return CacheDatasetResponse(
+    status="cached",
+    dataset_rid=dataset_rid,
+    version=used_version,
+    materialize=materialize,
+    bag_info=CacheDatasetBagInfo(**info),
+).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 4: Update `cache_dataset` docstring**
+
+Find the `Returns:` block in the `cache_dataset` docstring and replace it to reflect both wire breaks (status rename, bag_info nested):
+
+```
+        Returns:
+            JSON string ``{"status": "cached", "dataset_rid",
+            "version", "materialize", "bag_info": {...upstream
+            DerivaML keys...}}``. v3.0 changes: status renamed from
+            ``"success"`` to ``"cached"``; bag-info keys nested under
+            ``bag_info`` instead of spread top-level.
+```
+
+- [ ] **Step 5: Refactor `split_dataset` (line 524) — STATUS RENAME**
+
+Replace:
+
+```python
+return json.dumps({"status": "success", **payload}, default=str)
+```
+
+with:
+
+```python
+# v3.0: status renamed from "success" to "split". Construct via
+# unpacking from the helper's payload (same fields).
+return SplitDatasetResponse(status="split", **payload).model_dump_json(by_alias=True)
+```
+
+- [ ] **Step 6: Update `split_dataset` docstring**
+
+Find the `Returns:` block and replace `"status": "success"` with `"status": "split"`.
+
+- [ ] **Step 7: Update test assertions in `tests/test_dataset.py`**
+
+```bash
+grep -n 'cache_dataset\|split_dataset' tests/test_dataset.py
+```
+
+For each:
+- `assert payload["status"] == "success"` for cache_dataset → `assert payload["status"] == "cached"`.
+- `assert payload["cache_path"]` for cache_dataset → `assert payload["bag_info"]["cache_path"]`. Same for `tables`, `total_rows`, `total_asset_bytes`, `total_asset_size`, `cache_status`.
+- `assert payload["status"] == "success"` for split_dataset → `assert payload["status"] == "split"`.
+
+- [ ] **Step 8: Run tests**
+
+```bash
+uv run pytest tests/test_dataset.py -v
+```
+
+Expected: all dataset tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/deriva_ml_mcp/_response_models.py src/deriva_ml_mcp/tools/dataset/complex.py tests/test_dataset.py
+git commit -m "feat(v3.0): cache_dataset + split_dataset response models
+
+BREAKING:
+- cache_dataset: status='success' -> status='cached', bag-info keys
+  nested under 'bag_info' field (was spread top-level)
+- split_dataset: status='success' -> status='split'"
+```
+
+---
+
+### Task 10: Verify nothing returns the old status="success" anywhere
+
+**Files:**
+- Touch: nothing (verification only)
+
+- [ ] **Step 1: Grep for any remaining literal `"success"` returns in mutating-tool wrappers**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp
+grep -rn '"status": "success"\|status="success"' src/deriva_ml_mcp/tools/
+```
+
+Expected: NO matches. (If any remain, it's a missed wrapper — fix it before continuing.)
+
+- [ ] **Step 2: Grep for any remaining `"note":` returns in mutating-tool wrappers**
+
+```bash
+grep -rn '"note":' src/deriva_ml_mcp/tools/
+```
+
+Expected: NO matches in the mutating-tool wrapper success paths (the `note` field was the v2.x signal for `start_execution`/`abort_execution` no-ops; v3.0 promoted it to status values).
+
+- [ ] **Step 3: Grep for any remaining `**bag_info` / `**info` spreads in mutating-tool returns**
+
+```bash
+grep -rn '\*\*info\|\*\*bag_info' src/deriva_ml_mcp/tools/
+```
+
+Expected: NO matches in the mutating-tool wrappers. (The v3.0 contract is closed-shape; spreads are gone.)
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+uv run pytest -v
+```
+
+Expected: 287 passed (or whatever the new total is after the test edits in earlier tasks).
+
+- [ ] **Step 5: Run lint + format**
+
+```bash
+uv run ruff check src tests && uv run ruff format --check src tests
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit any cleanup found**
+
+If steps 1-3 found leftover instances, fix them and commit:
+
+```bash
+git add <touched files>
+git commit -m "fix(v3.0): clean up stragglers from response-model sweep"
+```
+
+If nothing was found, no commit is needed.
+
+---
+
+### Task 11: Update CLAUDE.md to document v3.0 shipped
+
+**Files:**
+- Modify: `CLAUDE.md` (the response-models section)
+
+- [ ] **Step 1: Replace the "Future v3.x sweep" block in CLAUDE.md**
+
+Find this block:
+
+```
+Future v3.x sweep:
+
+- v3.0 (PR 3 of #6): mutating-tool response shapes (currently
+  heterogeneous: `{"status": "created", ...}`, `{"status": "deleted",
+  ...}`, partial-result shapes for failures). Their own coherent
+  design pass.
+```
+
+Replace with:
+
+```
+v3.0 swept the mutating-tool response shapes. Every `mutates=True`
+tool now returns a named Pydantic response model with a
+`Literal[...]` `status` discriminator and `extra="forbid"`. The
+discriminator vocabulary was normalized -- the generic `"success"`
+status was retired in favor of operation-specific verbs (`created`,
+`added`, `removed`, `incremented`, `cached`, `split`). Idempotent
+no-ops on `start_execution` / `abort_execution` are now signaled
+via dedicated status values (`already_running` / `already_aborted`)
+instead of an optional `note` field. `update_dataset`'s
+conditional-key fields (`dataset_types`, `added`, `removed`) are
+now always present (`null` when the description-only branch ran).
+`cache_dataset` nests upstream bag-info keys under a `bag_info`
+field instead of spreading them top-level.
+
+v3.0 wire-break migration map for clients:
+
+- `add_dataset_members`: `status="success"` -> `status="added"`.
+- `delete_dataset_members`: `status="success"` -> `status="removed"`.
+- `add_dataset_element_type`: `status="success"` -> `status="created"`.
+- `increment_dataset_version`: `status="success"` -> `status="incremented"`.
+- `cache_dataset`: `status="success"` -> `status="cached"`; bag-info
+  keys moved from top-level to `payload["bag_info"][<key>]`.
+- `split_dataset`: `status="success"` -> `status="split"`.
+- `start_execution` no-op: `{"status": "running", "note": "already running"}`
+  -> `{"status": "already_running"}`.
+- `abort_execution` no-op: `{"status": "aborted", "note": "already aborted"}`
+  -> `{"status": "already_aborted", "reason": null}`.
+- `update_dataset` description-only edit: `dataset_types` / `added` /
+  `removed` keys are present as `null` instead of being omitted.
+- `abort_execution`: `reason` is always present (`null` when no
+  reason was given) instead of being omitted on the no-op branch.
+
+This closes PR 3 of #6. The response-shape Pydantic migration is
+complete -- every `_*_impl` helper, every list/detail/summary
+shape, and every mutating-tool response is now Pydantic-typed.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(v3.0): mark mutating-tool response sweep shipped"
+```
+
+---
+
+### Task 12: Open PR, merge, release v3.0.0
+
+**Files:**
+- Touch: nothing in the repo (release ops only)
+
+- [ ] **Step 1: Push branch**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp
+git push -u origin feature/v3.0-mutating-tool-response-models
+```
+
+- [ ] **Step 2: Open PR with the v3.0 changelog**
+
+```bash
+gh pr create --title "v3.0.0: Mutating-tool response models + vocabulary normalization" --body "$(cat <<'EOF'
+## Summary
+
+Closes PR 3 of #6 -- the response-shape Pydantic migration. Every
+`mutates=True` tool now returns a named Pydantic response model with
+a `Literal[...]` `status` discriminator. The discriminator vocabulary
+is normalized.
+
+## Wire breaks (read carefully -- this is a major bump)
+
+### Status renames (6 tools)
+- `add_dataset_members`: `success` -> `added`
+- `delete_dataset_members`: `success` -> `removed`
+- `add_dataset_element_type`: `success` -> `created`
+- `increment_dataset_version`: `success` -> `incremented`
+- `cache_dataset`: `success` -> `cached`
+- `split_dataset`: `success` -> `split`
+
+### Idempotent-no-op signal moved into `status` (2 tools)
+- `start_execution`: `{"status": "running", ..., "note": "already running"}`
+  -> `{"status": "already_running", ...}`
+- `abort_execution`: `{"status": "aborted", ..., "note": "already aborted"}`
+  -> `{"status": "already_aborted", ..., "reason": null}`
+
+### Conditional fields now always present (`null` when N/A)
+- `update_dataset`: `dataset_types` / `added` / `removed` are
+  always present in the response (was conditionally omitted in
+  v2.x for description-only edits).
+- `abort_execution`: `reason` is always present (was conditionally
+  omitted on the no-op branch).
+
+### Nested upstream payload (1 tool)
+- `cache_dataset`: bag-info keys (`tables`, `total_rows`,
+  `total_asset_bytes`, `total_asset_size`, `cache_status`,
+  `cache_path`) now nested under `payload["bag_info"]` instead of
+  spread top-level.
+
+## Test plan
+- [x] All 287+ tests pass (test files updated for breaking changes)
+- [x] `uv run ruff check src tests` clean
+- [x] `uv run ruff format --check src tests` clean
+- [x] No stragglers: `grep '"status": "success"' src/` returns empty
+- [x] CLAUDE.md updated with the migration map for clients
+- [ ] Manual smoke test against a live catalog (post-merge)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Merge PR**
+
+```bash
+gh pr merge --merge --delete-branch
+```
+
+- [ ] **Step 4: Release v3.0.0**
+
+```bash
+git checkout main && git pull
+uv run bump-version major
+```
+
+Expected output (final lines):
+
+```
+New version tag: v3.0.0
+Release process complete!
+```
+
+- [ ] **Step 5: Verify the release tag landed**
+
+```bash
+git log --oneline -3
+git tag --sort=-version:refname | head -3
+```
+
+Expected: top tag is `v3.0.0`; top commit is the version bump.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Q1 (status normalization): Tasks 8 + 9 cover the 6 renames; Task 10 step 1 verifies completeness.
+- Q2 (always-present optional fields): Task 6 step 9-10 (`abort_execution.reason`), Task 8 step 7 (`update_dataset.dataset_types/added/removed`), Task 9 step 1 (`SplitDatasetResponse.validation`).
+- Q3 (no-op promotion): Task 6 steps 4 + 9 (start/abort no-op branches use `already_*` status).
+- Q4 (`bag_info` nested): Task 9 steps 1 + 3 (`CacheDatasetResponse.bag_info: CacheDatasetBagInfo`).
+- Q5 (one model per tool + 1 mixin): 25 models defined across Tasks 2/3/4/6/8/9, with `_DatasetVersionBumpMixin` in Task 7 used by 3 tools.
+
+**2. Placeholder scan:** No "TBD", "implement later", "etc." that hides real work. Test-update steps (Task 6 step 14, Task 8 step 10, Task 9 step 7) name exact `grep` patterns and exact assertion swaps.
+
+**3. Type consistency:**
+- `CommitExecutionReport` declared in Task 5 step 1, consumed in Task 6 step 7 — same name, same fields.
+- `_DatasetVersionBumpMixin` declared in Task 7, consumed in Task 8 (3 uses) — same name.
+- `CacheDatasetBagInfo` declared in Task 9 step 1, consumed in Task 9 step 3 — same name.
+- All status `Literal[...]` values declared in models match the strings passed at construction sites.
+
+One real gap I caught during review: the `commit_execution` helper `_summarize_upload_dict` has a key set the model needs to mirror exactly. Task 5 step 2 explicitly tells the implementer to verify the key set and update the model if it differs. Listed as part of Task 5 (no separate task added).
+
+---
+
+## Execution choice
+
+After running this plan, the v3.0 milestone closes #6 (the response-shape
+Pydantic migration). The next backlog item (#7 — upstream tracking) is
+unrelated and waits on `deriva-mcp-core#2`.

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -823,3 +823,29 @@ class AddFeatureValuesResponse(BaseModel):
     feature_name: str
     execution_rid: str
     count: int
+
+
+class CommitExecutionReport(BaseModel):
+    """Per-call upload report nested inside ``CommitExecutionResponse``.
+
+    Mirrors the dict produced by ``_summarize_upload_dict`` in
+    ``tools/execution.py`` (which is internal -- consumers see only
+    the Pydantic shape on the wire).
+
+    ``per_table`` maps each asset table name to the count of files
+    uploaded for that table on this commit. ``execution_rids`` is a
+    one-element list (the execution being committed); the list shape
+    is preserved for forward-compat with multi-execution uploads.
+    ``errors`` is capped at the top 10 lines by the helper -- the
+    full list stays in the server logs. ``errors_truncated`` signals
+    that the cap was hit.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    execution_rids: list[str]
+    total_uploaded: int
+    total_failed: int
+    per_table: dict[str, int]
+    errors: list[str]
+    errors_truncated: bool

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -757,3 +757,31 @@ class UpdateAssetResponse(BaseModel):
     status: Literal["updated"]
     asset_rid: str
     updated_fields: list[str]
+
+
+class CreateWorkflowResponse(BaseModel):
+    """Response from ``deriva_ml_create_workflow``.
+
+    ``status="created"`` for new workflows, ``status="exists"`` for the
+    idempotent dedup branch (URL or checksum already registered).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["created", "exists"]
+    workflow_rid: str
+    name: str
+    workflow_type: list[str]
+    url: str
+    checksum: str | None = None
+    version: str | None = None
+
+
+class UpdateWorkflowResponse(BaseModel):
+    """Response from ``deriva_ml_update_workflow``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["updated"]
+    workflow_rid: str
+    updated_fields: list[str]

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -849,3 +849,91 @@ class CommitExecutionReport(BaseModel):
     per_table: dict[str, int]
     errors: list[str]
     errors_truncated: bool
+
+
+class CreateExecutionResponse(BaseModel):
+    """Response from ``deriva_ml_create_execution``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["created"]
+    execution_rid: str
+    workflow_rid: str
+    dataset_count: int
+    asset_count: int
+    dry_run: bool
+
+
+class StartExecutionResponse(BaseModel):
+    """Response from ``deriva_ml_start_execution``.
+
+    ``status="running"`` on a real start, ``status="already_running"``
+    on the idempotent no-op when the execution was already in Running
+    state. v3.0: replaced the optional ``note`` field with a
+    discriminator status value.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["running", "already_running"]
+    execution_rid: str
+
+
+class CommitExecutionResponse(BaseModel):
+    """Response from ``deriva_ml_commit_execution``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["uploaded"]
+    execution_rid: str
+    report: CommitExecutionReport
+
+
+class UpdateExecutionResponse(BaseModel):
+    """Response from ``deriva_ml_update_execution``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["updated"]
+    execution_rid: str
+    updated_fields: list[str]
+
+
+class AbortExecutionResponse(BaseModel):
+    """Response from ``deriva_ml_abort_execution``.
+
+    ``status="aborted"`` on a real abort, ``status="already_aborted"``
+    on the idempotent no-op. v3.0: replaced the optional ``note``
+    field with a discriminator status value. ``reason`` is always
+    present (``null`` when no reason was given OR when the call was a
+    no-op).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["aborted", "already_aborted"]
+    execution_rid: str
+    reason: str | None = None
+
+
+class CreateExecutionDatasetResponse(BaseModel):
+    """Response from ``deriva_ml_create_execution_dataset``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["created"]
+    dataset_rid: str
+    execution_rid: str
+    dataset_types: list[str]
+    description: str
+
+
+class AddNestedExecutionResponse(BaseModel):
+    """Response from ``deriva_ml_add_nested_execution``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["added"]
+    parent_rid: str
+    child_rid: str
+    sequence: int

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -723,3 +723,26 @@ class ErrorEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     error: str
+
+
+# ---------------------------------------------------------------------------
+# Mutating-tool response models (v3.0)
+#
+# Every ``mutates=True`` tool's success-path response is a Pydantic model
+# in this section. Each model has a ``Literal[...]`` ``status`` field that
+# acts as the discriminator -- consumers can ``match payload["status"]:``
+# without checking which tool produced the response.
+#
+# v3.0 wire-break notes (see ``CLAUDE.md`` for full migration guide):
+#
+# 1. Six tools' ``status`` values were renamed away from the generic
+#    ``"success"`` to operation-specific verbs (``created``, ``added``,
+#    ``removed``, ``incremented``, ``cached``, ``split``).
+# 2. ``start_execution`` and ``abort_execution`` no-op branches now emit
+#    ``status="already_running"`` / ``status="already_aborted"`` instead
+#    of carrying an optional ``note`` string.
+# 3. Conditional-key fields on ``update_dataset`` are now always present
+#    (``null`` when not meaningful) instead of being omitted.
+# 4. ``cache_dataset`` nests upstream bag-info keys under a ``bag_info``
+#    field instead of spreading them top-level.
+# ---------------------------------------------------------------------------

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -937,3 +937,51 @@ class AddNestedExecutionResponse(BaseModel):
     parent_rid: str
     child_rid: str
     sequence: int
+
+
+class _DatasetVersionBumpMixin(BaseModel):
+    """Common fields for tools that bump a dataset's version.
+
+    Three tools share this shape: ``add_dataset_members``,
+    ``delete_dataset_members``, and ``increment_dataset_version``.
+    They all return the dataset RID and the post-bump version
+    string. Subclasses add the ``status`` discriminator and any
+    tool-specific delta fields (e.g. ``added_count``).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_rid: str
+    new_version: str
+
+
+class AddDatasetMembersResponse(_DatasetVersionBumpMixin):
+    """Response from ``deriva_ml_add_dataset_members``.
+
+    v3.0: ``status`` was renamed from ``"success"`` to ``"added"`` to
+    match the v3.0 status vocabulary (operation-specific verbs).
+    """
+
+    status: Literal["added"]
+    added_count: int
+
+
+class DeleteDatasetMembersResponse(_DatasetVersionBumpMixin):
+    """Response from ``deriva_ml_delete_dataset_members``.
+
+    v3.0: ``status`` was renamed from ``"success"`` to ``"removed"``.
+    """
+
+    status: Literal["removed"]
+    removed_count: int
+
+
+class IncrementDatasetVersionResponse(_DatasetVersionBumpMixin):
+    """Response from ``deriva_ml_increment_dataset_version``.
+
+    v3.0: ``status`` was renamed from ``"success"`` to ``"incremented"``.
+    """
+
+    status: Literal["incremented"]
+    previous_version: str
+    component: str

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -924,7 +924,7 @@ class CreateExecutionDatasetResponse(BaseModel):
     status: Literal["created"]
     dataset_rid: str
     execution_rid: str
-    dataset_types: list[str]
+    dataset_types: list[str] | None = None
     description: str
 
 

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -104,6 +104,7 @@ The list of deriva-ml models we'd consider embedding in PR 2:
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -746,3 +747,13 @@ class ErrorEnvelope(BaseModel):
 # 4. ``cache_dataset`` nests upstream bag-info keys under a ``bag_info``
 #    field instead of spreading them top-level.
 # ---------------------------------------------------------------------------
+
+
+class UpdateAssetResponse(BaseModel):
+    """Response from ``deriva_ml_update_asset``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["updated"]
+    asset_rid: str
+    updated_fields: list[str]

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -785,3 +785,41 @@ class UpdateWorkflowResponse(BaseModel):
     status: Literal["updated"]
     workflow_rid: str
     updated_fields: list[str]
+
+
+class CreateFeatureResponse(FeatureSummary):
+    """Response from ``deriva_ml_create_feature``.
+
+    Wraps ``FeatureSummary`` (which the wrapper already builds) and
+    adds the ``status`` discriminator. Pydantic inherits
+    ``model_config`` from the parent so ``extra="forbid"`` is in
+    effect; the discriminator is added on top.
+    """
+
+    status: Literal["created"]
+
+
+class DeleteFeatureResponse(BaseModel):
+    """Response from ``deriva_ml_delete_feature``.
+
+    ``status="deleted"`` when the feature was removed,
+    ``status="not_found"`` on the idempotent no-op when the feature
+    didn't exist.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["deleted", "not_found"]
+    feature_name: str
+    table: str
+
+
+class AddFeatureValuesResponse(BaseModel):
+    """Response from ``deriva_ml_add_feature_values``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["added"]
+    feature_name: str
+    execution_rid: str
+    count: int

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -985,3 +985,61 @@ class IncrementDatasetVersionResponse(_DatasetVersionBumpMixin):
     status: Literal["incremented"]
     previous_version: str
     component: str
+
+
+class CreateDatasetResponse(DatasetSummary):
+    """Response from ``deriva_ml_create_dataset``.
+
+    Extends ``DatasetSummary`` with the v3.0 status discriminator and
+    the linking ``execution_rid``. ``model_config`` inherits from
+    ``DatasetSummary`` so ``extra="forbid"`` is in effect; the new
+    fields are added on top.
+    """
+
+    status: Literal["created"]
+    execution_rid: str
+
+
+class DeleteDatasetResponse(BaseModel):
+    """Response from ``deriva_ml_delete_dataset``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["deleted"]
+    dataset_rid: str
+    recursive: bool
+
+
+class UpdateDatasetResponse(BaseModel):
+    """Response from ``deriva_ml_update_dataset``.
+
+    v3.0: the ``dataset_types``, ``added``, and ``removed`` fields
+    are now ALWAYS present in the response (``null`` when the
+    description-only branch ran). v2.x omitted these keys when the
+    description-only branch ran.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["updated"]
+    dataset_rid: str
+    updated_fields: list[str]
+    new_version: str
+    dataset_types: list[str] | None = None
+    added: list[str] | None = None
+    removed: list[str] | None = None
+
+
+class AddDatasetElementTypeResponse(BaseModel):
+    """Response from ``deriva_ml_add_dataset_element_type``.
+
+    v3.0: ``status`` was renamed from ``"success"`` to ``"created"``
+    -- registering an element type IS a creation event (a new
+    association table row).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["created"]
+    table_name: str
+    association_table: str

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -104,7 +104,7 @@ The list of deriva-ml models we'd consider embedding in PR 2:
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -1043,3 +1043,83 @@ class AddDatasetElementTypeResponse(BaseModel):
     status: Literal["created"]
     table_name: str
     association_table: str
+
+
+class CacheDatasetBagInfo(BaseModel):
+    """Upstream bag-info dict from ``DerivaML.cache_dataset``.
+
+    v3.0: this content is now NESTED under ``CacheDatasetResponse.bag_info``
+    instead of spread top-level. Future DerivaML changes to bag-info
+    can land here without colliding with the v3.0 plugin contract.
+
+    ``extra="allow"`` because we don't own this shape -- DerivaML can
+    add fields. Keys we know about today are typed; unknowns ride
+    along. ``tables`` maps each table name to a per-table descriptor
+    (``{row_count, is_asset, asset_bytes, ...}``) -- the inner dict's
+    schema is upstream's, so it's typed loosely as ``dict[str, Any]``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    tables: dict[str, dict[str, Any]] | None = None
+    total_rows: int | None = None
+    total_asset_bytes: int | None = None
+    total_asset_size: str | None = None
+    cache_status: str | None = None
+    cache_path: str | None = None
+
+
+class CacheDatasetResponse(BaseModel):
+    """Response from ``deriva_ml_cache_dataset``.
+
+    v3.0: bag-info keys are nested under ``bag_info`` (was spread
+    top-level in v2.x). Migration: ``payload["cache_path"]`` -->
+    ``payload["bag_info"]["cache_path"]``. Status renamed from
+    ``"success"`` to ``"cached"``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["cached"]
+    dataset_rid: str
+    version: str
+    materialize: bool
+    bag_info: CacheDatasetBagInfo
+
+
+class SplitDatasetPartitionInfo(BaseModel):
+    """One partition in a split (training, testing, or validation).
+
+    Mirrors upstream ``deriva_ml.dataset.split.PartitionInfo``. We
+    redeclare locally rather than import to keep the v3.0 wire
+    contract independent of upstream model drift.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    rid: str
+    version: str
+    count: int
+
+
+class SplitDatasetResponse(BaseModel):
+    """Response from ``deriva_ml_split_dataset``.
+
+    v3.0: ``status`` renamed from ``"success"`` to ``"split"``. All
+    other fields mirror upstream ``deriva_ml.dataset.split.SplitResult``.
+    ``validation`` is ``null`` for two-way splits (training + testing
+    only).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["split"]
+    source: str
+    split: SplitDatasetPartitionInfo
+    training: SplitDatasetPartitionInfo
+    testing: SplitDatasetPartitionInfo
+    validation: SplitDatasetPartitionInfo | None = None
+    strategy: str
+    element_table: str
+    seed: int
+    dry_run: bool

--- a/src/deriva_ml_mcp/tools/asset.py
+++ b/src/deriva_ml_mcp/tools/asset.py
@@ -74,6 +74,7 @@ from deriva_ml_mcp._response_models import (
     AssetTableRef,
     AssetTablesResponse,
     PreflightCountResponse,
+    UpdateAssetResponse,
 )
 from deriva_ml_mcp.ml_context import get_ml
 
@@ -500,13 +501,11 @@ def register(ctx: PluginContext) -> None:
                 added=added_done,
                 removed=removed_done,
             )
-            return json.dumps(
-                {
-                    "status": "updated",
-                    "asset_rid": asset_rid,
-                    "updated_fields": updated_fields,
-                }
-            )
+            return UpdateAssetResponse(
+                status="updated",
+                asset_rid=asset_rid,
+                updated_fields=updated_fields,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,

--- a/src/deriva_ml_mcp/tools/dataset/complex.py
+++ b/src/deriva_ml_mcp/tools/dataset/complex.py
@@ -45,7 +45,12 @@ from deriva_ml_mcp._helpers import (
     _paginate,
     _row_rid_for,
 )
-from deriva_ml_mcp._response_models import PreflightCountResponse
+from deriva_ml_mcp._response_models import (
+    CacheDatasetBagInfo,
+    CacheDatasetResponse,
+    PreflightCountResponse,
+    SplitDatasetResponse,
+)
 
 if TYPE_CHECKING:
     from deriva_mcp_core.plugin.api import PluginContext
@@ -92,19 +97,20 @@ def register(ctx: PluginContext) -> None:
                 tables you don't need).
 
         Returns:
-            JSON string ``{"status": "success", "dataset_rid", "version",
-            "materialize", "tables", "total_rows", "total_asset_bytes",
-            "total_asset_size", "cache_status", "cache_path"}``. Pass-through
-            of DerivaML's bag_info-shaped return.
+            JSON string ``{"status": "cached", "dataset_rid",
+            "version", "materialize", "bag_info": {...upstream
+            DerivaML keys...}}``. v3.0 changes: status renamed from
+            ``"success"`` to ``"cached"``; bag-info keys nested under
+            ``bag_info`` instead of spread top-level.
 
         Raises:
             RuntimeError: Wrapped, propagated from
                 ``deriva_ml.DerivaML.cache_dataset``.
 
         Example:
-            ``{"status": "success", "dataset_rid": "1-AAAA", "version":
-            "1.0.0", "materialize": true, "cache_status":
-            "cached_materialized", "cache_path": "/path/to/bag", ...}``.
+            ``{"status": "cached", "dataset_rid": "1-AAAA", "version":
+            "1.0.0", "materialize": true, "bag_info": {"cache_status":
+            "cached_materialized", "cache_path": "/path/to/bag", ...}}``.
         """
         try:
             with deriva_call():
@@ -131,16 +137,13 @@ def register(ctx: PluginContext) -> None:
                 materialize=materialize,
                 exclude_tables=exclude_tables or [],
             )
-            return json.dumps(
-                {
-                    "status": "success",
-                    "dataset_rid": dataset_rid,
-                    "version": used_version,
-                    "materialize": materialize,
-                    **info,
-                },
-                default=str,
-            )
+            return CacheDatasetResponse(
+                status="cached",
+                dataset_rid=dataset_rid,
+                version=used_version,
+                materialize=materialize,
+                bag_info=CacheDatasetBagInfo(**info),
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -433,7 +436,7 @@ def register(ctx: PluginContext) -> None:
                 partition sizes before committing.
 
         Returns:
-            JSON string ``{"status": "success", "source", "split", "training",
+            JSON string ``{"status": "split", "source", "split", "training",
             "testing", "validation", "strategy", "element_table", "seed",
             "dry_run"}``. Each partition is ``{"rid", "version", "count"}``.
             ``validation`` is null for two-way splits.
@@ -444,7 +447,7 @@ def register(ctx: PluginContext) -> None:
                 strategy, stratify column missing).
 
         Example:
-            ``{"status": "success", "source": "1-AAAA", "split": {"rid":
+            ``{"status": "split", "source": "1-AAAA", "split": {"rid":
             "1-SPLT", "version": "1.0.0", "count": 100}, "training":
             {"rid": "1-TRN", "version": "1.0.0", "count": 80}, "testing":
             {"rid": "1-TST", "version": "1.0.0", "count": 20},
@@ -521,7 +524,9 @@ def register(ctx: PluginContext) -> None:
                             rid,
                             source_dataset_rid,
                         )
-            return json.dumps({"status": "success", **payload}, default=str)
+            # v3.0: status renamed from "success" to "split". Construct
+            # via unpacking from the helper's payload (same fields).
+            return SplitDatasetResponse(status="split", **payload).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,

--- a/src/deriva_ml_mcp/tools/dataset/mutate.py
+++ b/src/deriva_ml_mcp/tools/dataset/mutate.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 from deriva_mcp_core import deriva_call
 from deriva_ml.dataset.aux_classes import DatasetVersion, VersionPart
@@ -49,6 +49,15 @@ logger = logging.getLogger(__name__)
 # canonical factory) for the dual-patch context manager.
 import deriva_ml_mcp.tools.dataset as _pkg  # noqa: E402  (intentional cycle)
 from deriva_ml_mcp._helpers import _error_envelope, _set_row_description
+from deriva_ml_mcp._response_models import (
+    AddDatasetElementTypeResponse,
+    AddDatasetMembersResponse,
+    CreateDatasetResponse,
+    DeleteDatasetMembersResponse,
+    DeleteDatasetResponse,
+    IncrementDatasetVersionResponse,
+    UpdateDatasetResponse,
+)
 from deriva_ml_mcp.tools.dataset.read import _summarize_dataset
 
 if TYPE_CHECKING:
@@ -140,9 +149,11 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for dataset %s after create_dataset",
                     new_ds.dataset_rid,
                 )
-            return json.dumps(
-                {"status": "created", **summary.model_dump(), "execution_rid": execution_rid}
-            )
+            return CreateDatasetResponse(
+                status="created",
+                **summary.model_dump(),
+                execution_rid=execution_rid,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -207,13 +218,11 @@ def register(ctx: PluginContext) -> None:
                     "re-index drop failed for dataset %s after delete_dataset",
                     dataset_rid,
                 )
-            return json.dumps(
-                {
-                    "status": "deleted",
-                    "dataset_rid": dataset_rid,
-                    "recursive": recurse,
-                }
-            )
+            return DeleteDatasetResponse(
+                status="deleted",
+                dataset_rid=dataset_rid,
+                recursive=recurse,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -315,14 +324,12 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for dataset %s after add_dataset_members",
                     dataset_rid,
                 )
-            return json.dumps(
-                {
-                    "status": "success",
-                    "added_count": added_count,
-                    "dataset_rid": dataset_rid,
-                    "new_version": new_version,
-                }
-            )
+            return AddDatasetMembersResponse(
+                status="added",
+                added_count=added_count,
+                dataset_rid=dataset_rid,
+                new_version=new_version,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -397,14 +404,12 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for dataset %s after delete_dataset_members",
                     dataset_rid,
                 )
-            return json.dumps(
-                {
-                    "status": "success",
-                    "removed_count": removed_count,
-                    "dataset_rid": dataset_rid,
-                    "new_version": new_version,
-                }
-            )
+            return DeleteDatasetMembersResponse(
+                status="removed",
+                removed_count=removed_count,
+                dataset_rid=dataset_rid,
+                new_version=new_version,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -547,17 +552,27 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for dataset %s after update_dataset",
                     dataset_rid,
                 )
-            payload: dict[str, Any] = {
-                "status": "updated",
-                "dataset_rid": dataset_rid,
-                "updated_fields": updated_fields,
-                "new_version": new_version,
-            }
+            # v3.0: dataset_types / added / removed are ALWAYS in the response
+            # (null when the description-only branch ran). Was conditionally
+            # omitted in v2.x.
             if "dataset_types" in updated_fields:
-                payload["dataset_types"] = updated_types
-                payload["added"] = adds_requested
-                payload["removed"] = removes_requested
-            return json.dumps(payload)
+                response = UpdateDatasetResponse(
+                    status="updated",
+                    dataset_rid=dataset_rid,
+                    updated_fields=updated_fields,
+                    new_version=new_version,
+                    dataset_types=updated_types,
+                    added=adds_requested,
+                    removed=removes_requested,
+                )
+            else:
+                response = UpdateDatasetResponse(
+                    status="updated",
+                    dataset_rid=dataset_rid,
+                    updated_fields=updated_fields,
+                    new_version=new_version,
+                )
+            return response.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -619,13 +634,11 @@ def register(ctx: PluginContext) -> None:
                 table_name=table_name,
                 association_table=association_name,
             )
-            return json.dumps(
-                {
-                    "status": "success",
-                    "table_name": table_name,
-                    "association_table": association_name,
-                }
-            )
+            return AddDatasetElementTypeResponse(
+                status="created",
+                table_name=table_name,
+                association_table=association_name,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -703,15 +716,13 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for dataset %s after increment_dataset_version",
                     dataset_rid,
                 )
-            return json.dumps(
-                {
-                    "status": "success",
-                    "dataset_rid": dataset_rid,
-                    "previous_version": previous_version,
-                    "new_version": new_version_str,
-                    "component": component,
-                }
-            )
+            return IncrementDatasetVersionResponse(
+                status="incremented",
+                dataset_rid=dataset_rid,
+                previous_version=previous_version,
+                new_version=new_version_str,
+                component=component,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,

--- a/src/deriva_ml_mcp/tools/dataset/mutate.py
+++ b/src/deriva_ml_mcp/tools/dataset/mutate.py
@@ -263,7 +263,7 @@ def register(ctx: PluginContext) -> None:
             execution_rid: Optional execution to attribute the change to.
 
         Returns:
-            JSON string ``{"status": "success", "added_count",
+            JSON string ``{"status": "added", "added_count",
             "dataset_rid", "new_version"}``.
 
         Raises:
@@ -275,7 +275,7 @@ def register(ctx: PluginContext) -> None:
                 cycle, duplicate members).
 
         Example:
-            ``{"status": "success", "added_count": 3, "dataset_rid":
+            ``{"status": "added", "added_count": 3, "dataset_rid":
             "1-AAAA", "new_version": "1.2.0"}``.
         """
         has_list = bool(member_rids)
@@ -363,7 +363,7 @@ def register(ctx: PluginContext) -> None:
             execution_rid: Optional execution to attribute the change to.
 
         Returns:
-            JSON string ``{"status": "success", "removed_count",
+            JSON string ``{"status": "removed", "removed_count",
             "dataset_rid", "new_version"}``.
 
         Raises:
@@ -372,7 +372,7 @@ def register(ctx: PluginContext) -> None:
                 (e.g. RID not part of dataset).
 
         Example:
-            ``{"status": "success", "removed_count": 2, "dataset_rid":
+            ``{"status": "removed", "removed_count": 2, "dataset_rid":
             "1-AAAA", "new_version": "1.3.0"}``.
         """
         removed_count = len(member_rids)
@@ -610,7 +610,7 @@ def register(ctx: PluginContext) -> None:
             table_name: Name of the domain table to register.
 
         Returns:
-            JSON string ``{"status": "success", "table_name",
+            JSON string ``{"status": "created", "table_name",
             "association_table"}``.
 
         Raises:
@@ -619,7 +619,7 @@ def register(ctx: PluginContext) -> None:
                 unknown table, table is system/ML and not eligible).
 
         Example:
-            ``{"status": "success", "table_name": "Image",
+            ``{"status": "created", "table_name": "Image",
             "association_table": "Dataset_Image"}``.
         """
         try:
@@ -671,7 +671,7 @@ def register(ctx: PluginContext) -> None:
             execution_rid: Optional execution to attribute the bump to.
 
         Returns:
-            JSON string ``{"status": "success", "dataset_rid",
+            JSON string ``{"status": "incremented", "dataset_rid",
             "previous_version", "new_version", "component"}``.
 
         Raises:
@@ -679,7 +679,7 @@ def register(ctx: PluginContext) -> None:
                 ``deriva_ml.dataset.dataset.Dataset.increment_dataset_version``.
 
         Example:
-            ``{"status": "success", "dataset_rid": "1-AAAA",
+            ``{"status": "incremented", "dataset_rid": "1-AAAA",
             "previous_version": "1.2.0", "new_version": "1.3.0",
             "component": "minor"}``.
         """

--- a/src/deriva_ml_mcp/tools/execution.py
+++ b/src/deriva_ml_mcp/tools/execution.py
@@ -1252,7 +1252,7 @@ def register(ctx: PluginContext) -> None:
                 status="created",
                 dataset_rid=dataset_rid,
                 execution_rid=execution_rid,
-                dataset_types=types_list or [],
+                dataset_types=types_list,
                 description=description,
             ).model_dump_json(by_alias=True)
         except Exception as exc:

--- a/src/deriva_ml_mcp/tools/execution.py
+++ b/src/deriva_ml_mcp/tools/execution.py
@@ -45,6 +45,12 @@ from deriva_ml_mcp._helpers import (
     _read_rid,
 )
 from deriva_ml_mcp._response_models import (
+    AbortExecutionResponse,
+    AddNestedExecutionResponse,
+    CommitExecutionReport,
+    CommitExecutionResponse,
+    CreateExecutionDatasetResponse,
+    CreateExecutionResponse,
     ExecutionAssetRef,
     ExecutionChildrenResponse,
     ExecutionDetail,
@@ -56,6 +62,8 @@ from deriva_ml_mcp._response_models import (
     ExecutionParentsResponse,
     ExecutionSummary,
     PreflightCountResponse,
+    StartExecutionResponse,
+    UpdateExecutionResponse,
 )
 from deriva_ml_mcp.ml_context import get_ml
 
@@ -761,16 +769,14 @@ def register(ctx: PluginContext) -> None:
                         "re-index failed for execution %s after create_execution",
                         execution_rid,
                     )
-            return json.dumps(
-                {
-                    "status": "created",
-                    "execution_rid": execution_rid,
-                    "workflow_rid": workflow_rid,
-                    "dataset_count": len(ds_list),
-                    "asset_count": len(as_list),
-                    "dry_run": dry_run,
-                }
-            )
+            return CreateExecutionResponse(
+                status="created",
+                execution_rid=execution_rid,
+                workflow_rid=workflow_rid,
+                dataset_count=len(ds_list),
+                asset_count=len(as_list),
+                dry_run=dry_run,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -801,8 +807,9 @@ def register(ctx: PluginContext) -> None:
 
         Returns:
             JSON string ``{"status": "running", "execution_rid"}`` on
-            transition. ``{"status": "running", "execution_rid", "note":
-            "already running"}`` on idempotent no-op.
+            transition. ``{"status": "already_running", "execution_rid"}``
+            on idempotent no-op (v3.0 -- replaced the optional ``note``
+            field with a discriminator status value).
             ``{"error": "cannot start execution in state ..."}`` on
             terminal state.
 
@@ -821,14 +828,13 @@ def register(ctx: PluginContext) -> None:
                 current = execution.status
 
                 if current == ExecutionStatus.Running:
-                    # Idempotent no-op. No audit.
-                    return json.dumps(
-                        {
-                            "status": "running",
-                            "execution_rid": execution_rid,
-                            "note": "already running",
-                        }
-                    )
+                    # Idempotent no-op. No audit. v3.0: status discriminator
+                    # carries the no-op signal (was an optional ``note``
+                    # field in v2.x).
+                    return StartExecutionResponse(
+                        status="already_running",
+                        execution_rid=execution_rid,
+                    ).model_dump_json(by_alias=True)
                 if current in _START_REJECT_STATES:
                     state_name = current.value if isinstance(current, ExecutionStatus) else current
                     return json.dumps(
@@ -858,12 +864,10 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for execution %s after start_execution",
                     execution_rid,
                 )
-            return json.dumps(
-                {
-                    "status": "running",
-                    "execution_rid": execution_rid,
-                }
-            )
+            return StartExecutionResponse(
+                status="running",
+                execution_rid=execution_rid,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -976,14 +980,11 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for execution %s after commit_execution",
                     execution_rid,
                 )
-            return json.dumps(
-                {
-                    "status": "uploaded",
-                    "execution_rid": execution_rid,
-                    "report": summary,
-                },
-                default=str,
-            )
+            return CommitExecutionResponse(
+                status="uploaded",
+                execution_rid=execution_rid,
+                report=CommitExecutionReport(**summary),
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -1071,13 +1072,11 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for execution %s after update_execution",
                     execution_rid,
                 )
-            return json.dumps(
-                {
-                    "status": "updated",
-                    "execution_rid": execution_rid,
-                    "updated_fields": updated_fields,
-                }
-            )
+            return UpdateExecutionResponse(
+                status="updated",
+                execution_rid=execution_rid,
+                updated_fields=updated_fields,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -1107,8 +1106,11 @@ def register(ctx: PluginContext) -> None:
 
         Returns:
             JSON string ``{"status": "aborted", "execution_rid",
-            "reason"}``. ``{"status": "aborted", "execution_rid",
-            "note": "already aborted"}`` on idempotent no-op.
+            "reason"}``. ``{"status": "already_aborted", "execution_rid",
+            "reason": null}`` on idempotent no-op (v3.0 -- replaced the
+            optional ``note`` field with a discriminator status value).
+            ``reason`` is always present; ``null`` when no reason was
+            given.
 
         Raises:
             RuntimeError: Wrapped, propagated from
@@ -1126,13 +1128,15 @@ def register(ctx: PluginContext) -> None:
                 current = execution.status
 
                 if current == ExecutionStatus.Aborted:
-                    return json.dumps(
-                        {
-                            "status": "aborted",
-                            "execution_rid": execution_rid,
-                            "note": "already aborted",
-                        }
-                    )
+                    # v3.0: status discriminator carries the no-op signal
+                    # (was an optional ``note`` field in v2.x). ``reason``
+                    # is None here -- we didn't actually record an abort
+                    # reason this call.
+                    return AbortExecutionResponse(
+                        status="already_aborted",
+                        execution_rid=execution_rid,
+                        reason=None,
+                    ).model_dump_json(by_alias=True)
 
                 execution.abort()
 
@@ -1153,13 +1157,11 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for execution %s after abort_execution",
                     execution_rid,
                 )
-            return json.dumps(
-                {
-                    "status": "aborted",
-                    "execution_rid": execution_rid,
-                    "reason": reason,
-                }
-            )
+            return AbortExecutionResponse(
+                status="aborted",
+                execution_rid=execution_rid,
+                reason=reason,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -1246,15 +1248,13 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for execution %s after create_execution_dataset",
                     execution_rid,
                 )
-            return json.dumps(
-                {
-                    "status": "created",
-                    "dataset_rid": dataset_rid,
-                    "execution_rid": execution_rid,
-                    "dataset_types": types_list,
-                    "description": description,
-                }
-            )
+            return CreateExecutionDatasetResponse(
+                status="created",
+                dataset_rid=dataset_rid,
+                execution_rid=execution_rid,
+                dataset_types=types_list or [],
+                description=description,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -1321,14 +1321,12 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for parent execution %s after add_nested_execution",
                     parent_execution_rid,
                 )
-            return json.dumps(
-                {
-                    "status": "added",
-                    "parent_rid": parent_execution_rid,
-                    "child_rid": child_execution_rid,
-                    "sequence": sequence,
-                }
-            )
+            return AddNestedExecutionResponse(
+                status="added",
+                parent_rid=parent_execution_rid,
+                child_rid=child_execution_rid,
+                sequence=sequence,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,

--- a/src/deriva_ml_mcp/tools/feature.py
+++ b/src/deriva_ml_mcp/tools/feature.py
@@ -38,6 +38,9 @@ from deriva_ml_mcp._helpers import (
     _paginate,
 )
 from deriva_ml_mcp._response_models import (
+    AddFeatureValuesResponse,
+    CreateFeatureResponse,
+    DeleteFeatureResponse,
     FeatureListResponse,
     FeatureSummary,
     PreflightCountResponse,
@@ -497,7 +500,10 @@ def register(ctx: PluginContext) -> None:
                 n_asset_cols=len(assets_list),
                 n_value_cols=len(summary.value_columns),
             )
-            return json.dumps({"status": "created", **summary.model_dump()})
+            return CreateFeatureResponse(
+                status="created",
+                **summary.model_dump(),
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -551,13 +557,11 @@ def register(ctx: PluginContext) -> None:
             else:
                 # No state changed -- skip audit per convention.
                 status = "not_found"
-            return json.dumps(
-                {
-                    "status": status,
-                    "feature_name": feature_name,
-                    "table": table,
-                }
-            )
+            return DeleteFeatureResponse(
+                status=status,  # "deleted" or "not_found"
+                feature_name=feature_name,
+                table=table,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -670,14 +674,12 @@ def register(ctx: PluginContext) -> None:
                 execution_rid=execution_rid,
                 added_count=added,
             )
-            return json.dumps(
-                {
-                    "status": "added",
-                    "feature_name": feature_name,
-                    "execution_rid": execution_rid,
-                    "count": added,
-                }
-            )
+            return AddFeatureValuesResponse(
+                status="added",
+                feature_name=feature_name,
+                execution_rid=execution_rid,
+                count=added,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             response_fields: dict[str, Any] = {"attempted_count": len(entries)}
             if failed_index is not None:

--- a/src/deriva_ml_mcp/tools/workflow.py
+++ b/src/deriva_ml_mcp/tools/workflow.py
@@ -39,7 +39,9 @@ from deriva_ml_mcp._helpers import (
     _read_rid,
 )
 from deriva_ml_mcp._response_models import (
+    CreateWorkflowResponse,
     PreflightCountResponse,
+    UpdateWorkflowResponse,
     WorkflowDetail,
     WorkflowListResponse,
     WorkflowSummary,
@@ -410,17 +412,15 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for workflow %s after create_workflow",
                     rid,
                 )
-            return json.dumps(
-                {
-                    "status": status,
-                    "workflow_rid": rid,
-                    "name": name,
-                    "workflow_type": normalized_types,
-                    "url": url,
-                    "checksum": checksum,
-                    "version": version,
-                }
-            )
+            return CreateWorkflowResponse(
+                status=status,
+                workflow_rid=rid,
+                name=name,
+                workflow_type=normalized_types,
+                url=url,
+                checksum=checksum,
+                version=version,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
@@ -516,13 +516,11 @@ def register(ctx: PluginContext) -> None:
                     "re-index failed for workflow %s after update_workflow",
                     workflow_rid,
                 )
-            return json.dumps(
-                {
-                    "status": "updated",
-                    "workflow_rid": workflow_rid,
-                    "updated_fields": updated_fields,
-                }
-            )
+            return UpdateWorkflowResponse(
+                status="updated",
+                workflow_rid=workflow_rid,
+                updated_fields=updated_fields,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -716,7 +716,7 @@ async def test_add_dataset_members_with_list(dataset_ctx, capturing_mcp, mock_ml
                 execution_rid="EXEC-1",
             )
         )
-    assert out["status"] == "success"
+    assert out["status"] == "added"
     assert out["added_count"] == 3
     assert out["dataset_rid"] == "1-AAAA"
     assert out["new_version"] == "1.1.0"
@@ -812,7 +812,7 @@ async def test_delete_dataset_members_success(dataset_ctx, capturing_mcp, mock_m
                 execution_rid="EXEC-2",
             )
         )
-    assert out["status"] == "success"
+    assert out["status"] == "removed"
     assert out["removed_count"] == 2
     assert out["new_version"] == "1.3.0"
     ds.delete_dataset_members.assert_called_once_with(
@@ -1028,9 +1028,10 @@ async def test_update_dataset_description_only(dataset_ctx, capturing_mcp, mock_
         )
     assert out["status"] == "updated"
     assert out["updated_fields"] == ["description"]
-    # types fields are NOT present when only description was edited.
-    assert "dataset_types" not in out
-    assert "added" not in out
+    # types fields are always present in v3.0 (null when description-only branch ran).
+    assert out["dataset_types"] is None
+    assert out["added"] is None
+    assert out["removed"] is None
     # pathBuilder write happened with the right shape.
     update_mock.assert_called_once_with([{"RID": "1-AAAA", "Description": "new desc"}])
     # In-memory mirror updated too.
@@ -1091,7 +1092,7 @@ async def test_add_dataset_element_type_success(dataset_ctx, capturing_mcp, mock
             )
         )
     assert out == {
-        "status": "success",
+        "status": "created",
         "table_name": "Image",
         "association_table": "Dataset_Image",
     }
@@ -1139,7 +1140,7 @@ async def test_increment_dataset_version_success(dataset_ctx, capturing_mcp, moc
                 execution_rid="EXEC-3",
             )
         )
-    assert out["status"] == "success"
+    assert out["status"] == "incremented"
     assert out["dataset_rid"] == "1-AAAA"
     assert out["previous_version"] == "1.2.0"
     assert out["new_version"] == "1.3.0"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1233,12 +1233,12 @@ async def test_cache_dataset_explicit_version(dataset_ctx, capturing_mcp, mock_m
                 version="1.2.3",
             )
         )
-    assert out["status"] == "success"
+    assert out["status"] == "cached"
     assert out["dataset_rid"] == "1-AAAA"
     assert out["version"] == "1.2.3"
     assert out["materialize"] is True
-    assert out["cache_status"] == "cached_materialized"
-    assert out["cache_path"] == "/tmp/cache/1-AAAA"
+    assert out["bag_info"]["cache_status"] == "cached_materialized"
+    assert out["bag_info"]["cache_path"] == "/tmp/cache/1-AAAA"
 
     # spec carried the explicit version through.
     (spec_arg,) = mock_ml.cache_dataset.call_args.args
@@ -1604,7 +1604,7 @@ async def test_split_dataset_basic_success(dataset_ctx, capturing_mcp, mock_ml):
                 source_dataset_rid="1-AAAA",
             )
         )
-    assert out["status"] == "success"
+    assert out["status"] == "split"
     assert out["source"] == "1-AAAA"
     assert out["training"]["rid"] == "1-TRN"
     assert out["testing"]["rid"] == "1-TST"

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -418,8 +418,8 @@ async def test_start_execution_idempotent_when_already_running(
             hostname="h", catalog_id="1", execution_rid="1-EXEC"
         )
     payload = json.loads(result)
-    assert payload["status"] == "running"
-    assert payload["note"] == "already running"
+    assert payload["status"] == "already_running"
+    assert "note" not in payload
     execution.execution_start.assert_not_called()
     # Idempotent no-op: no audit row.
     assert mock_audit.call_count == 0
@@ -659,8 +659,9 @@ async def test_abort_execution_idempotent_when_already_aborted(
             hostname="h", catalog_id="1", execution_rid="1-EXEC"
         )
     payload = json.loads(result)
-    assert payload["status"] == "aborted"
-    assert payload["note"] == "already aborted"
+    assert payload["status"] == "already_aborted"
+    assert "note" not in payload
+    assert payload["reason"] is None
     execution.abort.assert_not_called()
     assert mock_audit.call_count == 0
 


### PR DESCRIPTION
## Summary

Closes PR 3 of #6 -- the response-shape Pydantic migration. Every
`mutates=True` tool now returns a named Pydantic response model with
a `Literal[...]` `status` discriminator and `extra="forbid"`. The
discriminator vocabulary is normalized.

This is the major-bump release. **Read the wire breaks carefully.**

## Wire breaks (11 total)

### Status renames (6 tools)
- `add_dataset_members`: `success` -> `added`
- `delete_dataset_members`: `success` -> `removed`
- `add_dataset_element_type`: `success` -> `created`
- `increment_dataset_version`: `success` -> `incremented`
- `cache_dataset`: `success` -> `cached`
- `split_dataset`: `success` -> `split`

### Idempotent-no-op signal moved into `status` (2 tools)
- `start_execution`: `{"status": "running", ..., "note": "already running"}`
  -> `{"status": "already_running", ...}`
- `abort_execution`: `{"status": "aborted", ..., "note": "already aborted"}`
  -> `{"status": "already_aborted", ..., "reason": null}`

### Conditional fields now always present (`null` when N/A)
- `update_dataset`: `dataset_types` / `added` / `removed` are
  always present in the response (was conditionally omitted in
  v2.x for description-only edits).
- `abort_execution`: `reason` is always present (was conditionally
  omitted on the no-op branch).
- `create_execution_dataset`: `dataset_types` is always present
  (`null` when omitted by the caller).

### Nested upstream payload (1 tool)
- `cache_dataset`: bag-info keys (`tables`, `total_rows`,
  `total_asset_bytes`, `total_asset_size`, `cache_status`,
  `cache_path`) now nested under `payload["bag_info"]` instead of
  spread top-level.

## Architecture

- 25 named Pydantic response models in `_response_models.py` (one
  per mutating tool, plus `CommitExecutionReport`,
  `CacheDatasetBagInfo`, and `SplitDatasetPartitionInfo` nested
  shapes).
- 1 shared mixin (`_DatasetVersionBumpMixin`) for the three
  dataset-version-bump tools that all return
  `{dataset_rid, new_version}`.
- `extra="forbid"` everywhere except `CacheDatasetBagInfo` (which
  uses `extra="allow"` because the bag-info shape is owned by
  upstream DerivaML, not by deriva-ml-mcp).

CLAUDE.md updated with the full v3.0 migration map for downstream
clients.

## Test plan
- [x] All 287 tests pass (test files updated for breaking changes)
- [x] `uv run ruff check src tests` clean
- [x] `uv run ruff format --check src tests` clean
- [x] No stragglers: `grep '"status": "success"' src/` returns empty
- [x] CLAUDE.md migration map covers all 11 wire breaks
- [x] Final-reviewer audit pass clean
- [ ] Manual smoke test against a live catalog (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)