### PR TITLE
v3.1.0: Expose sort=, execution_rids=, max_results= from deriva-ml v1.31.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,48 @@ This closes PR 3 of #6. The response-shape Pydantic migration is
 complete -- every `_*_impl` helper, every list/detail/summary
 shape, and every mutating-tool response is now Pydantic-typed.
 
+v3.1 exposes three new optional parameters from the deriva-ml v1.31.0
+release through the MCP tool surface:
+
+- `deriva_ml_list_executions`, `deriva_ml_list_datasets`,
+  `deriva_ml_list_workflows` (and `deriva_ml_find_workflow_executions`
+  which shares the executions impl) accept an optional `sort: bool =
+  False`. Default `False` preserves the current RID-ascending order
+  used for stable cursor pagination. `True` returns results
+  newest-first by record creation time (RCT desc) -- recommended for
+  "show me what's recent" queries. The `_list_*_impl` helpers were
+  extended in lockstep so the resource layer (which calls them
+  without `sort=`) keeps its current snapshot stability.
+
+- `deriva_ml_list_feature_values` accepts:
+  - `execution_rids: list[str] | None = None` -- server-side filter
+    to a known set of execution RIDs. Empty list short-circuits.
+    Recommended for cross-execution comparison queries (e.g. "give
+    me the F1 score for each of these 5 runs in one round-trip").
+  - `max_results: int = 50_000` -- caller-controlled cap on rows
+    materialized before pagination. The MCP wrapper translates
+    deriva-ml's `DerivaMLMaterializeLimitExceeded` into a clear
+    error envelope. Behavior tightening: queries that previously
+    OOMed silently now return `{"error": "...exceeds max_results..."}`.
+    Note the deliberate naming asymmetry -- the MCP wire uses
+    `max_results` (LLM-friendly name) and forwards as
+    `materialize_limit=max_results` to deriva-ml (library-internal
+    name).
+
+- `deriva-ml` is now pinned to `>=1.31.0` (was unpinned;
+  audit-flagged deployment risk).
+
+Resource shapes are unchanged. Resources keep RID-ascending defaults
+for snapshot stability; users who want recent-first content use the
+tool with `sort=True`.
+
+This release does NOT add a `compare_metrics` tool. The
+cross-execution comparison workflow is taught at the skill layer
+(`compare-model-runs` skill in `deriva-ml-skills`, follow-up) which
+respects both metric-storage patterns: features-as-scalars (use
+`execution_rids=` on `list_feature_values`) and metrics-as-JSONL-
+asset files (download via `work-with-assets`, parse locally).
+
 ## Coverage Report
 
 `docs/coverage.md` records what happened to every old `deriva-mcp` tool. Update it

--- a/docs/superpowers/notes/audit-2026-04-27-agent-design.md
+++ b/docs/superpowers/notes/audit-2026-04-27-agent-design.md
@@ -1,0 +1,251 @@
+# Agent-System Design Audit — deriva-ml-mcp + deriva-ml-skills
+
+**Date:** 2026-04-27
+**Scope:** deriva-ml-mcp v1.x tools/resources/prompts + deriva-ml-skills 23 skills
+**Auditor perspective:** An LLM (Claude) trying to do real ML-development work end-to-end
+
+---
+
+## User-Goal Walkthroughs
+
+### Goal 1: Explore an unfamiliar catalog
+
+**Walkthrough.** The LLM arrives with only a hostname and a catalog ID. There is no `connect_catalog` step — this is called out explicitly in both the `deriva_ml_getting_started` prompt and the `deriva-ml-context` always-on skill. The stateless model is actually well-documented once you read those two sources. Assuming the LLM has the prompt loaded (it is not automatically sent — the user must invoke `deriva_ml_getting_started` or the always-on context skill must trigger), the first move is clearly: read `deriva://catalog/{h}/{c}/ml/registries` (vocabs), `deriva://catalog/{h}/{c}/ml/datasets`, `deriva://catalog/{h}/{c}/ml/workflows`, and `deriva://catalog/{h}/{c}/ml/executions` as a four-resource cold-start sweep. These resources are free reads, uncapped only at 1000, and return structured JSON.
+
+The `registries` resource bundles dataset types, workflow types, asset types, and execution statuses in a single fetch — this is genuinely useful for orientation. It returns only `{name, rid}` per term by design (description is elided), which is a reasonable tradeoff. If the LLM wants descriptions it falls back to `rag_search` or `list_vocabulary_terms`.
+
+For schema discovery there is a gap: the MCP surface has no tool for "list domain tables" or "what tables carry my research data?" That is handled by the tier-1 `deriva-skills` plugin's schema tools (`browse-erd`, `route-catalog-schema`). An LLM using only `deriva-ml-mcp` tools directly cannot get a table list without calling the generic `get_table_sample_data` or `rag_search`. The `deriva-ml-context` skill bridges this — it says use `/deriva:browse-erd` or `/deriva:route-catalog-schema` for schema introspection — but only if that skill is loaded.
+
+Naming conventions are documented in the `api-naming-conventions` always-on skill and in the `deriva_ml_getting_started` prompt's "RESOLVING USER-MENTIONED NAMES TO CATALOG IDENTIFIERS" section. The RAG coverage index is also documented there with freshness caveats. This is strong.
+
+`rag_search` is the recommended semantic entry point, and the getting-started prompt explains two doc types: `catalog-data` (Dataset/Workflow/Execution rows) and `catalog-schema` (tables, vocab terms). The LLM is correctly steered to use RAG before paginated list tools.
+
+**Friction points:**
+1. The cold-start requires knowing to invoke `deriva_ml_getting_started` or having the always-on `deriva-ml-context` skill trigger. If neither fires, the LLM sees 45+ tools with no orientation.
+2. No "list domain tables" tool exists in this plugin. Schema discovery requires the tier-1 companion.
+3. The `registries` resource elides term descriptions. For "what does this workflow type mean?" the LLM must fire a follow-up `rag_search` or `list_vocabulary_terms`.
+4. Resource URIs must be fully known — the LLM cannot discover available resources by browsing; it must know the template from the prompt.
+
+**Score: 3/5.** Resources are well-structured, the getting-started prompt is comprehensive, and RAG is usable. But the cold-start assumes prompt consumption, schema discovery leaks to the tier-1 layer, and the resource URI namespace is not self-discoverable.
+
+---
+
+### Goal 2: Develop a new model
+
+**Walkthrough.** The user says "train a CNN on the Image dataset to predict cell types." The recommended path from `model-development-workflow` and `execution-lifecycle` is:
+
+1. Find the relevant data: `rag_search("Image cell type dataset", doc_type="catalog-data")`, then `deriva_ml_list_datasets` or `deriva://catalog/{h}/{c}/ml/datasets`. Good — the RAG and resource coverage makes data discovery tractable.
+2. Inspect features: `deriva_ml_list_features(table="Image")` or `deriva://catalog/{h}/{c}/ml/features/Image`. The resource has the right shape. `deriva_ml_get_feature(table="Image", feature_name="Cell_Type")` returns term_columns/value_columns/asset_columns with nullok flags — enough for the LLM to build valid feature records.
+3. Register a workflow: `deriva_ml_create_workflow(name=..., workflow_type=..., url=..., checksum=...)`. The `deriva_ml_workflow_dedup` prompt cleanly documents idempotency. However, the LLM must supply the Git URL and checksum itself — the tool cannot compute them. The `execution-lifecycle` skill says "code must be committed" and explains `deriva-ml-run`, but does not give the LLM a tool to fetch the Git hash. The LLM must ask the user or assume they computed it.
+4. Create an execution: `deriva_ml_create_execution(workflow_rid=..., dataset_rids=["4HM@1.0.0"], ...)`. The `"RID@version"` shorthand for dataset inputs is documented in the execution tool docstring. `dry_run=True` is supported.
+5. Start the execution: `deriva_ml_start_execution(execution_rid=...)`.
+6. Recording results: `deriva_ml_create_feature(target_table="Image", feature_name="Cell_Type_Prediction", terms=["Cell_Type"], ...)` then `deriva_ml_add_feature_values(table="Image", feature_name="Cell_Type_Prediction", execution_rid=..., entries=[...])`. The hybrid dispatch is documented in the `deriva_ml_execution_lifecycle` prompt — if the execution is already `Running`, call `add_feature_values` directly; if it is `Created`, the tool auto-wraps.
+7. Commit: `deriva_ml_commit_execution(execution_rid=...)`.
+
+**Where the LLM must guess or hand off:**
+
+- **File I/O is entirely out of scope for the MCP surface.** The model checkpoint file cannot be registered through MCP tools alone. The `work-with-assets` skill generates Python the user runs locally. This boundary is documented but requires the user to run code outside Claude.
+- **The `workflow_name` phantom parameter.** The `model-development-workflow` skill (lines 146, 191) passes `workflow_name=` to `deriva_ml_create_execution`. That parameter does not exist — the real signature is `workflow_rid=`. This will cause a runtime error if the LLM follows the skill exactly. A real hallucination risk baked into the skill text itself.
+- **`entries=` vs `values=`.** The `create-feature` skill uses `values=` in all its `deriva_ml_add_feature_values` examples (lines 166–188). The actual tool parameter is `entries=`. This mismatch will generate a validation error.
+- **The Git commit boundary.** `deriva-ml-run` enforces a clean working tree; MCP tools do not. An LLM trying to do the whole workflow via MCP tools without the CLI can succeed, but provenance is weaker. This boundary is explained well in `execution-lifecycle` but is a UX cliff the first time a user hits `DerivaMLDirtyWorkflowError`.
+- **`create_execution` does not accept a workflow name string.** The LLM must first resolve or create the workflow and hold its RID. The tool is correctly designed for this, but the step ordering is non-obvious without the prompts.
+
+**Score: 3/5.** The happy path is well-covered by the prompts and skills if the LLM reads them carefully. The `workflow_name` phantom and `entries`/`values` mismatch are real bugs in skill content that will cause tool call failures. File I/O hand-off to local Python is a coherent design decision but a significant capability gap.
+
+---
+
+### Goal 3: Compare model runs
+
+**Walkthrough.** "Show me which of the last 5 training runs got the best F1 score."
+
+1. Find executions: `deriva_ml_list_executions(status="Uploaded", limit=5)` — sorted by RID ascending, so "last 5" by RID is feasible. However, execution summary fields are `{rid, workflow_rid, status, description, start_time, stop_time, duration}`. There is no sorting by `start_time` descending; pagination is RID-ordered ascending. To get the 5 most recent, the LLM must either do a preflight count and page to the end, or use `rag_search("recent training executions", doc_type="catalog-data")` and hope the index is fresh.
+2. Identify the F1 feature: `rag_search("F1 score feature", doc_type="catalog-schema")` or `deriva_ml_list_features(table="Image")`. If the catalog has a feature named `Metrics` with a `f1_score` value column, the LLM can find it via RAG. If the feature name is not intuitive, this step requires trial and iteration.
+3. Query feature values per execution: `deriva_ml_list_feature_values(table="Image", feature_name="Metrics", selector="by_execution", selector_execution_rid="1-EXEC")` — one call per execution. For 5 executions this is 5 calls. The selector enum is documented in the tool's `Args:` block inline: `none | newest | first | latest | majority_vote | by_workflow | by_execution`. Clear and actionable.
+4. Ranking: The LLM must aggregate the responses across 5 tool calls and sort. There is no "query feature values across multiple executions" tool. This is a real gap — the LLM cannot do an in-catalog comparison query. It must materialize all the values into context and compute the ranking itself.
+
+**Friction points:**
+- No reverse-chronological ordering on list tools. "Last 5" requires either the preflight-count dance or a RAG hit.
+- No cross-execution feature value query. The LLM must loop.
+- Feature discovery relies on naming conventions or RAG. If the metric column is named `val_f1` in the feature value record, the LLM must know that from `deriva_ml_get_feature` before it can extract it.
+- The `selector="by_execution"` path works well once the LLM knows the execution RIDs and the feature name.
+
+**Score: 2/5.** This is the weakest goal. The surface has the building blocks but no "compare across executions" primitive. The LLM must do 5+ sequential tool calls, aggregate in context, and rank manually. On large catalogs where the last 5 runs require paging, the friction compounds. RAG freshness also matters here — stale RAG on a shared catalog means recent runs may not be discoverable.
+
+---
+
+### Goal 4: Manage catalog growth
+
+**Walkthrough.** "We need a new feature schema for storing model uncertainty per-prediction."
+
+1. Design: The `create-feature` skill documents the decision tree (term-based / asset-based / scalar / mixed). A per-prediction scalar uncertainty score is a value column (`float4`), making this a metadata-only feature. The LLM would call `deriva_ml_create_feature(target_table="Image", feature_name="Uncertainty", metadata=["uncertainty_score"], comment="...")`. The `metadata=` parameter accepts `list[str | dict]` — the type union is documented in the tool's `Args:` block, but "metadata" here means "extra scalar columns"; the naming is not self-explanatory. The `create-feature` skill explains it as "metadata columns" with a type table, which is better.
+2. Vocabulary: If the feature is term-based (e.g., uncertainty category), `add_term(schema="deriva-ml", table="...", ...)` via the tier-1 surface. This hand-off is documented in `deriva-ml-context`.
+3. Verify: Read `deriva://catalog/{h}/{c}/ml/features/Image` to confirm the feature appears. Good.
+4. Re-index: The LLM must call `deriva_ml_reindex_vocabularies()` after adding terms. But `deriva_ml_create_feature` does not trigger a schema RAG re-index (that is a tier-1 responsibility). The getting-started prompt says: "To re-index after adding a term via core's `add_term`, call `deriva_ml_reindex_vocabularies` first." But creating a new feature table is a schema mutation — the schema RAG (`catalog-schema` doc type) needs refreshing too. The prompt says fresh-on-first-connect for tables/columns, but does not say how to force a schema re-index after creating a new feature table mid-session. `rag_index_schema()` is mentioned in `model-development-workflow` Phase 1, but is it a tool available to the LLM? It exists as a tier-1 tool (`rag_index_schema`) but is not called out in the feature skill.
+5. Communication to other users: Nothing in the surface addresses this. The cross-user freshness gap (v1.4 known limitation) means other users will not see the new feature in their RAG index until they reconnect. `deriva_ml_resync_indexes` is the manual bridge, but it is not mentioned in the create-feature skill.
+
+**Score: 3/5.** Feature creation is well-supported. The friction is at the edges: the `metadata=` parameter name is misleading for scalar columns, schema RAG re-index after feature creation is not clearly documented in the create-feature skill, and cross-user propagation is invisible unless you know about `deriva_ml_resync_indexes`.
+
+---
+
+### Goal 5: Recover from failure
+
+**Walkthrough.** "My training run crashed mid-epoch. Execution shows Running but process is dead."
+
+1. Diagnose: `deriva_ml_get_execution(hostname=..., catalog_id=..., execution_rid="1-EXEC")` — returns `{rid, workflow_rid, status, description, start_time, stop_time, duration}`. Or read `deriva://catalog/{h}/{c}/ml/execution/1-EXEC` for the richer detail including inputs/outputs. Status will be `Running`.
+2. The `troubleshoot-execution` skill covers "Execution Stuck in Running" explicitly with the right diagnostic sequence.
+3. Decision: abort. `deriva_ml_abort_execution(execution_rid="1-EXEC", reason="Process died mid-epoch")`. This is clean and idempotent — if the status is already `Aborted`, it no-ops with `status="already_aborted"`. The state machine is enforced.
+4. **Critical bug in the skill.** The `troubleshoot-execution` skill (line 129) lists this option: `deriva_ml_update_execution(hostname, catalog_id, execution_rid, status="Failed", message="Manually marked as failed")`. That tool signature is wrong. `deriva_ml_update_execution` only accepts `description=` — it does not accept `status=` or `message=`. If the LLM follows this skill text, it will generate a tool call that fails. `update_execution` explicitly rejects status edits with: "description must be provided; no other fields are editable on Execution (status changes go through start/commit/abort)".
+5. Recovery: `deriva_ml_create_execution(workflow_rid=..., dataset_rids=..., ...)` — fresh execution with same inputs. The troubleshoot skill documents this "re-run after abort" pattern correctly (lines 159–163).
+6. Verify: `deriva_ml_get_execution(execution_rid="<new_exec>")` — confirm status is `Created`.
+
+**Friction points:**
+- The bogus `status="Failed"` option in `troubleshoot-execution` is a live trap. The LLM reading the skill might try the "arbitrary status" path before the abort path. It will fail with an error envelope, at which point it should fall back to `abort_execution` — but that requires the LLM to correctly interpret the error and try the right alternative.
+- `deriva_ml_get_execution` returns a flat summary (no inputs/outputs). The resource `deriva://catalog/{h}/{c}/ml/execution/{rid}` returns inputs+outputs+experiment. For diagnosing "what did this run have as inputs?" the resource is better but requires knowing the URI template.
+- The orphaned local working directory (staged files) is not addressable from the MCP surface at all. The `troubleshoot-execution` skill mentions `derive://storage/execution-dirs` but that resource is from the tier-1 plugin, and the cleanup is manual.
+
+**Score: 3/5.** The abort path is solid, the state machine enforcement is good, and the re-run pattern is documented. The bogus `status=` option in the troubleshoot skill is a real hazard that needs fixing.
+
+---
+
+### Score Summary
+
+| Goal | Score | Top friction |
+|------|-------|-------------|
+| 1 — Explore unfamiliar catalog | 3/5 | No cold-start prompt auto-injection; schema discovery leaks to tier-1 |
+| 2 — Develop new model | 3/5 | `workflow_name` phantom param; `entries`/`values` mismatch in skills |
+| 3 — Compare model runs | 2/5 | No reverse-sort on list tools; no cross-execution feature query |
+| 4 — Manage catalog growth | 3/5 | `metadata=` naming; schema RAG re-index gap after feature creation |
+| 5 — Recover from failure | 3/5 | Bogus `status=` option in troubleshoot skill; resource vs tool gap for full detail |
+
+---
+
+## Cross-Cutting Findings
+
+### A. Tool naming + discoverability
+
+The `deriva_ml_` prefix is consistent across all 45 tools and is the right call — it prevents collision with tier-1 tools and makes grep/autocomplete reliable.
+
+**Verb clarity is high.** `create` / `list` / `get` / `find` / `delete` / `add` / `update` / `commit` / `abort` are all standard REST-flavored verbs that translate directly to intent.
+
+**Two close-sibling pairs require docstring disambiguation:**
+
+- `deriva_ml_create_execution` vs `deriva_ml_create_execution_dataset`: the latter creates an output dataset linked to a completed execution, not a general dataset. An LLM trying to "create a dataset from this execution" will likely pick the right one — the name is explicit — but the distinction between "input dataset" (supplied at `create_execution` time via `dataset_rids=`) and "output dataset" (created post-hoc via `create_execution_dataset`) is subtle enough to cause mistakes. The getting-started prompt documents this cleanly.
+- `deriva_ml_list_executions` vs `deriva_ml_find_workflow_executions`: these are nearly identical in behavior (the latter is `list_executions(workflow_rid=...)`). The getting-started prompt justifies this as "different LLM intent" — "runs of this workflow" vs "browse executions." This is debatable; in practice an LLM that sees both tools may invoke either for either intent.
+
+**`deriva_ml_list_feature_values` with `selector=` is the most complex tool in the surface.** The `Literal[...]` type annotation with 7 values plus two conditional required parameters (`selector_workflow`, `selector_execution_rid`) is hard for an LLM to get right without the `create-feature` skill loaded. Without the skill, the LLM might invoke `selector="by_workflow"` without `selector_workflow=` and get a clean error message — which is good.
+
+### B. Tool argument design
+
+**Strengths:**
+- The `entries=` parameter in `deriva_ml_add_feature_values` carries a clear inline error if empty.
+- Pagination is uniform across all list tools (`limit=`, `after_rid=`, `preflight_count=`). The contract is documented once in the getting-started prompt and not repeated in every docstring — good DRY discipline.
+- The `workflow_rid=` name in `deriva_ml_create_execution` is precise; early versions of the code comment explain that passing a raw string would silently route to `lookup_workflow_by_url` instead of `lookup_workflow`, which would be a confusing failure. The resolved path is the right design.
+- Status enum values (`Created`, `Running`, `Stopped`, `Pending_Upload`, `Uploaded`, `Failed`, `Aborted`) are enumerated in the `deriva_ml_execution_lifecycle` prompt and in `_list_executions_impl`'s Args docstring. The string values match `ExecutionStatus.value` exactly.
+
+**Weaknesses:**
+- `deriva_ml_create_feature`'s `metadata=` parameter accepts `list[str | dict]`. "Metadata" is ambiguous — it sounds like key-value metadata about the feature, but it means "extra scalar or FK columns added to the feature table." The `create-feature` skill explains this, but the tool docstring does not.
+- `deriva_ml_create_workflow`'s `workflow_type=` accepts `str | list[str]`. This is good for single vs multi-type, but the valid values are not listed in the docstring (`Args:` says "Each must be a term in the `Workflow_Type` vocabulary" without enumerating the terms). The LLM must do a prior `rag_search` or `registries` fetch to know valid values.
+- `deriva_ml_split_dataset`'s parameters are not visible from this audit; it is in `complex.py` which was not fully read. The skill mentions `stratify_by_column` but does not enumerate required vs optional args.
+- `deriva_ml_cache_dataset`'s `materialize=` parameter defaults to `True` (full asset download). An LLM doing a preflight check that calls `cache_dataset` without `materialize=False` will trigger a full download — potentially gigabytes. The docstring says "If False, only fetch the bag metadata" but does not warn "this downloads everything." The `execution-lifecycle` skill's Phase 1 table says to use `bag_info` for size checking before `cache_dataset`, which partially mitigates this.
+
+### C. Resource utility
+
+Resources are actively used across the skill surface. Counting explicit resource references in skills:
+
+- `execution-lifecycle` SKILL.md: 3 resource references (execution detail, executions list, workflows list, registries)
+- `dataset-lifecycle` SKILL.md: 2 resource references (datasets list, registries)
+- `create-feature` SKILL.md: 0 explicit `deriva://` resource references (recommends RAG and typed tools instead)
+- `troubleshoot-execution` SKILL.md: 1 resource reference (execution detail in Phase 3 verify)
+- `model-development-workflow` SKILL.md: 0 explicit resource references
+
+Resources are better used in the getting-started prompt (10 URIs enumerated) than in individual skills. The skills lean more toward typed tools (`deriva_ml_get_execution`, `deriva_ml_list_features`) than their corresponding resources (`deriva://catalog/.../ml/execution/{rid}`, `deriva://catalog/.../ml/features/{table}`). This is defensible — tools are stateful (they handle errors cleanly) and skills document the typed tools for predictability. But the resources are faster (one network call vs tool overhead) and return richer detail for execution (inputs + outputs bundled). The `execution-lifecycle` skill does point to the detail resource for post-run verification, which is correct.
+
+**Underused resources:** `deriva://catalog/{h}/{c}/ml/asset/{rid}` and `deriva://catalog/{h}/{c}/ml/asset-tables` are mentioned only in the getting-started prompt. No skill explicitly says "use the asset resource for this." The `work-with-assets` skill was not fully read but likely covers this.
+
+### D. Prompt utility
+
+**`deriva_ml_getting_started`** is the strongest asset in the system. It covers: the stateless model, the pagination contract, the error envelope, the five ML domains with verb tables, the resource URI namespace, RAG discovery patterns, name resolution order, RAG freshness with cross-user caveats, the mutation chain, and the asset file I/O split. At approximately 370 lines it is long but dense and mostly non-redundant. Grounding on this prompt gives an LLM an accurate mental model of the surface.
+
+**`deriva_ml_execution_lifecycle`** correctly describes the state machine with concrete state names, the two state-set constants (`_START_REJECT_STATES`, `_COMMIT_ALLOWED_STATES`), the five lifecycle tools, the hybrid dispatch on `add_feature_values`, and the two pitfalls (no manual status edit, always commit). This is load-bearing; without it the LLM will likely mishandle the `Created -> Running` boundary.
+
+**`deriva_ml_workflow_dedup`** is short and correct. The anti-pattern / correct pattern pair is exactly what an LLM needs to avoid the double-call trap.
+
+**Missing prompts:**
+
+- **`deriva_ml_feature_design`** — There is no prompt for the feature design mental model (term vs asset vs scalar, single vs multi-column, selector strategy). The `create-feature` skill covers this, but a prompt would help an LLM that encounters a feature question without loading the skill.
+- **`deriva_ml_dataset_versioning`** — The versioning rules (always pin versions in configs, increment after changes, semantic version convention) are important enough for a prompt. They are currently spread across `dataset-lifecycle` skill, `model-development-workflow` skill, and the `execution-lifecycle` skill's pre-flight section.
+- **`deriva_ml_rag_freshness`** — The cross-user freshness gap and the `resync_indexes` recovery pattern deserve a prompt. The getting-started prompt covers this in one paragraph, but it is easy to miss.
+
+### E. Error message quality
+
+The `_error_envelope` implementation calls `str(exc)` on the caught exception. Error quality depends on what `deriva-ml` raises.
+
+**Sampled error paths:**
+
+1. **Unknown workflow RID in `create_execution`.** `ml.lookup_workflow(workflow_rid)` will raise `DerivaMLException`. The error envelope returns `{"error": "Workflow with RID '<rid>' not found in catalog"}` (inferred from the comment in the source: `"Workflow with URL or checksum '<rid>' not found in catalog"` — but this is the URL path, not the RID path). The RID lookup path raises a different exception. The error text may say "not found" without telling the LLM what to do next. Actionability: low.
+
+2. **Wrong execution state for `start_execution`.** This path is handled before `_error_envelope`: the tool returns `{"error": "cannot start execution in state Stopped; only Created (will start) or Running (no-op) are valid"}`. This is actionable — it tells the LLM exactly what states are valid and what the rejected state was.
+
+3. **Empty `entries` in `add_feature_values`.** Returns `{"error": "entries must be a non-empty list.", "attempted_count": 0}`. Clear and actionable.
+
+4. **Unknown workflow_type term in `create_workflow`.** Will propagate from `ml._add_workflow()` as a `DerivaMLException` or catalog FK violation. The `str()` of the underlying exception is catalog-layer text — likely something like "unknown term in Workflow_Type vocabulary." Not specifically actionable (doesn't say "call `add_term` to add it").
+
+5. **`commit_execution` on an already-aborted execution.** Returns `{"error": "cannot commit execution in state Aborted; only Created, Running, Stopped, Pending_Upload, or Uploaded (additive upload) are valid"}`. This is excellent — the valid state list is enumerated, the rejected state is named, and the additive-upload edge case is explained inline.
+
+**Assessment:** The tool-internal validation paths (states, empty lists) produce actionable errors. The passa-through from `deriva-ml` library errors are less predictable — they give the LLM the raw exception message which may or may not say what to do next. No error message in the surface says "call `rag_search` to find the correct value" or "use `list_vocabulary_terms` to find valid terms." That gap means the LLM must synthesize the recovery step from general knowledge rather than the error text.
+
+### F. Provenance + reproducibility
+
+The surface makes provenance **hard to skip by accident**:
+
+- `deriva_ml_add_feature_values` requires `execution_rid=` — there is no way to add feature values without an execution context.
+- `deriva_ml_create_execution_dataset` requires `execution_rid=` — output datasets must be linked to an execution.
+- The `deriva-ml-context` always-on skill's steering principle explicitly warns: "raw `insert_entities` bypasses provenance tracking" and lists the specific harms.
+- `deriva_ml_create_execution` accepts a `dry_run=True` flag that skips catalog writes and audit — explicitly documented as "test without recording."
+
+**Gap:** `deriva_ml_create_dataset` (the standalone tool) does not require an execution context. You can create a dataset that is not linked to any execution. The skills recommend creating an execution first ("create a workflow and execution for provenance tracking") but the tool does not enforce it. This is a correct design decision for bootstrap scenarios (the first dataset of a project cannot be linked to an execution that consumed it), but it is a place where the LLM can accidentally skip provenance for datasets it is curating.
+
+**Git boundary:** `DerivaMLDirtyWorkflowError` is enforced by `deriva-ml-run` but not by the MCP tools. The MCP execution tools do not check for dirty working trees. This means an LLM driving the execution lifecycle entirely through MCP tools (without the CLI) will happily create executions without a clean git state. The provenance record will not have a verifiable git hash. The skills document this but the tools cannot enforce it.
+
+### G. Pagination + scale
+
+**Implemented correctly:**
+- All list tools support `limit=` (default 100, max 1000) and `after_rid=` cursor pagination.
+- Resources are capped at 1000 rows with `truncated: bool` signal.
+- `preflight_count=True` allows the LLM to learn the count before committing to a page size.
+- `_paginate` implementation: `truncated = len(page) == limit` — this is a false-positive edge case (exactly 1000 results looks truncated), matching deriva-mcp-core convention. Acceptable.
+- Feature values have the same pagination (`after_rid=` is by RID for feature records, which have RIDs).
+
+**Gap:** `deriva_ml_list_feature_values` materializes ALL matching records into memory before pagination (`records = list(ds.feature_values(...))`). For a catalog with 10M feature values, this will OOM or timeout before pagination kicks in. The tool does not mention this limitation. A `preflight_count=True` call has the same problem — it counts a fully-materialized list. This is a known scalability risk.
+
+**Ordering:** List tools sort by RID ascending. There is no `sort_by=` or `order=` parameter. For "show me the most recent executions" the LLM must either page to the end of a large set or rely on RAG freshness. This is a real gap for time-ordered exploration.
+
+### H. Failure modes specific to LLMs
+
+**RID hallucination:** `deriva_ml_get_execution(execution_rid="1-XXXX")` on a non-existent RID will return `{"error": "<DerivaMLException message>"}`. The LLM has no tool to validate a RID before using it except `get_entities` from the tier-1 surface. `validate_rids` was removed. The typed lookups (`deriva_ml_get_dataset`, `deriva_ml_get_execution`, etc.) are the correct recovery — the skills document this correctly. The LLM is steered to look up before operating on a RID.
+
+**Column/feature name hallucination:** `deriva_ml_get_feature(table="Image", feature_name="Quality_Score")` on a non-existent feature returns an error. The LLM should then use `deriva_ml_list_features(table="Image")` to find the real name. The `create-feature` skill says to use `rag_search` first, which catches this class of hallucination.
+
+**Vocabulary term hallucination:** An LLM passing an invented `workflow_type="Model_Training_CNN"` to `deriva_ml_create_workflow` will get a catalog FK violation error. The error text from `deriva-ml` may not say "this is not in the Workflow_Type vocabulary." The LLM must infer that and call `list_vocabulary_terms` or `rag_search`. The getting-started prompt documents the vocabulary as searchable but doesn't enumerate terms (by design — terms vary per catalog). The `registries` resource gives the LLM all valid terms in one read.
+
+**Status enum hallucination:** `deriva_ml_list_executions(status="Complete")` instead of `status="Uploaded"` will raise `ValueError` in `ExecutionStatus("Complete")`. The error envelope will return `{"error": "'Complete' is not a valid ExecutionStatus"}` (Python's enum error text). The valid values are enumerated in the execution lifecycle prompt. Moderately actionable.
+
+**The `entries`/`values` and `workflow_name` bugs documented above** are literal skill-induced hallucinations — the skill tells the LLM to pass parameters that do not exist. These are the highest-risk findings in the audit.
+
+---
+
+## Top-Line Findings
+
+1. **Two skill content bugs will cause runtime failures.** The `model-development-workflow` skill passes `workflow_name=` to `deriva_ml_create_execution` (the parameter is `workflow_rid=`) and the `create-feature` skill uses `values=` in `add_feature_values` examples (the parameter is `entries=`). Both will produce tool-call errors on first use. Fix these immediately.
+
+2. **The troubleshoot-execution skill contains a bogus recovery option.** Line 129 suggests `deriva_ml_update_execution(..., status="Failed", message="...")`. That tool accepts only `description=`. An LLM reading this skill may try the wrong tool before trying `abort_execution`. Fix by removing the status/message option entirely.
+
+3. **No reverse-chronological ordering makes "recent runs" queries expensive.** Every list tool paginates by RID ascending. Finding the last 5 executions on a large catalog requires knowing the total count and paging to the end, or relying on RAG freshness. A `sort_desc=True` or `order="desc"` parameter on `list_executions` would eliminate the most common cross-run comparison pattern.
+
+4. **Feature value retrieval at scale is unsafe.** `deriva_ml_list_feature_values` materializes all records into memory before pagination. On catalogs with millions of feature rows this will OOM or timeout. The tool needs a server-side cursor or a maximum pre-materialization guard.
+
+5. **The cross-user freshness gap is real and underexplained in individual skills.** Only the getting-started prompt documents `deriva_ml_resync_indexes`. Skills like `create-feature` and `troubleshoot-execution` do not mention it. A colleague adding a vocabulary term or creating a feature is invisible to the LLM until reconnect unless the LLM proactively resyncs. The skills should add a one-line reminder.
+
+6. **The `deriva_ml_getting_started` prompt is the system's most important defense against LLM confusion** — and it is not automatically loaded. If the user does not invoke it and the `deriva-ml-context` always-on skill does not fire (e.g., the user asks a very specific tool question without DerivaML-flavored phrasing), the LLM operates on 45 tools with no grounding. Consider making the prompt part of the framework's server-startup greeting or the always-on context skill's content.
+
+7. **File I/O is a hard boundary that the surface does not bridge gracefully.** The asset upload/download split (MCP for catalog metadata, local Python for bytes) is architecturally correct but requires the user to context-switch from the Claude conversation to a local script. The `work-with-assets` skill bridges this by generating the Python, but the LLM cannot verify the script ran, cannot read the output, and cannot diagnose upload failures. A structured "here is the Python you need to run; paste the output back" pattern would help — this is a UX convention the skills could encode more explicitly.

--- a/docs/superpowers/notes/audit-2026-04-27-architecture.md
+++ b/docs/superpowers/notes/audit-2026-04-27-architecture.md
@@ -1,0 +1,296 @@
+# Architecture & Coverage Audit — deriva-ml-mcp
+
+*Audited: 2026-04-27. Auditor: Claude Sonnet 4.6 (independent pass).*
+
+---
+
+## Part A: Software Architecture
+
+### Module structure
+
+- **Line counts (approx):** `execution.py` 1338 lines, `resources/rag.py` 1078 lines, `_response_models.py` 1125 lines, `tools/dataset/read.py` 746, `tools/dataset/mutate.py` 734, `tools/dataset/complex.py` 539, `tools/feature.py` 696, `tools/workflow.py` 532, `tools/asset.py` 525. Only `execution.py` and `resources/rag.py` are above 800 lines.
+
+- **`execution.py` at 1338 lines** is the one module worth flagging. It contains 5 read tools, 6 mutation tools, and 5 shared helpers (`_summarize_execution`, `_list_executions_impl`, `_get_execution_detail_impl`, `_summarize_upload_dict`, and a `register` aggregator). The dataset domain was already split into read/mutate/complex at 17 tools/1745 lines; execution at 11 tools/1338 lines is growing toward the same threshold. A read/mutate split would bring it under 700 lines per file, but it isn't urgent today.
+
+- **`resources/rag.py` at 1078 lines** is large but not incoherent — it's a single subsystem (per-user RAG hooks, vocabulary indexing, and surgical `_reindex_*` helpers) with no natural split point. The complexity is inherent to the per-user safety contract; the module docstring thoroughly explains the design.
+
+- **`_response_models.py` at 1125 lines** is an intentional single-file Pydantic model registry. All ~50 models in one file means `grep` and cross-referencing stay trivial; no split is warranted.
+
+- **Dataset subpackage** (`__init__.py` + read/mutate/complex) is coherent. The package-level `audit_event` re-export trick (`_pkg.audit_event`) to maintain a single patch site across three submodules is slightly non-obvious but documented in the `__init__.py` docstring and preserves a clean test surface.
+
+- **No cycle / coupling issues found.** The one intentional import-cycle (`mutate.py` imports `deriva_ml_mcp.tools.dataset` at module load time) is documented and resolved by deferring submodule imports inside `register()`.
+
+### Separation of concerns
+
+- Each module has one clear responsibility: `ml_context.py` builds DerivaML instances, `_helpers.py` owns pagination/error-envelope/table-utils, `_response_models.py` owns wire shapes, `tools/<domain>` files own tool registration, `resources/` files own resource registration and RAG indexing.
+
+- `_helpers.py` is genuinely shared: `_error_envelope`, `_paginate`, `_read_rid`, `_table_qname`, `_table_to_dict`, `_set_row_description`, `_row_rid_for` are all called from multiple domain modules. No copy-paste found.
+
+- `_summarize_*` helpers in each domain file are domain-specific (not copy-pasted cross-module) and return typed Pydantic instances after the v2.2 sweep.
+
+- The `_summarize_upload_dict` helper in `execution.py` (line 314) returns a plain `dict`, not Pydantic. It feeds `CommitExecutionReport(**summary)` immediately, so the Pydantic boundary is still honored; but the helper itself is untyped. Minor inconsistency with the v2.2 pattern; not a correctness issue.
+
+### Dual-mode policy compliance
+
+| Domain | List tool | Detail tool | List resource | Detail resource | Shared `_*_impl` helper |
+|---|---|---|---|---|---|
+| Dataset | `deriva_ml_list_datasets` | `deriva_ml_get_dataset` | `ml/datasets` | `ml/dataset/{rid}` | `_list_datasets_impl`, `_get_dataset_detail_impl` |
+| Workflow | `deriva_ml_list_workflows` | `deriva_ml_get_workflow` | `ml/workflows` | `ml/workflow/{rid}` | `_list_workflows_impl`, `_get_workflow_impl` |
+| Execution | `deriva_ml_list_executions` | `deriva_ml_get_execution` | `ml/executions` | `ml/execution/{rid}` | `_list_executions_impl`, `_get_execution_detail_impl` |
+| Feature | `deriva_ml_list_features` | `deriva_ml_get_feature` | `ml/features/{table}` | — | `_list_features_impl` |
+| Asset | `deriva_ml_list_assets` | `deriva_ml_lookup_asset` | `ml/asset-tables` | `ml/asset/{rid}` | `_list_asset_tables_impl`, `_get_asset_detail_impl` |
+
+**One gap:** features have no per-feature detail resource (`ml/feature/{table}/{name}`). The tool `deriva_ml_get_feature` exists and returns the full schema, but there is no corresponding `deriva://catalog/{h}/{c}/ml/feature/{table}/{name}` resource. Features are schema objects, not data rows, so a resource here would be unusual (no stable RID-based URI), but it's worth noting for consistency. Not a defect under the current policy — the CLAUDE.md says "fixed-shape with no filters = resource" and feature detail has two required keys (table + name), making it more tool-like.
+
+**`deriva_ml_get_execution` tool returns `ExecutionSummary` shape** (7 fields: rid/workflow_rid/status/description/start_time/stop_time/duration), while the `ml/execution/{rid}` resource returns `ExecutionDetail` (summary + inputs + outputs + experiment). The `deriva_ml_get_execution` tool does NOT call `_get_execution_detail_impl`. This is a documented intentional difference — `get_execution` is a lightweight lookup, the resource is the bundled view. The CLAUDE.md's dual-mode policy says shapes MUST match when the helper is shared; here the tool intentionally returns a subset, which is permissible but the docstring (line 456–466) should note that callers wanting full detail should use the resource or call `_get_execution_detail_impl` explicitly.
+
+### Audit + re-index pattern compliance
+
+Scan results for `mutates=True` tools:
+
+| Tool | audit_event on success | audit_event on failure (via _error_envelope) | _reindex_* call |
+|---|---|---|---|
+| `deriva_ml_create_dataset` | yes (line 128) | yes | yes (`_reindex_dataset`, line 144) |
+| `deriva_ml_delete_dataset` | yes (line 201) | yes | yes (`_delete_dataset_source`, line 213) |
+| `deriva_ml_add_dataset_members` | yes (line 309) | yes | yes (`_reindex_dataset`, line 319) |
+| `deriva_ml_delete_dataset_members` | yes (line 389) | yes | yes (`_reindex_dataset`, line 399) |
+| `deriva_ml_update_dataset` | yes (line 535) | yes | yes (`_reindex_dataset`, line 547) |
+| `deriva_ml_add_dataset_element_type` | yes (line 630) | yes | yes (`_reindex_dataset`, line 711) |
+| `deriva_ml_increment_dataset_version` | yes (line 700) | yes | yes (`_reindex_dataset`, line 711) |
+| `deriva_ml_cache_dataset` | yes (line 131) | yes | no — intentional: `cache_dataset` does not change catalog data rows, only local filesystem |
+| `deriva_ml_split_dataset` | yes (line 489) | yes | yes (`_reindex_dataset` for each split RID, line 510) |
+| `deriva_ml_denormalize_dataset` | `mutates=False` | — | — |
+| `deriva_ml_create_workflow` | yes (line 394) | yes | yes (`_reindex_workflow`, line 407) |
+| `deriva_ml_update_workflow` | yes (line 500) | yes | yes (`_reindex_workflow`, line 511) |
+| `deriva_ml_create_execution` | yes (line 752) | yes | yes (`_reindex_execution`, line 764) |
+| `deriva_ml_start_execution` | yes (line 851) | yes | yes (`_reindex_execution`, line 859) |
+| `deriva_ml_commit_execution` | yes (line 964) | yes | yes (`_reindex_execution`, line 975) |
+| `deriva_ml_update_execution` | yes (line 1058) | yes | yes (`_reindex_execution`, line 1067) |
+| `deriva_ml_abort_execution` | yes (line 1143) | yes | yes (`_reindex_execution`, line 1152) |
+| `deriva_ml_create_execution_dataset` | yes (line 1218) | yes | yes (both `_reindex_dataset` + `_reindex_execution`, lines 1232-1250) |
+| `deriva_ml_add_nested_execution` | yes (line 1306) | yes | yes (`_reindex_execution`, line 1316) |
+| `deriva_ml_create_feature` | yes (line 493) | yes | no — intentional: features are schema objects, not RAG-indexed data rows |
+| `deriva_ml_delete_feature` | yes (line 549) | yes | no — same rationale |
+| `deriva_ml_add_feature_values` | yes (line 669) | yes | no — feature records are not RAG-indexed |
+| `deriva_ml_update_asset` | yes (line 495) | yes | no — assets are not in the per-user RAG trio (dataset/workflow/execution) |
+
+**No missing audit_event calls found.** The `cache_dataset` and `denormalize_dataset` omissions are consistent with their documented purposes. All `mutates=True` tools emit `_error_envelope(audit=True)` on failure via `_helpers.py`.
+
+**One idempotent-no-op deviation:** `deriva_ml_start_execution` returns `{"error": "cannot start execution in state ..."}` via raw `json.dumps` (line 840) for terminal-state rejection. This is the error path, but it doesn't go through `_error_envelope` and doesn't emit an audit row. The same pattern appears in `deriva_ml_commit_execution` (line 923) and `deriva_ml_update_execution` (line 1042 — the `description is None` guard). These are argument-validation returns, not exception-caught returns, so the `_error_envelope` wrapping would be unusual here; but the inconsistency means some validation errors are not logged at `ERROR` level. Minor.
+
+### Error handling
+
+- `_error_envelope` is used consistently across all tool try/except blocks. Every exception is caught at the outer level and serialized to `{"error": str(exc)}`, with the full traceback logged server-side (`exc_info=True`). No raw exception trace reaches the wire.
+
+- The bare `except Exception:` with `# noqa: BLE001` comments in `_get_execution_detail_impl` and `_get_asset_detail_impl` are intentional best-effort swallows for optional sub-payloads (inputs/outputs/experiment on execution detail; executions list on asset detail). These are acceptable because the outer payload is still valid and the catch is narrow in scope.
+
+- No leaky abstraction of deriva-py exceptions found. The `DerivaMLException` import in `workflow.py` (line 25) is used to check for a specific exception type; it doesn't re-raise it raw.
+
+### Pydantic response-model coverage
+
+- **All `mutates=True` tool returns** use `model_dump_json(by_alias=True)` as of v3.0. No raw dict returns for mutation responses.
+
+- **Remaining `json.dumps` calls** are confined to:
+  1. Argument-validation error returns that pre-date `_error_envelope` and use `json.dumps({"error": ...})` directly — `execution.py` lines 840, 923, 1042; `feature.py` lines 355, 363, 372, 634; `dataset/complex.py` lines 231, 237, 272, 335, 351. These are structurally identical `{"error": ...}` responses; no Pydantic model wraps them (there's no `ValidationErrorResponse` model).
+  2. Two read tools that return ad-hoc dicts: `deriva_ml_list_dataset_members` in summary mode (lines 415, 424, 452 — no Pydantic model for the summary sub-path) and `deriva_ml_list_dataset_element_types` (line 608). `deriva_ml_bag_info` (line 667) does `json.dumps(info, default=str)` because the `bag_info()` return shape is upstream-defined and varies. `deriva_ml_get_dataset_spec` (line 728) returns a plain dict. `deriva_ml_list_feature_values` result rows (line 412) call `r.model_dump()` then `json.dumps` — this is fine (the inner records ARE Pydantic).
+  3. `workflow.py` lines 481, 485 — the `lookup_workflow_by_url` no-result branch returns `{"url_or_checksum": ..., "message": ...}` as a raw dict instead of a named model.
+
+- The CLAUDE.md's v2.2 note explicitly calls out `_summarize_*` helpers as swept to Pydantic and the ad-hoc payload sites as retired in v2.3. The remaining `json.dumps` uses (listed above) are post-v2.3 survivors that weren't part of those sweeps. Not regressions, but the migration isn't 100% complete.
+
+- **No cases found** where a `_*_impl` helper returns a Pydantic model but the wrapper then calls `json.dumps` on it (which would lose the alias-map). The aliased `model_dump_json(by_alias=True)` pattern is applied correctly everywhere a Pydantic model is returned from an impl helper.
+
+### Lazy imports
+
+- All `from deriva_ml_mcp.resources.rag import _reindex_*` calls are inside tool function bodies (not at module level), consistent with the lazy-import pattern described in CLAUDE.md. This applies across all tool modules: `execution.py` (7 lazy imports), `workflow.py` (2), `dataset/mutate.py` (6), `dataset/complex.py` (1), `tools/maintenance.py` (2).
+
+- `resources/rag.py` itself uses top-level imports from `deriva_mcp_core.rag`, `deriva_ml_mcp._helpers`, `deriva_ml_mcp.ml_context`, and the `tools/dataset`, `tools/execution`, `tools/workflow` impl helpers. These are all intra-plugin imports; the RAG indexer is not loaded at plugin import time because `resources/rag.py` is only loaded when `plugin.py` calls `resources_rag.register(ctx)`, not at MCP server start. Fine.
+
+- `ctx.rag_dataset_indexer` is NOT called anywhere in the plugin source. The only reference is in the module docstring and a comment in `rag.py`'s module docstring explaining why it's banned. The safety contract is preserved.
+
+---
+
+## Part B: deriva-ml Coverage
+
+### DerivaML class methods (from `core/base.py` and mixin classes)
+
+**DatasetMixin (`core/mixins/dataset.py`)**
+
+| Method | Exposed? | Tool name | Notes |
+|---|---|---|---|
+| `find_datasets` | Yes | `deriva_ml_list_datasets` | |
+| `lookup_dataset` | Yes | `deriva_ml_get_dataset` | |
+| `delete_dataset` | Yes | `deriva_ml_delete_dataset` | |
+| `list_dataset_element_types` | Yes | `deriva_ml_list_dataset_element_types` | |
+| `add_dataset_element_type` | Yes | `deriva_ml_add_dataset_element_type` | |
+| `download_dataset_bag` | No | — | Intentional: requires local filesystem access on the client side, not the MCP server |
+| `estimate_bag_size` | Partial | `deriva_ml_bag_info` | `bag_info` wraps this; `estimate_bag_size` standalone is not exposed |
+| `bag_info` | Yes | `deriva_ml_bag_info` | |
+| `estimate_denormalized_size` | Yes | `deriva_ml_denormalize_dataset` (size-only mode) | Exposed via the tool's `describe_only=True` branch |
+| `cache_dataset` | Yes | `deriva_ml_cache_dataset` | |
+
+**Dataset class methods (`dataset/dataset.py`)**
+
+| Method | Exposed? | Tool name | Notes |
+|---|---|---|---|
+| `create_dataset` | Yes | `deriva_ml_create_dataset` | Via `Execution.create_dataset` in MCP; direct `DatasetMixin.create_dataset` is not separately exposed but the effect is the same |
+| `add_dataset_type` | Partial | `deriva_ml_update_dataset` | Set-style diff exposes the behavior |
+| `remove_dataset_type` | Partial | `deriva_ml_update_dataset` | Same |
+| `increment_dataset_version` | Yes | `deriva_ml_increment_dataset_version` | |
+| `list_dataset_members` | Yes | `deriva_ml_list_dataset_members` | |
+| `dataset_history` | Yes | `deriva_ml_get_dataset(include_history=True)` | |
+| `current_version` | Yes | Included in `_summarize_dataset` return | |
+| `get_chaise_url` | Yes | Included in `deriva_ml_get_dataset` return | |
+| `list_dataset_parents` | Yes | `deriva_ml_list_dataset_relations(direction="parents")` | |
+| `list_dataset_children` | Yes | `deriva_ml_list_dataset_relations(direction="children")` | |
+| `list_executions` | No | — | No tool to list executions for a given dataset RID. Gap — callers must filter `deriva_ml_list_executions` by result. |
+| `add_dataset_members` | Yes | `deriva_ml_add_dataset_members` | |
+| `delete_dataset_members` | Yes | `deriva_ml_delete_dataset_members` | |
+| `get_denormalized_as_dict` | Yes | `deriva_ml_denormalize_dataset` | |
+| `get_denormalized_as_dataframe` | No | — | Intentional: DataFrames not serializable to JSON |
+| `describe_denormalized` | Yes | `deriva_ml_denormalize_dataset(describe_only=True)` | |
+| `list_denormalized_columns` | No | — | No direct exposure; callers use `describe_denormalized` |
+| `list_schema_paths` | No | — | Internal schema introspection; rarely needed externally |
+| `cache_denormalized` | No | — | Requires local filesystem; intentional |
+| `to_markdown` / `display_markdown` | No | — | Intentional: presentation-layer, not catalog-state |
+| `prefetch` | No | — | Low-level; no clear LLM use case |
+| `find_features` | Partial | `deriva_ml_list_features` (table filter) | Dataset-scoped feature listing is exposed via the Dataset object's `feature_values` (see below) |
+| `feature_values` | Yes | `deriva_ml_list_feature_values(dataset_rid=...)` | Dataset-scoped |
+
+**ExecutionMixin (`core/mixins/execution.py`)**
+
+| Method | Exposed? | Tool name | Notes |
+|---|---|---|---|
+| `create_execution` | Yes | `deriva_ml_create_execution` | |
+| `lookup_execution` | Yes | `deriva_ml_get_execution` | |
+| `list_executions` | Yes | `deriva_ml_list_executions` | |
+| `pending_summary` | No | — | Workspace-level diagnostic; useful but LLM context unclear |
+| `find_incomplete_executions` | No | — | Gap: useful for recovery workflows; no LLM tool equivalent |
+| `resume_execution` | No (internal) | — | Used internally by start/commit/abort tools; not directly exposed as an "resume" tool, which is correct |
+| `gc_executions` | No | — | Intentional: destructive GC not safe to expose unguarded |
+| `find_executions` | Yes | `deriva_ml_list_executions` + `deriva_ml_find_workflow_executions` | |
+| `lookup_experiment` | Partial | Embedded in `_get_execution_detail_impl` | Not a standalone tool; accessible only via the execution detail resource |
+| `find_experiments` | No | — | Gap: no tool to list experiments independent of executions |
+| `upload_pending` | No | — | Low-level upload path; covered by `commit_execution` |
+
+**Execution class methods (`execution/execution.py`)**
+
+| Method | Exposed? | Tool name | Notes |
+|---|---|---|---|
+| `execution_start` | Yes | `deriva_ml_start_execution` | |
+| `execution_stop` + `upload_execution_outputs` | Yes | `deriva_ml_commit_execution` | Combined into one lifecycle step |
+| `abort` | Yes | `deriva_ml_abort_execution` | |
+| `add_features` | Yes | `deriva_ml_add_feature_values` | Staged via execution |
+| `create_dataset` | Yes | `deriva_ml_create_execution_dataset` | |
+| `add_nested_execution` | Yes | `deriva_ml_add_nested_execution` | |
+| `list_input_datasets` | Yes | Embedded in execution detail resource | |
+| `list_assets` | Yes | Embedded in execution detail resource | |
+| `add_files` | No | — | Intentional: requires local filesystem; file upload is a client-side operation |
+| `upload_assets` | No | — | Same |
+| `download_dataset_bag` | No | — | Same |
+| `asset_file_path` / `metrics_file` | No | — | Filesystem path accessors; MCP server has no local working dir |
+| `pending_summary` | No | — | Low-level; execution internals |
+
+**WorkflowMixin (`core/mixins/workflow.py`)**
+
+| Method | Exposed? | Tool name | Notes |
+|---|---|---|---|
+| `find_workflows` | Yes | `deriva_ml_list_workflows` | |
+| `lookup_workflow` | Yes | `deriva_ml_get_workflow` | |
+| `create_workflow` | Yes | `deriva_ml_create_workflow` | |
+| `lookup_workflow_by_url` | Yes | `deriva_ml_find_workflow_by_url` | |
+| `_add_workflow` | No | — | Internal; not public API |
+
+**FeatureMixin (`core/mixins/feature.py`)**
+
+| Method | Exposed? | Tool name | Notes |
+|---|---|---|---|
+| `create_feature` | Yes | `deriva_ml_create_feature` | |
+| `delete_feature` | Yes | `deriva_ml_delete_feature` | |
+| `lookup_feature` | Yes | `deriva_ml_get_feature` | |
+| `find_features` | Yes | `deriva_ml_list_features` | |
+| `feature_values` | Yes | `deriva_ml_list_feature_values` | |
+| `add_features` | Yes | `deriva_ml_add_feature_values` | Via execution |
+| `feature_record_class` | No | — | Intentional: Python class object; used internally to build records |
+| `fetch_table_features` | No | — | Low-level batch accessor; no clear LLM-facing use |
+| `list_feature_values` | Partial | `deriva_ml_list_feature_values` | Overlaps with `feature_values`; CLAUDE.md notes the distinction |
+| `list_workflow_executions` | No | — | On the Feature object, not the mixin; minor gap |
+| `select_by_workflow` | Yes | Exposed as `selector="by_workflow"` parameter in `deriva_ml_list_feature_values` | |
+
+**AssetMixin (`core/mixins/asset.py`)**
+
+| Method | Exposed? | Tool name | Notes |
+|---|---|---|---|
+| `create_asset` | No | — | Intentional: requires local file staging; out of scope (documented in `asset.py` module docstring) |
+| `list_assets` | Yes | `deriva_ml_list_assets` | |
+| `list_asset_executions` | Partial | Embedded in `_get_asset_detail_impl` via `asset.list_executions()` | Not independently queryable; the asset detail bundles execution refs |
+| `lookup_asset` | Yes | `deriva_ml_lookup_asset` | |
+| `list_asset_tables` | Yes | `deriva_ml_list_asset_tables` | |
+| `find_assets` | No | — | Gap: `list_assets` requires a specific table; `find_assets` does cross-table search. No MCP equivalent for searching across all asset tables |
+| `asset_record_class` | No | — | Python class; intentional |
+
+**VocabularyMixin (`core/mixins/vocabulary.py`)**
+
+All vocabulary operations (`add_term`, `lookup_term`, `list_vocabulary_terms`, `delete_term`) are explicitly delegated to `deriva-mcp-core` per the Boundary Rules. The MCP `registries` resource bundles vocabulary term names for quick reference; the core `add_term` / `delete_term` tools handle mutations. Coverage is correct by design.
+
+**DerivaML base class (`core/base.py`) — catalog administration methods**
+
+| Method | Exposed? | Notes |
+|---|---|---|
+| `refresh_schema` | No | Server-side cache invalidation; no LLM use case |
+| `pin_schema` / `unpin_schema` | No | Schema administration; delegated to `deriva-mcp-core` or `deriva-skills` |
+| `validate_schema` | No | Intentional: schema admin, not ML-domain |
+| `apply_catalog_annotations` | No | Intentional: annotation admin, not ML-domain |
+| `create_vocabulary` | No | Intentional: delegated to `deriva-mcp-core` |
+| `create_table` | No | Intentional: delegated to `deriva-mcp-core` |
+| `clear_cache` | No | Local filesystem; no MCP equivalent needed |
+| `get_cache_size` | No | Same |
+| `list_execution_dirs` | No | Local filesystem |
+| `clean_execution_dirs` | No | Destructive; intentional omission |
+| `get_storage_summary` | No | Local filesystem |
+| `workspace` / `download_dir` | No | Path accessors; filesystem |
+| `pathBuilder` | No | Intentional: query builder, returns Python object |
+| `chaise_url` | No | Covered by individual entity `get_chaise_url()` |
+| `cite` | No | Intentional: Python-session convenience method |
+
+### Coverage summary
+
+- **DatasetMixin**: ~70% of public methods exposed. Gaps: `download_dataset_bag` (intentional), `cache_denormalized` (intentional), `list_schema_paths` / `list_denormalized_columns` (low LLM value), `Dataset.list_executions` (actual gap — see below).
+- **ExecutionMixin**: ~65% exposed. Intentional omissions: `gc_executions`, `upload_pending`, `pending_summary`. Actual gaps: `find_incomplete_executions`, `find_experiments`.
+- **Execution class**: ~60% of public methods exposed. Intentional: file I/O methods, path accessors.
+- **WorkflowMixin**: ~90% exposed (all meaningful public methods). Only internal `_add_workflow` omitted.
+- **FeatureMixin**: ~80% exposed. Minor gap: `list_workflow_executions` on the Feature object.
+- **AssetMixin**: ~55% exposed. Intentional omission: `create_asset` (file staging). Actual gap: `find_assets` for cross-table search.
+- **VocabularyMixin**: 0% directly — correctly delegated to `deriva-mcp-core`. Not a gap.
+- **DerivaML base**: ~10% exposed. Most omissions intentional (filesystem, schema admin, Python-only APIs).
+
+**Most-significant gaps (methods where an LLM would have to work around):**
+
+1. `Dataset.list_executions()` — no tool to list executions that produced a given dataset. Callers must query `deriva_ml_list_executions` and filter manually, or fetch the execution detail resource if they know execution RIDs. A `deriva_ml_list_dataset_executions(dataset_rid)` tool would close this.
+
+2. `AssetMixin.find_assets()` — the only cross-table asset search. `deriva_ml_list_assets` requires a specific `asset_table`. An LLM that doesn't know which table an asset lives in has no tool to discover it by RID or filename cross-table. `find_assets` supports filtering by RID or other criteria across all asset tables.
+
+3. `ExecutionMixin.find_incomplete_executions()` — no tool to surface executions stuck in non-terminal states (Created/Running/Stopped/Pending_Upload). Useful for recovery workflows but not exposed.
+
+4. `ExecutionMixin.find_experiments()` — experiments are accessible via `lookup_experiment` embedded in the execution detail, but there is no tool to list or search experiments independently.
+
+**Things intentionally not exposed (with justification):**
+
+- All file I/O methods (`download_dataset_bag`, `add_files`, `upload_assets`, `cache_denormalized`, etc.): the MCP server runs without a writable local filesystem from the calling user's perspective. These methods require a local working directory. Correct to omit.
+- `pathBuilder()`, `get_table_as_dataframe()`: Python-session objects not serializable to JSON.
+- `gc_executions()`, `clean_execution_dirs()`: destructive maintenance operations that should not be exposed to LLMs without explicit human confirmation workflows.
+- All vocabulary mutations: correctly delegated to `deriva-mcp-core`.
+- All annotation/schema administration methods: correctly delegated to `deriva-mcp-core` / `deriva-skills`.
+
+---
+
+## Top-line findings
+
+1. **Architecture is sound.** The module split, helper factoring, dual-mode policy, and audit + re-index pattern are consistently applied across all five domains. The `_*_impl` shared-helper rule is followed without drift in 10 of 11 resource+tool pairs (`deriva_ml_get_execution` vs `ml/execution/{rid}` being the documented intentional exception where the tool returns a summary, not the full detail).
+
+2. **`execution.py` at 1338 lines is the only oversize file.** It is on the same trajectory that triggered the dataset read/mutate/complex split at ~1745 lines. A read/mutate split for execution would be the natural next structural refactor, but it is not urgent.
+
+3. **Pydantic migration is ~95% complete.** All mutation responses and all list/detail responses from `_*_impl` helpers are Pydantic-typed. Remaining `json.dumps` uses are: (a) argument-validation error returns (structurally fine, no model needed), (b) two read tools with ad-hoc sub-paths (bag_info, dataset_spec, list_dataset_members summary mode, list_dataset_element_types, lookup_workflow_by_url no-result branch). These are post-v2.3 survivors, not regressions.
+
+4. **Three actual coverage gaps worth filing issues for:** (a) `Dataset.list_executions` — no tool to enumerate which executions produced a given dataset; (b) `find_assets` — no cross-table asset search; (c) `find_incomplete_executions` — no tool for recovery-workflow discovery. All other omissions are intentional.
+
+5. **Lazy-import and per-user RAG safety contracts are correctly enforced.** `ctx.rag_dataset_indexer` is never called; all `_reindex_*` imports are inside tool function bodies; the `data:{host}:{cat}:{user_id}:{table}:{rid}` per-RID source naming is used throughout `rag.py`. The CI test pins (`test_register_does_not_use_rag_dataset_indexer`, `test_data_sources_use_per_rid_naming`) cover the regressions that matter most.

--- a/docs/superpowers/notes/audit-2026-04-27-comprehensive.md
+++ b/docs/superpowers/notes/audit-2026-04-27-comprehensive.md
@@ -1,0 +1,388 @@
+# Comprehensive Audit — deriva-ml-mcp + deriva-ml-skills
+
+**Date:** 2026-04-27
+**Scope:** `deriva-ml-mcp` v3.0.0 (MCP plugin) + `deriva-ml-skills` v1.1.0 (Claude Code plugin)
+**Method:** Five independent subagent audits, synthesized below
+**Source documents:**
+- `audit-2026-04-27-architecture.md` — software architecture + deriva-ml API coverage
+- `audit-2026-04-27-tests.md` — test coverage (95% line, 287 tests)
+- `audit-2026-04-27-core-integration.md` — deriva-mcp-core boundary discipline
+- `audit-2026-04-27-skills.md` — skill coverage of tools and workflows
+- `audit-2026-04-27-agent-design.md` — LLM-leverage walkthroughs of 5 user goals
+
+---
+
+## Executive summary
+
+The `deriva-ml-mcp` plugin and its companion `deriva-ml-skills` are in good shape architecturally and well-tested. The plugin holds the contract with `deriva-mcp-core` cleanly, exposes the right ~70-90% of the `deriva-ml` Python API, and gets 95% line coverage from a 287-test suite that pins all 11 v3.0 wire breaks.
+
+The skills layer, however, contains **three documented bugs that will cause runtime failures** when an LLM follows them: a `workflow_name=` parameter that doesn't exist, a `values=` parameter that should be `entries=`, and a `status=`/`message=` argument set on `update_execution` that the tool doesn't accept. These ship in skill text across at least 6 files and represent the highest-severity findings in the audit.
+
+The agent-system design has one structural friction at its core: **no reverse-chronological ordering on list tools** makes "show me the last 5 runs" — one of the most common ML-development queries — expensive on any catalog of meaningful size. Combined with `list_feature_values` materializing all records before pagination, the system has scalability rough edges that will surface as catalogs grow.
+
+The remaining findings are smaller. Coverage gaps in tests are confined to a handful of error paths and reindex-failure swallows. Coverage gaps in tools are three real but bounded missing capabilities (`Dataset.list_executions`, `find_assets` cross-table, `find_incomplete_executions`). Skill content drift from the v3.0 wire breaks exists but is mostly contained.
+
+**Findings sorted by severity:**
+
+| # | Severity | Finding | Source |
+|---|---|---|---|
+| 1 | **Critical (correctness)** | 4 skill content bugs cause tool-call failures | Skills + Agent |
+| 2 | **High (UX)** | No reverse-chrono sort; "last N" requires page-to-end | Agent |
+| 3 | **High (scalability)** | `list_feature_values` materializes all rows pre-pagination | Agent |
+| 4 | **High (UX)** | `resync_indexes` cross-user freshness has zero skill coverage | Skills + Agent |
+| 5 | **Medium (UX)** | `getting_started` prompt is load-bearing but not auto-injected | Agent |
+| 6 | **Medium (correctness)** | 3 missing deriva-ml tools (`list_executions` per dataset, `find_assets`, `find_incomplete_executions`) | Architecture |
+| 7 | **Medium (deployment)** | `deriva-mcp-core` declared without lower-bound version pin | Core integration |
+| 8 | **Medium (test gap)** | 3 resource error paths, 1 preflight branch, 5 reindex-swallow branches untested | Tests |
+| 9 | **Low (technical debt)** | 3 sites access `deriva-ml` private attributes | Core integration |
+| 10 | **Low (technical debt)** | Mock factory duplication across 4 test files | Tests |
+
+---
+
+## 1. Software architecture
+
+### What works
+
+- **Module structure is coherent.** Domain-per-file factoring is consistent (`tools/dataset/{read,mutate,complex}.py`, `tools/feature.py`, `tools/workflow.py`, `tools/execution.py`, `tools/asset.py`). Only `execution.py` at 1338 lines is approaching the threshold that triggered the dataset split (~1745 lines). A future read/mutate split for execution is the natural next refactor but isn't urgent.
+- **`_helpers.py` is genuinely shared** across all five domains (pagination, error envelope, table utilities, RID extraction). No copy-paste duplication.
+- **Dual-mode policy (tools + resources sharing `_*_impl` helpers) is followed in 10 of 11 resource+tool pairs.** The one intentional deviation is `deriva_ml_get_execution` (returns `ExecutionSummary`) vs `ml/execution/{rid}` (returns `ExecutionDetail`). The deviation is documented but the tool docstring should note that callers wanting full detail should use the resource.
+- **The Pydantic response-model migration is ~95% complete after v3.0.** All 25 mutating tools, all `_*_impl` helpers, and all summary helpers return Pydantic instances. Remaining `json.dumps` calls are: argument-validation early returns (which structurally don't need a model) and 4 small read paths (`bag_info`, `get_dataset_spec`, `list_dataset_members` summary mode, `lookup_workflow_by_url` no-result branch).
+- **Audit + re-index pattern is consistently applied.** Every `mutates=True` tool emits `audit_event` on success and routes failures through `_error_envelope` (which emits `<op>_failed`). All catalog-mutating tools call `_reindex_<entity>` after the catalog mutation. Lazy imports inside tool bodies (per the documented anti-circular-import pattern) are followed everywhere.
+- **No cycles, no leaky abstraction of deriva-py exceptions, no orphaned helpers.**
+
+### What needs attention
+
+**`execution.py` size.** At 1338 lines with 11 tools and 5 helpers, this file is on the same trajectory that triggered the dataset split. Not urgent (the file is still readable), but worth keeping on the radar for the next major refactor pass.
+
+**Three `deriva-ml` private-attribute accesses.** Not boundary violations against `deriva-mcp-core`, but real coupling risks:
+- `tools/workflow.py:392`: `ml._add_workflow(wf)`
+- `tools/execution.py:746`: `ml._execution = None`
+- `tools/dataset/mutate.py:529`: `_set_row_description(ml, ml._dataset_table, ...)`
+
+These represent gaps in `deriva-ml`'s public API. They should be tracked as upstream issues in `deriva-ml` to expose proper public methods. A future `deriva-ml` refactor that renames any of these would silently break the plugin.
+
+**`_summarize_upload_dict` returns a plain dict, not Pydantic.** Minor inconsistency with the v2.2 sweep. The dict is immediately wrapped in `CommitExecutionReport(**summary)` so the wire boundary is still typed; but the helper itself is untyped. Cleanup item.
+
+---
+
+## 2. Coverage of `deriva-ml`
+
+### Coverage by mixin
+
+| Mixin | Coverage | Notes |
+|---|---|---|
+| `WorkflowMixin` | ~90% | Only internal `_add_workflow` omitted |
+| `FeatureMixin` | ~80% | Minor gap: `Feature.list_workflow_executions` |
+| `DatasetMixin` (mixin + class) | ~70% | One real gap: `Dataset.list_executions` |
+| `ExecutionMixin` (mixin + class) | ~65% | Two gaps: `find_incomplete_executions`, `find_experiments` |
+| `AssetMixin` | ~55% | One real gap: `find_assets` (cross-table) |
+| `VocabularyMixin` | 0% (delegated to core) | Correct by design |
+| `DerivaML` base | ~10% | Most omissions intentional (filesystem, schema admin, Python-only APIs) |
+
+### Three real coverage gaps worth filing as issues
+
+1. **`Dataset.list_executions(dataset_rid)`** — no tool to enumerate which executions produced (or consumed) a given dataset. Callers must filter `deriva_ml_list_executions` results manually. Useful for "who used this dataset?" lineage queries. Suggested tool: `deriva_ml_list_dataset_executions(dataset_rid=...)`.
+
+2. **`AssetMixin.find_assets()`** — `deriva_ml_list_assets` requires a known `asset_table` argument. There's no cross-table search. An LLM that has a RID or filename and doesn't know which asset table it lives in cannot discover the table without iterating. Suggested tool: `deriva_ml_find_assets(rid=..., filename=..., asset_type=...)`.
+
+3. **`ExecutionMixin.find_incomplete_executions()`** — no tool to surface executions stuck in non-terminal states (`Created`, `Running`, `Stopped`, `Pending_Upload`). Useful for recovery workflows. Suggested tool: `deriva_ml_list_incomplete_executions()`.
+
+### Intentional non-coverage (correct)
+
+All file-I/O methods (`download_dataset_bag`, `add_files`, `upload_assets`, `cache_denormalized`), Python-session objects (`pathBuilder`, DataFrame returns), destructive maintenance (`gc_executions`, `clean_execution_dirs`), and schema/annotation admin are correctly omitted. The MCP server has no writable local filesystem from the calling user's perspective; the rest belong to `deriva-skills` (tier-1) or `deriva-mcp-core`.
+
+---
+
+## 3. Test coverage
+
+### Quantitative
+
+- **287 tests pass, 0 fail, 0 skip.** 14 deselected (integration suite gated by `@pytest.mark.integration`).
+- **95% overall line coverage** (1763 / 1848 statements).
+- **Per-module:** every module ≥ 86% coverage except auto-generated `_version.py`. `_helpers.py` 86%, `resources/ml.py` 95%, `resources/rag.py` 94%, all tool modules 91-100%.
+- **All 11 v3.0 wire breaks are pinned by exact value-level assertions.** This is the strongest part of the suite.
+
+### Qualitative strengths
+
+- **Wire-shape discipline is uniform.** Every test does `payload = json.loads(result)` and asserts on JSON keys/values. No test inspects internal Python state in place of the wire shape.
+- **Audit assertions on both branches.** Every `mutates=True` tool has both a success-path audit assertion (`_success_calls(mock_audit, "deriva_ml_<op>")`) and a failure-path audit assertion (`<op>_failed`). The dual-patch helper handles the two-bind-site problem cleanly.
+- **Async harness is uniform** (`asyncio_mode = "auto"`), no test mixes asyncio with anyio or sync wrappers.
+- **Tests are independent.** Function-scoped fixtures everywhere; `_set_plugin_context(None)` cleanup in `conftest.py`. Running any single file passes standalone.
+- **Test naming and organization are intuitive** — `test_<tool>_<scenario>` with section-comment delimiters. No orphan tests.
+
+### Gaps to close
+
+1. **3 resource error paths untested** — `ml/asset-tables`, `ml/asset/{rid}`, `ml/registries` in `resources/ml.py:320-321, 348-349, 376-377` have no exception-path tests. One test each would close this. Estimated effort: 30 minutes.
+
+2. **`update_workflow` reindex untested** — workflow.py:511-513 calls `_reindex_workflow` on success, but no test asserts it. The analogous `create_workflow` reindex test exists. Same for 4 dataset mutation tools (`add_dataset_members`, `delete_dataset_members`, `update_dataset`, `increment_dataset_version`) which all have untested reindex exception-swallow branches.
+
+3. **`find_workflow_executions` missing preflight test** — execution.py:528-530 is the only uncovered preflight branch across all paginated tools. A two-line test modeled on `test_list_executions_preflight` would close it.
+
+4. **`create_execution_dataset` `dataset_types=None` case** — the v3.0 contract says the field is always present (null when omitted). Only the non-null branch is currently tested.
+
+5. **Mock factory duplication.** `_make_dataset_mock`, `_make_workflow_mock`, and `_make_execution_record_mock` are defined in 2-3 separate test files. A shared `tests/_factories.py` would consolidate them. Negligible runtime impact; matters for maintainability.
+
+### Test design quality
+
+Low brittleness, high assertion specificity, focused fixtures. Two minor exceptions: (a) preflight `action_required` assertions check key presence but not message content (a broken preflight returning empty string would pass), and (b) error-path tests use substring matching on exception messages (`assert "kaboom" in payload["error"]`), which is slightly brittle to rewording.
+
+---
+
+## 4. `deriva-mcp-core` integration
+
+### Boundary discipline — fully compliant
+
+- **Connection management** centralized in `ml_context.py` via `get_request_credential()`. No raw catalog opens.
+- **Auth/credential handling** entirely delegated to core. No `os.environ` reads, no `keyring`.
+- **Audit machinery** entirely from `deriva_mcp_core.telemetry`. No competing implementation.
+- **RAG per-user safety contract is the most rigorous item.** `ctx.rag_dataset_indexer` is provably unused (two CI pins: one at the plugin level, one at the RAG module level). Per-RID source naming is pinned end-to-end. The `vocab:` prefix carve-out for catalog-public content is separately pinned. This is the most security-sensitive boundary and it is the most thoroughly tested.
+- **Vocabulary primitives** delegated to core's `add_term`/`lookup_term`/`delete_term`. The plugin's `tools/maintenance.py` ships only RAG-indexing tools (`reindex_vocabularies`, `resync_indexes`), not term CRUD.
+- **Generic Deriva primitives** never duplicated. Where a low-level write is needed (Asset/Dataset description has no setter in `deriva-ml`), the plugin uses `ml.pathBuilder()` — `deriva-ml` API, not raw ERMrest.
+
+### Plugin-authoring-guide conformance — fully compliant
+
+- All 46 tool registrations carry explicit `mutates=True/False` (no bare `@ctx.tool()` that would raise `TypeError` at startup).
+- All DERIVA I/O wrapped in `with deriva_call():`.
+- All mutating tools emit audit on both success and failure (failure path centralized in `_error_envelope`, which makes it structurally impossible to forget).
+- Tool naming, prompt naming, and audit event naming all follow the `deriva_ml_<op>` convention.
+
+### Findings
+
+**Two upstream-tracked gaps:**
+- `# TODO(upstream-rag-doctype)` in `resources/rag.py:428, 903` — tracks `deriva-mcp-core#2` (no per-table `doc_type` filter on RAG chunks).
+- `# TODO(deriva-ml-execution-metadata-api)` in `tools/execution.py:275` — no `deriva-ml` API to enumerate `Execution_Metadata` files. The `ml/execution/{rid}` resource omits the `metadata` key as a result. This is a `deriva-ml` upstream gap, not a `deriva-mcp-core` one.
+
+**Version-pinning concern.** `pyproject.toml:26` declares `deriva-mcp-core` with no version constraint. In development the `[tool.uv.sources]` editable-install path covers this, but a published release could be installed against a too-old core that lacks `resolve_user_identity`, `get_rag_store`, etc. **Recommend adding a lower-bound pin** like `"deriva-mcp-core>=<current-version>"`.
+
+**Import-surface contract uncertainty.** Five RAG-extension imports from internal submodule paths (`deriva_mcp_core.rag.chunker`, `.data`, `.store`) are not enumerated as stable public exports in core's `__init__.py`. If core reorganizes its RAG package, the plugin's import paths break. Either confirm these paths are intentionally stable, or request that core re-exports them from `deriva_mcp_core.rag`.
+
+---
+
+## 5. Skills coverage
+
+### What works
+
+- **Tool coverage is broad.** 41 of 43 mutating/reading tools (excluding the two maintenance tools) are mentioned by at least one skill. Most are covered by 3-7 skills with clear primary teaching skills.
+- **`api-naming-conventions`, `dataset-lifecycle`, `execution-lifecycle`, `create-feature`, `troubleshoot-execution`, `model-development-workflow`** form a solid primary teaching set covering the major workflows.
+- **Cross-references between skills are consistent.** `execution-lifecycle` correctly points to `dataset-lifecycle`, `create-feature`, `ml-data-engineering`, `configure-experiment`, etc. Tier-1 references use the `(tier-1; deriva-skills)` annotation convention.
+- **`deriva-ml-context` (always-on) carries its load-bearing role correctly.** The steering principle (DerivaML abstractions > raw primitives), the stateless model, and the vocabulary-extension pattern are all present and accurate. This skill alone prevents the most common LLM mistake: using raw entity CRUD for ML domain objects.
+
+### What's broken
+
+**Critical: skill content bugs that will cause tool-call failures.**
+
+1. **`workflow_name=` phantom parameter.** `model-development-workflow/SKILL.md` (lines 146, 191) passes `workflow_name=` to `deriva_ml_create_execution`. The actual parameter is `workflow_rid=`. An LLM following this skill will produce a tool call that errors immediately. **Fix:** rename to `workflow_rid=` in both call sites.
+
+2. **`values=` vs `entries=` mismatch.** `create-feature/SKILL.md` (lines 166-188) uses `values=` in all `deriva_ml_add_feature_values` examples. The actual parameter is `entries=`. **Fix:** rename to `entries=` in all examples.
+
+3. **`update_execution` accepts `status=`/`message=` (false).** Multiple skill files document the call signature `deriva_ml_update_execution(..., status="Failed", message="...")`. The actual tool only accepts `description=`. Status changes go through `start_execution`/`commit_execution`/`abort_execution`. Affected files:
+   - `troubleshoot-execution/SKILL.md:129`
+   - `execution-lifecycle/references/workflow.md:38, 123`
+   - `execution-lifecycle/references/concepts.md:114, 120`
+   - `run-notebook/references/workflow.md:262`
+   - `api-naming-conventions/SKILL.md:179`
+
+4. **Phantom `status` field in `denormalize_dataset` example.** `ml-data-engineering/references/denormalize-guide.md:91` shows `"status": "success"` in a `deriva_ml_denormalize_dataset` response. The tool has no `status` field — it uses `mode` as the discriminator.
+
+**Two completely orphan tools.**
+
+5. **`deriva_ml_reindex_vocabularies`** has zero skill coverage. After adding/removing vocabulary terms via core's `add_term`/`delete_term`, this tool must be called to refresh the RAG vocab index. Skills teach term addition (via `add_term`) but never mention the follow-up reindex.
+
+6. **`deriva_ml_resync_indexes`** has zero skill coverage. This is the documented v1.4 cross-user freshness bridge — when user B needs to see user A's mutations to shared-visible datasets, this tool refreshes B's per-user RAG sources. The plugin's CLAUDE.md explicitly documents this as the manual bridge for the cross-user staleness gap, but no skill surfaces it. **The most impactful UX gap in the system.** A user experiencing "I can't see the dataset my colleague just created" has no skill-level guidance.
+
+**Smaller skill issues.**
+
+7. **`deriva_ml_cache_dataset(asset_rid="...")`** — `manage-storage/SKILL.md:184` shows an `asset_rid=` argument. The actual parameter is `dataset_rid=`. Minor but real.
+
+8. **Singular vs plural in `deriva-ml-context`.** The abstractions table lists `deriva_ml_add_feature_value` (singular). Correct name is `deriva_ml_add_feature_values` (plural).
+
+9. **Skill count discrepancy.** CLAUDE.md mentions 24 tier-2 skills; the actual count is 23. Off-by-one in the prose.
+
+### Workflow coverage scorecard
+
+10 ML/catalog workflows scored:
+
+| # | Workflow | Status |
+|---|---|---|
+| 1 | Create dataset from catalog data | ✅ Covered |
+| 2 | Register new model architecture | ⚠ Partial — missing Git URL/checksum recipe |
+| 3 | Run training execution | ✅ Covered |
+| 4 | Define + record features | ✅ Covered |
+| 5 | Compare model runs | ⚠ Partial — pieces exist in separate skills, no synthesis |
+| 6 | Cache dataset locally | ✅ Covered |
+| 7 | Split dataset (train/test/val) | ✅ Covered |
+| 8 | Recover from failed execution | ✅ Covered (with bug #3 above) |
+| 9 | Cross-user dataset visibility | ❌ Not covered |
+| 10 | Explore unfamiliar catalog | ⚠ Partial — pieces in individual skills, no first-visit recipe |
+
+**Score: 4/10 fully covered, 4/10 partially, 2/10 not.**
+
+Most-impactful gaps to close:
+- **Workflow 9 (cross-user visibility).** A `cross-user-data-sync` skill (or a section in `troubleshoot-execution`) that says "when collaborator changes are missing, call `deriva_ml_resync_indexes`" would close this.
+- **Workflow 5 (compare runs).** A "compare model runs" section in `create-feature` or `execution-lifecycle` showing the find-executions → query-features-per-execution → aggregate pattern.
+- **Workflow 2 (register workflow).** A concrete recipe for computing `git rev-parse HEAD` and the GitHub URL before calling `deriva_ml_create_workflow`.
+
+---
+
+## 6. Agent-system design
+
+This is the most consequential perspective: does the surface give an LLM enough leverage to do real work? The answer is **mostly yes, with three structural friction points and the four content bugs already named**.
+
+### Per-goal scores
+
+| Goal | Score | Top friction |
+|---|---|---|
+| 1 — Explore unfamiliar catalog | 3/5 | No cold-start prompt auto-injection; schema discovery leaks to tier-1 |
+| 2 — Develop new model | 3/5 | `workflow_name` phantom; `entries`/`values` mismatch in skills |
+| 3 — Compare model runs | **2/5** | No reverse-sort on list tools; no cross-execution feature query |
+| 4 — Manage catalog growth | 3/5 | `metadata=` naming ambiguity; schema RAG re-index gap after feature creation |
+| 5 — Recover from failure | 3/5 | Bogus `status=` option in `troubleshoot-execution` |
+
+The lowest score (Goal 3, comparing runs) reflects two structural issues that aren't bugs but are real frictions:
+
+### The three structural frictions
+
+**A. No reverse-chronological ordering on list tools.** Every `list_*` tool paginates by RID ascending. Finding "the last 5 executions" on a catalog of any meaningful size requires either:
+- A preflight count, then paging to the end (expensive and round-trip-heavy), or
+- Reliance on RAG freshness (subject to the cross-user freshness gap)
+
+This is a real UX cliff for what should be the most natural ML-development query. Adding `sort_desc=True` or `order="desc"` to `list_executions` (and ideally all list tools) would eliminate it. Estimated implementation effort: medium — needs upstream `deriva-ml` support for descending iteration, or post-fetch reversal with a cap.
+
+**B. `list_feature_values` materializes all rows before pagination.** `records = list(ds.feature_values(...))` loads everything into memory, then paginates the list. On a catalog with millions of feature values this will OOM or timeout before the LLM ever sees a page. Even `preflight_count=True` triggers full materialization. **This is a known scalability cliff.** Solutions: server-side cursor in `deriva-ml`, or a tool-level guard that refuses to materialize beyond a threshold and returns a clear "use a server-side query" error.
+
+**C. No cross-execution feature value query primitive.** Comparing metrics across 5 runs requires 5 sequential `list_feature_values(selector="by_execution", ...)` calls + in-context aggregation. There's no "give me the F1 score from each of these executions" tool. For comparison workflows this means N+1 round-trips and N×payload context cost. A `deriva_ml_compare_executions(execution_rids=[...], feature_name=..., column=...)` tool would close this — the use case is concrete and the cost is bounded.
+
+### Tool design — strong overall, two blind spots
+
+**Strong:**
+- `deriva_ml_` prefix is consistent and prevents tier-1 collisions.
+- Verb clarity is high (`create`/`list`/`get`/`find`/`delete`/`add`/`update`/`commit`/`abort`).
+- Pagination contract is uniform across all list tools.
+- Status enum values are enumerated in the execution-lifecycle prompt and in tool docstrings.
+- Inline error messages for state-machine rejections are excellent (e.g., `"cannot start execution in state Stopped; only Created (will start) or Running (no-op) are valid"`).
+
+**Two blind spots:**
+- **`metadata=` parameter naming on `create_feature`.** Accepts `list[str | dict]` for "extra scalar or FK columns added to the feature table." The name "metadata" is ambiguous — sounds like key-value metadata about the feature itself, not extra columns. The skill explains this; the tool docstring doesn't.
+- **`workflow_type=` valid values not enumerated in docstring.** `create_workflow` accepts `str | list[str]` but the docstring says "Each must be a term in the `Workflow_Type` vocabulary" without listing terms. Vocabulary varies per catalog so the docstring can't enumerate them all, but pointing to `registries` resource or `list_vocabulary_terms` would help. The LLM has to do a prior lookup or risk an FK violation.
+
+### Resource utility
+
+Resources are used in skills but unevenly:
+- `execution-lifecycle`: 3 resource references
+- `dataset-lifecycle`: 2 resource references
+- `create-feature`: 0 resource references (uses RAG + typed tools)
+- `troubleshoot-execution`: 1 resource reference
+- `model-development-workflow`: 0 resource references
+
+The `getting_started` prompt enumerates 10 resource URIs cleanly. Skills lean toward typed tools, which is defensible (tools handle errors uniformly) but means resources are underused. Resources are typically faster (one network call) and return richer detail (execution detail bundles inputs+outputs+experiment). The `execution-lifecycle` skill correctly points to the detail resource for post-run verification.
+
+**Underused resources:** `ml/asset/{rid}` and `ml/asset-tables` are only mentioned in the prompt, never in `work-with-assets`.
+
+### Prompts — three load-bearing, three missing
+
+**The 3 existing prompts are good:**
+- **`deriva_ml_getting_started`** (the most important) is comprehensive: stateless model, pagination contract, error envelope, five domains, resource URIs, RAG patterns, name resolution, mutation chain, asset I/O split. ~370 lines but dense and mostly non-redundant. **Without this prompt the LLM operates on 45+ tools with no grounding** — but the prompt is not auto-injected. Either users invoke it explicitly or the always-on `deriva-ml-context` skill must trigger.
+- **`deriva_ml_execution_lifecycle`** correctly describes the state machine, the lifecycle tools, the hybrid dispatch on `add_feature_values`, and the two pitfalls.
+- **`deriva_ml_workflow_dedup`** is short and correct; the anti-pattern/correct-pattern pair is exactly what's needed.
+
+**Three prompts that should exist:**
+- **`deriva_ml_feature_design`** — feature design mental model (term vs asset vs scalar, single vs multi-column, selector strategy). Currently only in the `create-feature` skill, which the LLM may not load.
+- **`deriva_ml_dataset_versioning`** — semantic versioning, when to bump, how to pin in configs. Currently spread across 3 skills.
+- **`deriva_ml_rag_freshness`** — the cross-user freshness gap and `resync_indexes` recovery. Easy to miss in the getting-started prompt.
+
+### Provenance + reproducibility
+
+**The surface makes provenance hard to skip by accident:**
+- `add_feature_values` requires `execution_rid=`.
+- `create_execution_dataset` requires `execution_rid=`.
+- The `deriva-ml-context` skill explicitly warns against raw `insert_entities`.
+- `dry_run=True` is the documented "test without recording" path.
+
+**One soft gap:** `deriva_ml_create_dataset` does not require an execution context. Datasets can be created without provenance linkage. This is correct for bootstrap (the first dataset of a project has no prior execution to link to), but it's the one place an LLM can accidentally skip provenance.
+
+**Hard gap:** `DerivaMLDirtyWorkflowError` is enforced by `deriva-ml-run` (the CLI) but not by MCP execution tools. An LLM driving the lifecycle entirely through MCP can create executions without a clean git state. The provenance record won't have a verifiable git hash. The skills document this; the tools can't enforce it.
+
+### Failure modes specific to LLMs
+
+| Hallucination type | Protection? |
+|---|---|
+| RID hallucination | Tool returns `{"error": ...}`; skills steer to lookup-before-operate |
+| Feature/column name hallucination | `rag_search` and `list_features` cover this; skills teach the lookup-first pattern |
+| Vocabulary term hallucination | Catalog FK violation propagates; error text isn't always actionable |
+| Status enum hallucination | Python enum error text propagates; valid values are in the prompt |
+| **Skill-induced phantom params** | **No protection — skills tell the LLM to use parameters that don't exist** |
+
+The last row is the most dangerous because it's the hardest to recover from. An LLM that gets `{"error": "unexpected keyword argument 'workflow_name'"}` will likely retry rather than question whether the skill text is wrong.
+
+---
+
+## Action items (prioritized)
+
+### Critical — fix before any new user onboards
+
+1. **Fix the `workflow_name=` phantom parameter** in `model-development-workflow/SKILL.md` (rename to `workflow_rid=`).
+2. **Fix the `values=` → `entries=` rename** in `create-feature/SKILL.md`.
+3. **Fix the `update_execution(status=, message=)` false signature** across 5 files (remove the option entirely; redirect to `abort_execution`).
+4. **Fix the phantom `status` field in `denormalize_dataset`** example in `ml-data-engineering/references/denormalize-guide.md`.
+
+These are 4 file edits totaling maybe 20 lines of content. They prevent runtime tool-call failures.
+
+### High — close the largest UX gaps
+
+5. **Add a `cross-user-data-sync` skill** (or a section in `troubleshoot-execution`) covering `deriva_ml_resync_indexes`. This closes Workflow 9 and surfaces orphan tool #6.
+6. **Add a `compare-model-runs` section** to `create-feature` or `execution-lifecycle` that synthesizes find-executions → query-features-per-execution → aggregate.
+7. **Auto-inject the `getting_started` prompt** into the `deriva-ml-context` always-on skill, so an LLM doesn't depend on the user invoking it.
+
+### High — close the structural frictions
+
+8. **Add `sort_desc=True` (or `order=`) to `list_executions`** (and ideally all list tools). The "last N runs" query is the most common ML-development pattern; the current design forces an expensive workaround.
+9. **Add a server-side cursor or pre-materialization guard to `list_feature_values`.** OOM on millions of rows is a real risk.
+10. **Add a `compare_executions` tool** for cross-execution feature value queries.
+
+### Medium — coverage gaps
+
+11. **File three deriva-ml-mcp issues:**
+   - `deriva_ml_list_dataset_executions(dataset_rid)` for dataset → executions lineage
+   - `deriva_ml_find_assets(rid=, filename=, ...)` for cross-table asset search
+   - `deriva_ml_list_incomplete_executions()` for recovery workflows
+
+12. **Three test-coverage micro-gaps:**
+   - 3 resource error-path tests (`ml/asset-tables`, `ml/asset/{rid}`, `ml/registries`)
+   - 1 `find_workflow_executions` preflight test
+   - `update_workflow` reindex assertion + 4 `_reindex_dataset` exception-swallow tests
+
+13. **Add `deriva-mcp-core` lower-bound version pin** to `pyproject.toml`.
+
+### Low — technical debt
+
+14. **Track three deriva-ml private-attribute accesses as upstream issues** (`ml._add_workflow`, `ml._execution`, `ml._dataset_table`). Either expose proper public methods upstream, or document the workarounds with explicit deriva-ml version compatibility notes.
+
+15. **Consolidate mock factories** into `tests/_factories.py` to remove duplication across `test_dataset.py`, `test_resources.py`, `test_execution.py`, `test_workflow.py`.
+
+16. **Sweep `_summarize_upload_dict` to return Pydantic** for v2.2 consistency. Minor.
+
+17. **Add three new prompts** (`deriva_ml_feature_design`, `deriva_ml_dataset_versioning`, `deriva_ml_rag_freshness`).
+
+18. **Update CLAUDE.md** to fix the 24-vs-23 skill-count off-by-one and update the resource-count from 9 to 11 in `resources/ml.py` module docstring.
+
+---
+
+## What's notably good
+
+To balance the action-item list, three things deserve explicit recognition:
+
+1. **The RAG per-user safety contract is exemplary.** The architectural decision to ban `ctx.rag_dataset_indexer` (which would leak per-user ACL rows), the per-RID source-naming scheme, the vocab `vocab:` prefix carve-out, and the dual CI pins enforcing both the ban and the naming scheme — this is the most security-sensitive boundary in the system and it's the most thoroughly tested. The plugin's `CLAUDE.md` explains the rationale clearly enough that a future contributor can't accidentally regress.
+
+2. **The v3.0 wire-break test coverage is unusually disciplined.** All 11 wire breaks are pinned by exact value-level assertions. This is the kind of contract testing that prevents silent regressions; most projects this size have a few wire breaks that drift undetected.
+
+3. **`deriva-ml-context` is the right load-bearing always-on skill.** The steering principle ("DerivaML abstractions take precedence over raw catalog primitives") is stated cleanly with six concrete reasons, the stateless model is explained, and the vocabulary-extension pattern is correct. This single skill prevents the most common LLM mistake in deriva-ml-loaded catalogs.
+
+---
+
+## Cross-document references
+
+- Architecture details + per-mixin coverage tables: `audit-2026-04-27-architecture.md`
+- Test coverage report + per-module breakdown: `audit-2026-04-27-tests.md`
+- Boundary discipline + plugin-authoring-guide conformance: `audit-2026-04-27-core-integration.md`
+- Skill coverage matrix (40 tools × 23 skills) + workflow-by-workflow notes: `audit-2026-04-27-skills.md`
+- Per-goal LLM walkthroughs + tool-by-tool design notes: `audit-2026-04-27-agent-design.md`

--- a/docs/superpowers/notes/audit-2026-04-27-core-integration.md
+++ b/docs/superpowers/notes/audit-2026-04-27-core-integration.md
@@ -1,0 +1,412 @@
+# deriva-mcp-core Integration Audit -- deriva-ml-mcp
+
+**Date:** 2026-04-27
+**Auditor:** Claude Sonnet 4.6 (independent automated audit)
+**Scope:** `deriva-ml-mcp` v3.0.0 against `deriva-mcp-core` plugin-authoring-guide contract
+
+---
+
+## Part A: Boundary Discipline
+
+### Connection management
+
+COMPLIANT.
+
+`ml_context.py` is the single gateway: `get_ml(hostname, catalog_id)` calls
+`get_request_credential()` from core and passes the credential to `DerivaML(...)`. No
+tool module opens a raw `ErmrestCatalog` or `DerivaServer` connection directly. The
+module docstring explicitly names this as the enforced pattern.
+
+One ambiguity worth noting: `tools/workflow.py:392` calls `ml._add_workflow(wf)` and
+`tools/execution.py:746` nulls out `ml._execution`. These are private attributes on
+the `DerivaML` object (not on `PluginContext`), so they are not a core-boundary
+violation -- they are plugin-to-deriva-ml coupling. That is a separate concern and is
+addressed in Part C.
+
+### Auth / credential handling
+
+COMPLIANT.
+
+No `os.environ` reads for tokens, no `keyring` imports, no direct reads or writes to
+`~/.deriva/credential.json`. The only auth-adjacent code is in `ml_context.py:11`:
+
+```python
+from deriva_mcp_core import get_request_credential
+```
+
+This is the documented sanctioned path. Integration tests read `os.environ.get("DERIVA_HOST",
+"localhost")` in `conftest.py` for the test server hostname, which is correct test
+infrastructure, not auth handling.
+
+### Audit machinery
+
+COMPLIANT.
+
+The plugin does NOT define its own audit machinery. All audit calls go through:
+
+```python
+from deriva_mcp_core.telemetry import audit_event
+```
+
+imported at module level in `_helpers.py:45`, `tools/asset.py:53`,
+`tools/dataset/__init__.py:56`, `tools/execution.py:30`, `tools/feature.py:23`,
+`tools/workflow.py:24`. The `_error_envelope` helper in `_helpers.py:107` centralizes
+failure-path audit emission for all mutating tools. No competing audit implementation
+was found.
+
+### RAG subsystem (per-user safety)
+
+COMPLIANT. Both the architectural requirement and the CI pin are in place.
+
+The plugin deliberately avoids `ctx.rag_dataset_indexer(...)`. `resources/rag.py:40-46`
+explains the rationale explicitly in the module docstring: the global enriched-source
+API leaks per-user ACL rows. Instead the plugin uses `ctx.on_catalog_connect(...)` with
+direct `store.delete_source + store.add` writes under per-RID source names
+(`data:{host}:{cat}:{user_id}:{table}:{rid}` shape, established in v1.3).
+
+The required CI pin exists and runs:
+
+- `tests/test_plugin.py:309` -- `test_register_does_not_use_rag_dataset_indexer` --
+  asserts `len(ctx._rag_dataset_indexers) == 0` after `register(ctx)`.
+- `tests/test_plugin.py:393` -- `test_data_sources_use_per_rid_naming` -- fires each
+  hook with mocked fetchers and asserts every produced source name matches the v1.3
+  shape.
+- `tests/test_rag.py:100` -- a second assertion `rag_ctx._rag_dataset_indexers == []`
+  at the RAG-module registration level.
+
+The vocab path (`resources/rag.py:855-864`) writes under `vocab:{hostname}:{catalog_id}:{qname}`
+to bypass upstream's per-user filter, which is the documented correct carve-out for
+catalog-public content. `tests/test_plugin.py:328` pins that vocab chunks never land
+under `data:`.
+
+### Vocabulary primitives
+
+COMPLIANT. `tools/vocabulary.py` does NOT exist -- the module was renamed to
+`tools/maintenance.py` in v1.4. The maintenance module ships exactly two tools:
+
+- `deriva_ml_reindex_vocabularies` (`mutates=False`) -- re-indexes the RAG vector store
+  from vocab table data via `_index_vocabularies` in `resources/rag.py`. No term CRUD.
+- `deriva_ml_resync_indexes` (`mutates=False`) -- refreshes per-user RAG sources after
+  cross-user mutations. No term CRUD.
+
+Neither tool duplicates core's `add_term` / `lookup_term` / `delete_term`. The plugin
+delegates all term CRUD to core as documented. `resources/ml.py:357-383` provides a
+read-only `ml/registries` resource that calls `ml.list_vocabulary_terms(...)` for
+snapshot display -- also not term CRUD.
+
+### Generic Deriva primitives
+
+COMPLIANT.
+
+No re-implementation of entity CRUD (`insert_records`, `update_record`, `get_entities`),
+schema introspection, or Hatrac operations was found. The plugin exclusively uses the
+`DerivaML` high-level API (via `get_ml()`). Where a low-level write was needed and the
+DerivaML API lacked it (`Asset.description` and `Dataset.description` have no write-
+through setter), the plugin uses `_set_row_description` in `_helpers.py:250-287`, which
+calls `ml.pathBuilder()` -- this is `deriva-ml` API, not raw ERMrest. The docstring
+flags this as an upstream gap in `deriva-ml` (not `deriva-mcp-core`).
+
+---
+
+## Part B: Plugin-Authoring-Guide Conformance
+
+### `mutates=` discipline
+
+COMPLIANT.
+
+Every `@ctx.tool(...)` decorator in the plugin carries an explicit `mutates=True` or
+`mutates=False`. Verified across all six tool modules (46 total registrations):
+
+- `tools/execution.py`: 5 `mutates=False`, 7 `mutates=True`
+- `tools/dataset/read.py`: 7 `mutates=False`
+- `tools/dataset/mutate.py`: 7 `mutates=True`
+- `tools/dataset/complex.py`: 1 `mutates=True` (`cache_dataset`); `denormalize` and
+  `split` are also `mutates=True`
+- `tools/workflow.py`: 3 `mutates=False`, 2 `mutates=True`
+- `tools/feature.py`: 3 `mutates=False`, 3 `mutates=True`
+- `tools/asset.py`: 3 `mutates=False`, 1 `mutates=True`
+- `tools/maintenance.py`: 2 `mutates=False`
+
+No bare `@ctx.tool()` decorators (which would raise `TypeError` at startup) were found.
+
+### `with deriva_call():` discipline
+
+COMPLIANT.
+
+Every tool function that performs DERIVA I/O wraps it in `with deriva_call():`. The
+pattern is consistent across all tool modules. Resources (`resources/ml.py`) likewise
+wrap all `get_ml()` + data-fetch calls in `with deriva_call():`. The maintenance tools
+(`tools/maintenance.py:112`, `206`) wrap their `_index_vocabularies` /
+`_resync_user_sources` calls, even though those helpers call into `get_ml()` themselves
+-- defensive double-coverage.
+
+One nuance: the `_reindex_*` helpers in `resources/rag.py` are called from within the
+already-established `deriva_call()` block of the mutating tools that trigger them
+(e.g. `tools/execution.py:763-771`), and are also reachable from the on-connect hooks
+where no `deriva_call()` wraps them at the hook level. The hooks are fire-and-forget
+background tasks -- the guide does not require `deriva_call()` in background hooks, and
+hook failures are logged and suppressed per the framework contract. This is acceptable.
+
+### Audit-on-success / audit-on-failure discipline
+
+COMPLIANT. Five mutating tools sampled:
+
+**`deriva_ml_create_execution` (`execution.py:672`)**
+- Success: `audit_event("deriva_ml_create_execution", ...)` at line 752. Dry-run
+  skips audit intentionally (documented at line 748: no catalog state changed).
+- Failure: `_error_envelope(exc, operation="create_execution", ...)` at line 781,
+  which emits `deriva_ml_create_execution_failed`.
+
+**`deriva_ml_create_workflow` (`workflow.py:302`)**
+- Success: `audit_event("deriva_ml_create_workflow", ...)` at line 394.
+- Failure: `_error_envelope(exc, operation="create_workflow", ...)` at line 425.
+
+**`deriva_ml_add_dataset_members` (`dataset/mutate.py`)**
+- Success: `_pkg.audit_event(...)` at line 201.
+- Failure: `_error_envelope` via `_pkg` at the `except` block.
+
+**`deriva_ml_update_workflow` (`workflow.py:434`)**
+- Success: `audit_event("deriva_ml_update_workflow", ...)` at line 500.
+- Failure: `_error_envelope(exc, operation="update_workflow", ...)` at line 525.
+
+**`deriva_ml_update_asset` (`asset.py:409`)**
+- Success: `audit_event(...)` at line 495.
+- Failure: routed through `_error_envelope` (confirmed by grep pattern at line 405
+  comment).
+
+All five confirm the dual-path pattern. The `_error_envelope` helper centralizes the
+failure-path emission (`_helpers.py:107`) so the pattern cannot silently break if a
+tool fails to add its own `except` block.
+
+### Audit event naming convention
+
+COMPLIANT.
+
+All success-path audit events follow `deriva_ml_<operation>` exactly:
+`"deriva_ml_create_execution"`, `"deriva_ml_create_workflow"`, `"deriva_ml_update_workflow"`,
+etc. Failure events are emitted by `_error_envelope` as `f"deriva_ml_{operation}_failed"`
+(line 108: `f"deriva_ml_{operation}_failed"`). The `operation` parameter passed by each
+tool is the bare verb without prefix (e.g., `"create_execution"`, `"create_workflow"`),
+and the helper prepends `deriva_ml_`. This is consistent with the guide's
+`<plugin_name>_<operation>` convention where `plugin_name = "deriva_ml"`.
+
+### Tool/prompt naming convention
+
+COMPLIANT.
+
+All 46 tools follow the `deriva_ml_<verb>` prefix (full list confirmed via grep).
+All 3 prompts follow the same convention: `deriva_ml_getting_started`,
+`deriva_ml_execution_lifecycle`, `deriva_ml_workflow_dedup` (`prompts.py:603`, `613`,
+`623`). No tool or prompt name deviates from this prefix.
+
+---
+
+## Part C: Integration Touch-Points
+
+### Plugin entry point
+
+COMPLIANT. `plugin.py:register(ctx)` is clean:
+
+```python
+def register(ctx: PluginContext) -> None:
+    _dataset.register(ctx)
+    _feature.register(ctx)
+    _workflow.register(ctx)
+    _execution.register(ctx)
+    _asset.register(ctx)
+    _maintenance.register(ctx)
+    _ml_resources.register(ctx)
+    _ml_rag.register_rag_sources(ctx)
+    _ml_prompts.register(ctx)
+```
+
+Pure dispatch to per-domain registrars. Synchronous. No side effects at module scope.
+`PluginContext` is TYPE_CHECKING-guarded so the import is lazy at runtime (only needed
+at type-check time, not during plugin loading before core is fully initialized).
+
+### PluginContext usage
+
+LARGELY COMPLIANT, with one ambiguity in tests.
+
+Plugin production source (`src/`) never accesses private `ctx._*` attributes. All
+interaction with `ctx` is through documented public methods: `ctx.tool(...)`,
+`ctx.resource(...)`, `ctx.prompt(...)`, `ctx.on_catalog_connect(...)`,
+`ctx.rag_github_source(...)`.
+
+Tests (`tests/conftest.py:24`, `tests/test_plugin.py:279`, `325`, `349`, `431-433`,
+`tests/test_rag.py:60`, `79`, `84`, `95`, `100`) access `ctx._rag_dataset_indexers`,
+`ctx._rag_sources`, `ctx._catalog_connect_hooks`, and `ctx._mcp`. These private
+attributes are used exactly as the plugin-authoring-guide's own test examples show
+(`ctx._mcp.tools["tool_name"]` on page 598 of the guide, `_set_plugin_context` at
+page 536). The guide canonizes this pattern for test code, so this is intended use.
+
+One distinct private API is `_set_plugin_context` (imported from
+`deriva_mcp_core.plugin.api` in `conftest.py:24`). This is a leading-underscore
+function from core's public-ish testing surface -- the guide itself shows this exact
+import and usage in the "Fixtures" section. Ambiguous whether this is a contract
+violation or a documented testing escape hatch; the guide treats it as the latter.
+
+**Note on DerivaML private access (not a core boundary issue):** Three sites access
+private `deriva_ml.DerivaML` internals:
+- `tools/workflow.py:392`: `ml._add_workflow(wf)` -- undocumented `deriva-ml` API.
+- `tools/execution.py:746`: `ml._execution = None` -- nulls a private DerivaML field.
+- `tools/dataset/mutate.py:529`: `_set_row_description(ml, ml._dataset_table, ...)`.
+
+These are `deriva-ml` contract issues, not `deriva-mcp-core` boundary violations.
+They represent API gaps in `deriva-ml` that forced the plugin to reach into internals.
+
+### Resource URI scheme
+
+COMPLIANT. All 11 resources (the module docstring lists 11 but the code registers 11)
+follow `deriva://catalog/{hostname}/{catalog_id}/ml/...`:
+
+```
+deriva://catalog/{hostname}/{catalog_id}/ml/datasets
+deriva://catalog/{hostname}/{catalog_id}/ml/dataset/{dataset_rid}
+deriva://catalog/{hostname}/{catalog_id}/ml/dataset/{dataset_rid}/members
+deriva://catalog/{hostname}/{catalog_id}/ml/workflows
+deriva://catalog/{hostname}/{catalog_id}/ml/workflow/{workflow_rid}
+deriva://catalog/{hostname}/{catalog_id}/ml/executions
+deriva://catalog/{hostname}/{catalog_id}/ml/execution/{execution_rid}
+deriva://catalog/{hostname}/{catalog_id}/ml/features/{table_name}
+deriva://catalog/{hostname}/{catalog_id}/ml/asset-tables
+deriva://catalog/{hostname}/{catalog_id}/ml/asset/{asset_rid}
+deriva://catalog/{hostname}/{catalog_id}/ml/registries
+```
+
+All 11 are namespaced under `ml/`. None escape the `ml/` namespace. (The module
+docstring says 9 but the code has 11 -- the docstring was not updated when `asset-tables`,
+`asset/{rid}`, and `registries` were added. Minor doc drift, not a contract violation.)
+
+### Error envelope shape
+
+COMPLIANT.
+
+`_error_envelope` in `_helpers.py:114` returns `json.dumps({"error": str(exc)})`,
+optionally extended with `response_fields`. The base shape is `{"error": "..."}`, which
+matches the guide's example at page 128-129. Validation errors from Pydantic models are
+caught by the `except Exception` block in each tool and routed through `_error_envelope`,
+so they surface as `{"error": "..."}` consistently. Resources use the same helper with
+`audit=False`.
+
+### Lazy import patterns
+
+COMPLIANT.
+
+The authoring guide requires imports of `get_catalog`, `deriva_call`, etc. inside tool
+function bodies, not at `register()` scope, so test patches resolve at call time.
+
+In practice, this plugin uses `DerivaML` (via `get_ml()`) rather than raw `get_catalog`,
+so the lazy-import requirement is satisfied by `get_ml(...)` being called inside each
+tool body. The `deriva_call` import at module level (e.g., `from deriva_mcp_core import
+deriva_call` in `execution.py:29`) is safe because `deriva_call` is a context manager
+class, not a function that reads request state -- it does not capture credential context
+at import time.
+
+The per-RID re-indexers (`_reindex_dataset`, `_reindex_workflow`, `_reindex_execution`)
+ARE imported lazily inside tool bodies (e.g., `execution.py:764`: `from deriva_ml_mcp.resources.rag
+import _reindex_execution`). The CLAUDE.md calls this out explicitly as the correct
+pattern to avoid circular imports during plugin loading. Similarly, `maintenance.py:116`
+lazily imports `_index_vocabularies`, and `maintenance.py:210` lazily imports
+`_resync_user_sources`.
+
+---
+
+## Part D: Forward/Upstream Compatibility
+
+### Open upstream issues
+
+Two tracked upstream gaps found:
+
+1. **`# TODO(upstream-rag-doctype)`** -- `resources/rag.py:428` and `resources/rag.py:903`.
+   Tracked as `deriva-mcp-core#2`: `index_table_data` should accept a `doc_type`
+   parameter so per-table RAG chunks can be filtered by `rag_search(doc_type="ml-dataset")`
+   etc. Until then, all chunks land under `doc_type="catalog-data"`. Both sites carry
+   the issue reference inline.
+
+2. **`# TODO(deriva-ml-execution-metadata-api)`** -- `tools/execution.py:275`. No
+   generic `deriva-ml` API exists to enumerate `Execution_Metadata` files. Until an
+   upstream enumerator exists, the `ml/execution/{rid}` resource omits the `metadata`
+   key. This is a `deriva-ml` gap, not a `deriva-mcp-core` gap.
+
+The CLAUDE.md also references `deriva-mcp-core#3` (core's `add_term`/`delete_term`
+tools don't fire any lifecycle hook, so vocab RAG goes stale after term edits). This
+gap is addressed in the plugin via the manual `deriva_ml_reindex_vocabularies` tool
+bridge. No inline `# TODO` for this one -- it is handled, not deferred.
+
+No other `# TODO(upstream-...)` markers were found.
+
+### Version pinning
+
+POTENTIAL CONCERN.
+
+`pyproject.toml:26` declares `"deriva-mcp-core"` with no version constraint -- fully
+unpinned. In development, the `[tool.uv.sources]` stanza (`pyproject.toml:57`) points
+to a local path `../deriva-mcp-core` (editable install), which implicitly pins to
+whatever version is checked out locally. For published releases, the absence of a lower-
+bound constraint (e.g., `"deriva-mcp-core>=1.0"`) means the plugin could be installed
+against a too-old core that lacks `resolve_user_identity`, `get_rag_store`, or other
+symbols the plugin imports. This is a deployment risk, not a correctness issue in the
+current workspace where both are developed together.
+
+The guide's own example shows `"deriva-mcp-core>=0.1"`, which is still loose but at
+least establishes a floor. Recommend adding a lower-bound pin.
+
+### Import-surface contract
+
+MOSTLY COMPLIANT. The full set of imported symbols from `deriva_mcp_core`:
+
+| Symbol | Import path | Visibility |
+|---|---|---|
+| `get_request_credential` | `deriva_mcp_core` (`__init__.py`) | Public |
+| `deriva_call` | `deriva_mcp_core` (`__init__.py`) | Public |
+| `audit_event` | `deriva_mcp_core.telemetry` | Public (submodule) |
+| `PluginContext` | `deriva_mcp_core.plugin.api` | Public (plugin API) |
+| `resolve_user_identity` | `deriva_mcp_core.context` | Ambiguous |
+| `get_rag_store` | `deriva_mcp_core.rag` | Ambiguous |
+| `chunk_markdown` | `deriva_mcp_core.rag.chunker` | Ambiguous |
+| `RowSerializer` | `deriva_mcp_core.rag.data` | Ambiguous |
+| `Chunk` | `deriva_mcp_core.rag.store` | Ambiguous |
+| `_set_plugin_context` | `deriva_mcp_core.plugin.api` | **Private** (leading `_`) |
+
+`_set_plugin_context` is the only leading-underscore import. It appears only in
+`tests/conftest.py:24`, not in production source. The authoring guide itself uses this
+symbol in its "Fixtures" section (guide page 536), making it a documented testing
+escape hatch. It is not a production code contract violation.
+
+The five `deriva_mcp_core.rag.*` imports (`resolve_user_identity`, `get_rag_store`,
+`chunk_markdown`, `RowSerializer`, `Chunk`) are internal submodule paths without leading
+underscores. They are not listed as stable public exports in core's `__init__.py`. If
+core reorganizes its RAG package (e.g. moves `RowSerializer` to a different submodule),
+the plugin's import paths break. This is the RAG extension's natural API surface -- the
+authoring guide documents the RAG extension pattern but does not enumerate which specific
+submodule paths are stable. **Recommendation:** confirm with core maintainers that these
+five paths are intentionally stable, or request that core re-exports them from a
+top-level `deriva_mcp_core.rag` namespace.
+
+---
+
+## Top-line Findings
+
+- **Boundary discipline is excellent.** Connection management, auth, audit machinery,
+  vocabulary primitives, and generic Deriva primitives are all clean -- no duplication.
+  The single-gateway `ml_context.py` design holds throughout the codebase.
+
+- **The RAG per-user safety contract is well-enforced.** `ctx.rag_dataset_indexer`
+  is provably unused (CI pin), per-RID source naming is pinned end-to-end (CI pin),
+  and vocab indexing correctly uses the `vocab:` prefix carve-out. This is the most
+  security-sensitive boundary and it is the most thoroughly tested.
+
+- **Plugin-authoring-guide conformance is complete.** All 46 tools carry explicit
+  `mutates=`, all DERIVA I/O is wrapped in `deriva_call()`, all mutating tools emit
+  audit on both success and failure via the centralized `_error_envelope` pattern, and
+  all tool/prompt names follow the `deriva_ml_` prefix.
+
+- **Three `deriva-ml` private-attribute accesses are the most significant
+  technical-debt items** (`ml._add_workflow`, `ml._execution`, `ml._dataset_table`).
+  These are not `deriva-mcp-core` boundary violations but they represent fragile
+  coupling to `deriva-ml` internals that could silently break on a `deriva-ml` refactor.
+
+- **Version pinning is absent.** `deriva-mcp-core` is declared without a lower-bound
+  version. For a published package this is a deployment risk; recommend
+  `"deriva-mcp-core>=<current-compatible-version>"`.

--- a/docs/superpowers/notes/audit-2026-04-27-skills.md
+++ b/docs/superpowers/notes/audit-2026-04-27-skills.md
@@ -1,0 +1,333 @@
+# deriva-ml-skills Audit
+
+**Date:** 2026-04-27
+**Scope:** `deriva-ml-skills` (23-skill Claude Code plugin) against `deriva-ml-mcp` v3.0 tool/resource surface.
+
+---
+
+## Part A: Tool Coverage by Skills
+
+### The 23 skills (one-line each)
+
+**User-invocable (`/deriva-ml:<name>`):**
+
+- `dataset-lifecycle` — End-to-end dataset operations: create, populate, split, version, browse, download BDBags.
+- `debug-bag-contents` — Diagnose missing data in BDBag exports (FK traversal, missing tables, materialization issues).
+- `execution-lifecycle` — Full execution lifecycle: pre-flight, create, start, work, commit/abort, nested, CLI.
+- `troubleshoot-execution` — Recovery guide for stuck, failed, or incomplete DerivaML executions.
+- `create-feature` — Feature design, creation, value insertion with provenance, selectors, browsing.
+- `work-with-assets` — File asset discovery, download, upload, provenance, asset-type tagging.
+- `manage-storage` — Local cache inspection, cleanup, pre-fetching, cache-vs-working-dir guidance.
+- `configure-experiment` — Hydra-zen experiment project setup, config groups, DerivaModelConfig.
+- `write-hydra-config` — Write and validate hydra-zen config files (DatasetSpecConfig, asset_store, builds).
+- `new-model` — Scaffold a new DerivaML model function and wire it to configs and workflows.
+- `model-development-workflow` — End-to-end project progression: schema → small dataset → dry run → production.
+- `setup-notebook-environment` — Install Jupyter kernel, uv sync, nbstripout, Deriva auth for notebooks.
+- `run-notebook` — Create, develop, and run DerivaML Jupyter notebooks with execution tracking.
+- `route-run-workflows` — Router: configure, create notebooks, write configs, debug ML workflows.
+- `route-project-setup` — Router: versions, environment setup, bag export troubleshooting, dev environment.
+- `check-deriva-ml-versions` — Check and update the DerivaML ecosystem (lib, MCP plugin, skills plugin).
+- `help` — General orientation for DerivaML, Deriva, and what Claude can help with.
+
+**Always-on (auto-invoked):**
+
+- `deriva-ml-context` — Plugin-wide steering: five abstractions, precedence principle, stateless model.
+- `maintain-experiment-notes` — Silently append tacit decisions to `experiment-decisions.md` after any consequential action.
+- `catalog-operations-workflow` — Steer toward committed Python scripts for catalog-modifying operations.
+- `api-naming-conventions` — Reference for `lookup_` vs `find_` vs `list_` vs `create_` etc. method prefixes.
+- `ml-data-engineering` — Get data OUT of DerivaML INTO ML pipelines: restructure, denormalize, DatasetBag.
+- `generate-scripts` — Generate committed or ephemeral Python scripts for catalog operations.
+
+**Note:** CLAUDE.md says 24 tier-2 skills in the Architecture section but the marketplace and skill directory both show 23. The discrepancy appears to be an off-by-one in the CLAUDE.md prose.
+
+### Tool coverage matrix
+
+**Dataset domain (17 tools)**
+
+| Tool | Mentioned in skills |
+|---|---|
+| `deriva_ml_list_datasets` | api-naming-conventions, dataset-lifecycle, troubleshoot-execution |
+| `deriva_ml_get_dataset` | api-naming-conventions, dataset-lifecycle, debug-bag-contents, execution-lifecycle, ml-data-engineering, model-development-workflow, troubleshoot-execution, write-hydra-config |
+| `deriva_ml_list_dataset_members` | api-naming-conventions, dataset-lifecycle, debug-bag-contents, ml-data-engineering |
+| `deriva_ml_list_dataset_relations` | api-naming-conventions, dataset-lifecycle |
+| `deriva_ml_list_dataset_element_types` | api-naming-conventions, dataset-lifecycle |
+| `deriva_ml_bag_info` | api-naming-conventions, dataset-lifecycle, debug-bag-contents, execution-lifecycle, manage-storage, ml-data-engineering, model-development-workflow, troubleshoot-execution, work-with-assets |
+| `deriva_ml_get_dataset_spec` | api-naming-conventions, dataset-lifecycle, debug-bag-contents, model-development-workflow, troubleshoot-execution |
+| `deriva_ml_create_dataset` | api-naming-conventions, dataset-lifecycle, deriva-ml-context, model-development-workflow, write-hydra-config |
+| `deriva_ml_delete_dataset` | api-naming-conventions, dataset-lifecycle, debug-bag-contents |
+| `deriva_ml_add_dataset_members` | api-naming-conventions, dataset-lifecycle, debug-bag-contents, deriva-ml-context, model-development-workflow, troubleshoot-execution |
+| `deriva_ml_delete_dataset_members` | api-naming-conventions, dataset-lifecycle, debug-bag-contents |
+| `deriva_ml_update_dataset` | api-naming-conventions, dataset-lifecycle |
+| `deriva_ml_add_dataset_element_type` | api-naming-conventions, dataset-lifecycle, debug-bag-contents, model-development-workflow |
+| `deriva_ml_increment_dataset_version` | api-naming-conventions, create-feature, dataset-lifecycle, debug-bag-contents, deriva-ml-context, model-development-workflow, troubleshoot-execution, write-hydra-config |
+| `deriva_ml_cache_dataset` | deriva-ml-context, execution-lifecycle, manage-storage, model-development-workflow |
+| `deriva_ml_denormalize_dataset` | api-naming-conventions, create-feature, dataset-lifecycle, debug-bag-contents, generate-scripts, ml-data-engineering, model-development-workflow |
+| `deriva_ml_split_dataset` | create-feature, dataset-lifecycle, maintain-experiment-notes, ml-data-engineering, model-development-workflow, troubleshoot-execution, write-hydra-config |
+
+**Execution domain (11 tools)**
+
+| Tool | Mentioned in skills |
+|---|---|
+| `deriva_ml_list_executions` | api-naming-conventions, execution-lifecycle, troubleshoot-execution |
+| `deriva_ml_get_execution` | api-naming-conventions, configure-experiment, execution-lifecycle, manage-storage, model-development-workflow, troubleshoot-execution, work-with-assets |
+| `deriva_ml_find_workflow_executions` | api-naming-conventions, dataset-lifecycle, execution-lifecycle, model-development-workflow, work-with-assets |
+| `deriva_ml_list_execution_children` | api-naming-conventions, configure-experiment, execution-lifecycle, model-development-workflow, troubleshoot-execution |
+| `deriva_ml_list_execution_parents` | api-naming-conventions, configure-experiment, execution-lifecycle, model-development-workflow, troubleshoot-execution |
+| `deriva_ml_create_execution` | api-naming-conventions, create-feature, dataset-lifecycle, deriva-ml-context, execution-lifecycle, manage-storage, model-development-workflow, troubleshoot-execution, work-with-assets |
+| `deriva_ml_start_execution` | create-feature, dataset-lifecycle, deriva-ml-context, execution-lifecycle, model-development-workflow, troubleshoot-execution, work-with-assets |
+| `deriva_ml_commit_execution` | create-feature, dataset-lifecycle, deriva-ml-context, execution-lifecycle, model-development-workflow, troubleshoot-execution, work-with-assets |
+| `deriva_ml_update_execution` | api-naming-conventions, deriva-ml-context, execution-lifecycle, run-notebook, troubleshoot-execution |
+| `deriva_ml_abort_execution` | create-feature, dataset-lifecycle, deriva-ml-context, execution-lifecycle, run-notebook, troubleshoot-execution, work-with-assets |
+| `deriva_ml_create_execution_dataset` | api-naming-conventions, execution-lifecycle, troubleshoot-execution |
+| `deriva_ml_add_nested_execution` | api-naming-conventions, execution-lifecycle, troubleshoot-execution |
+
+**Feature domain (6 tools)**
+
+| Tool | Mentioned in skills |
+|---|---|
+| `deriva_ml_list_features` | api-naming-conventions, create-feature, dataset-lifecycle, ml-data-engineering, troubleshoot-execution |
+| `deriva_ml_get_feature` | api-naming-conventions, create-feature, model-development-workflow, troubleshoot-execution |
+| `deriva_ml_list_feature_values` | api-naming-conventions, create-feature, ml-data-engineering, model-development-workflow |
+| `deriva_ml_create_feature` | api-naming-conventions, create-feature, deriva-ml-context, maintain-experiment-notes, troubleshoot-execution |
+| `deriva_ml_delete_feature` | api-naming-conventions, create-feature |
+| `deriva_ml_add_feature_values` | api-naming-conventions, create-feature, deriva-ml-context, execution-lifecycle, model-development-workflow |
+
+**Workflow domain (5 tools)**
+
+| Tool | Mentioned in skills |
+|---|---|
+| `deriva_ml_list_workflows` | api-naming-conventions, configure-experiment, execution-lifecycle |
+| `deriva_ml_get_workflow` | api-naming-conventions |
+| `deriva_ml_find_workflow_by_url` | api-naming-conventions, deriva-ml-context, execution-lifecycle, troubleshoot-execution |
+| `deriva_ml_create_workflow` | api-naming-conventions, create-feature, dataset-lifecycle, deriva-ml-context, execution-lifecycle, troubleshoot-execution, write-hydra-config |
+| `deriva_ml_update_workflow` | api-naming-conventions, execution-lifecycle |
+
+**Asset domain (4 tools)**
+
+| Tool | Mentioned in skills |
+|---|---|
+| `deriva_ml_list_asset_tables` | api-naming-conventions, deriva-ml-context, work-with-assets |
+| `deriva_ml_list_assets` | api-naming-conventions, work-with-assets |
+| `deriva_ml_lookup_asset` | api-naming-conventions, dataset-lifecycle, deriva-ml-context, execution-lifecycle, model-development-workflow, work-with-assets, write-hydra-config |
+| `deriva_ml_update_asset` | api-naming-conventions, deriva-ml-context, work-with-assets |
+
+**Maintenance domain (2 tools)**
+
+| Tool | Mentioned in skills |
+|---|---|
+| `deriva_ml_reindex_vocabularies` | **NONE** |
+| `deriva_ml_resync_indexes` | **NONE** |
+
+**Resources (11 resources)**
+
+All 11 resources under `deriva://catalog/{h}/{c}/ml/...` are referenced in the skills — the execution-lifecycle and dataset-lifecycle skills both list the resource URIs explicitly. The `registries` resource is specifically called out in `execution-lifecycle` SKILL.md.
+
+### Orphan tools (no skill mentions)
+
+- **`deriva_ml_reindex_vocabularies`** — Zero skill mentions. This tool is needed after adding/removing vocabulary terms via `add_term`/`delete_term`. The gap matters because skills do teach adding vocabulary terms (via the generic `add_term` call) but never mention that a `derive_ml_reindex_vocabularies` call is needed afterward.
+- **`deriva_ml_resync_indexes`** — Zero skill mentions. This is the documented cross-user freshness bridge (v1.4). The `CLAUDE.md` for `deriva-ml-mcp` explicitly calls this out as the manual bridge for cross-user staleness, but no skill surfaces it to the LLM.
+
+### Orphan skills (no tool calls)
+
+All 23 skills either reference `deriva_ml_*` tools directly, or are router/context/reference skills that intentionally contain no tool calls:
+
+- `route-run-workflows` — Pure router, delegates to other skills. No tool calls is correct.
+- `route-project-setup` — Pure router. No tool calls is correct.
+- `help` — Orientation skill. No tool calls is correct.
+- `setup-notebook-environment` — Environment setup; uses shell commands, not `deriva_ml_*` tools. Correct.
+- `check-deriva-ml-versions` — Calls Python version check script, not MCP tools. Correct.
+- `api-naming-conventions` — Reference card, no workflow. Correct.
+
+No skills are orphaned in the problematic sense.
+
+---
+
+## Part B: Workflow Coverage
+
+### Workflow 1: Create dataset from catalog data
+
+**Status: Covered end-to-end.**
+
+`dataset-lifecycle` SKILL.md covers: check element types (`deriva_ml_list_dataset_element_types`), add element type if missing (`deriva_ml_add_dataset_element_type`), create execution, `deriva_ml_create_dataset`, `deriva_ml_add_dataset_members` with both `member_rids` and `members_by_table` forms, then `deriva_ml_increment_dataset_version`. The references directory has detailed workflow.md and concepts.md with concrete examples. The `derive-ml-context` also mentions the key tools.
+
+**Minor gap:** No explicit guidance on when to call `add_term` to add a new `Dataset_Type` before creating the dataset, or that `deriva_ml_reindex_vocabularies` should follow.
+
+### Workflow 2: Register a new model architecture as a workflow
+
+**Status: Partially covered.**
+
+`execution-lifecycle` covers `deriva_ml_create_workflow` with dedup behavior and mentions `deriva_ml_find_workflow_by_url` for pre-check. The `new-model` and `configure-experiment` skills cover the Python-side scaffold. However, the skills do not guide the LLM on computing the Git URL and checksum locally (the "Boundary rule" in the MCP source states "the caller computes the Git URL, checksum, and version locally and passes them in — the MCP server never runs git introspection"), so there is no end-to-end example of `git rev-parse HEAD` → URL construction → `deriva_ml_create_workflow` call. `deriva_ml_update_workflow` is mentioned only in `api-naming-conventions` and `execution-lifecycle` without meaningful context.
+
+**Missing:** Concrete recipe for computing Git checksum and URL from a local repo before registering.
+
+### Workflow 3: Running a training execution
+
+**Status: Covered end-to-end.**
+
+`execution-lifecycle` covers all six phases: pre-flight (validate RIDs, check cache, stage data), create execution, start, do work (Python API for I/O), commit or abort. The three paths (MCP tools, Python API, CLI) are all documented. `troubleshoot-execution` covers recovery paths. Code examples exist in both SKILL.md and the references directory.
+
+### Workflow 4: Defining and recording features (model evaluation outputs)
+
+**Status: Covered end-to-end.**
+
+`create-feature` covers: semantic-search-first discovery (`rag_search`), deciding whether a feature is needed vs a column, designing term/value/asset columns, `deriva_ml_create_feature`, `deriva_ml_get_feature` for schema inspection, `deriva_ml_add_feature_values` with the hybrid dispatch (Created vs Running state), and querying with selectors via `deriva_ml_list_feature_values`. The references directory has detailed concepts.md and feature-selectors.md.
+
+### Workflow 5: Comparing model runs
+
+**Status: Partially covered.**
+
+`execution-lifecycle` and `model-development-workflow` both mention `deriva_ml_find_workflow_executions` and `deriva_ml_list_executions` with status filtering. `create-feature` covers querying feature values per execution with `selector="by_execution"`. However, there is no skill that ties these together into a comparison workflow: "find executions of workflow X, for each execution get feature values with `selector='by_execution'`, compare metrics." The pieces exist in separate skills; an LLM doing a first-time comparison would need to compose from multiple skill loads.
+
+**Missing:** A dedicated "compare runs" section in either `create-feature` or `execution-lifecycle` that shows the end-to-end query pattern.
+
+### Workflow 6: Caching a dataset locally for offline training
+
+**Status: Covered end-to-end.**
+
+`execution-lifecycle` (pre-flight section), `manage-storage`, and `model-development-workflow` all cover `deriva_ml_cache_dataset`. The `manage-storage` skill gives the full pre-flight sequence (bag_info → cache if needed → verify materialized). Cache status values (`not_cached`, `cached_metadata_only`, `cached_materialized`, `cached_incomplete`) are documented.
+
+**Minor v3.0 gap:** `manage-storage` SKILL.md line 82 mentions `cache_path` as a top-level field: `- \`cache_path\`: where it lives on disk`. In v3.0, bag-info keys were moved under `bag_info` nested key for `cache_dataset`, but `deriva_ml_bag_info` (read tool) still returns `cache_path` top-level — this may be correct for that tool. Needs verification.
+
+### Workflow 7: Splitting a dataset for train/test/val
+
+**Status: Covered end-to-end.**
+
+`dataset-lifecycle` covers `deriva_ml_split_dataset` with all major parameters: `test_size`, `val_size`, `stratify_by_column`, `dry_run`, element table auto-detection. Stratified split guidance is present. The `write-hydra-config` skill also mentions split as a tracked operation.
+
+### Workflow 8: Recovering from a failed execution
+
+**Status: Covered.**
+
+`troubleshoot-execution` has a dedicated "I Need to Resume an Aborted Execution" section. It explicitly documents that `restore_execution` has no equivalent and provides the workaround: inspect prior execution → create fresh execution with same config → link via description. The SKILL.md also covers "Execution Stuck in Running" and "Files Not Uploaded" scenarios.
+
+**Bug:** Line 129 of `troubleshoot-execution/SKILL.md` says `deriva_ml_update_execution(hostname, catalog_id, execution_rid, status="Failed", message="Manually marked as failed")`. This is wrong — `deriva_ml_update_execution` only accepts `description`, not `status` or `message`. Status changes must go through `abort_execution` or `commit_execution`. The same incorrect signature appears in `execution-lifecycle/references/workflow.md`, `run-notebook/references/workflow.md`, `execution-lifecycle/references/concepts.md`, and `api-naming-conventions/SKILL.md`.
+
+### Workflow 9: Cross-user dataset visibility (resync_indexes)
+
+**Status: Not covered.**
+
+`deriva_ml_resync_indexes` is mentioned nowhere in the skills. The `deriva-ml-mcp` CLAUDE.md explicitly documents this as the v1.4 bridge for cross-user freshness (when user B needs to see user A's mutations). There is no skill that tells the LLM when or how to call it. The only related text is in the `CLAUDE.md` workspace notes, which Claude does not load in normal conversation.
+
+This is the most significant user-facing gap: a user experiencing "I can't see the dataset my colleague just created" has no skill-level guidance to reach for `deriva_ml_resync_indexes`.
+
+### Workflow 10: Exploring an unfamiliar catalog
+
+**Status: Partially covered.**
+
+`deriva-ml-context` sets up the five abstractions and provides pointers to domain skills. The `help` skill covers orientation. The `ml-data-engineering` skill covers `deriva_ml_denormalize_dataset` for wide-table exploration. The skills recommend `rag_search` as the discovery mechanism.
+
+**Missing:** No explicit "here is how to start if you know nothing about this catalog" walkthrough. The canonical discovery order (read `deriva://catalog/{h}/{c}/ml/registries` → browse workflows → look at datasets → explore features on tables) is mentioned in individual skills but never synthesized into a first-visit recipe. The `help` skill could carry this.
+
+### Workflow coverage summary
+
+- 4/10 fully covered: workflows 3 (training execution), 4 (features), 6 (caching), 7 (splitting).
+- 4/10 partially covered: workflows 1 (dataset creation — minor vocab gap), 2 (workflow registration — missing Git URL recipe), 5 (comparing runs — missing synthesis), 10 (catalog exploration — missing first-visit recipe).
+- 2/10 not covered: workflow 8 is largely covered but has a concrete API bug; workflow 9 (cross-user visibility) has zero coverage.
+
+---
+
+## Part C: Skill Design Quality
+
+### Granularity
+
+The 23 skills are well-sized overall. A few observations:
+
+- **`execution-lifecycle`** is large (the SKILL.md alone is ~180 lines plus 3 reference files). It could be split into "running-mcp-executions" and "running-cli-executions" but the current structure with references works reasonably well because the primary SKILL.md stays focused on decision points.
+- **`route-run-workflows`** and **`route-project-setup`** are thin routers that overlap slightly. Both mention version checks, bag export troubleshooting, and environment setup. A user asking "how do I get started" might hit either one. The routing logic in descriptions could be tighter.
+- **`api-naming-conventions`** is always-on and comprehensive. The risk is that it duplicates information already in domain skills (the `lookup_` vs `find_` table is useful but large for an always-on context).
+- **`generate-scripts`** and **`catalog-operations-workflow`** partly overlap: both steer toward Python scripts over interactive tool use. The boundary (`generate-scripts` generates the script text; `catalog-operations-workflow` teaches when to use that pattern) is logical but may not be clear from descriptions alone.
+
+### Discoverability (frontmatter descriptions)
+
+Most descriptions are strong and follow the "ALWAYS use when X, triggers on: Y" pattern. Specific concerns:
+
+- **`deriva_ml_get_workflow`** has minimal skill coverage (only `api-naming-conventions` mentions it). An LLM asked "show me the details of workflow 1-WF" has no skill that explicitly teaches when to use this tool versus reading the resource URI. This is a coverage gap, not a discoverability gap, but it manifests because no skill uses `deriva_ml_get_workflow` as its primary teaching example.
+- **`troubleshoot-execution`** has `user-invocable: false` and `disable-model-invocation: true`. The description says "ALWAYS use when a DerivaML execution fails." These flags are contradictory for an "ALWAYS use" skill — if model invocation is disabled, the LLM must explicitly load it. Check that the flags are correct.
+- **`debug-bag-contents`** description is appropriately scoped to export issues. However it is not in the "user-invocable" list in the CLAUDE.md Architecture section (it only lists user-invocable skills by name, and debug-bag-contents is not there). The frontmatter does not have `user-invocable: false`, so it should be user-invocable — CLAUDE.md's omission is just a documentation gap.
+- **`help`** description says "ALWAYS prefer this skill for general 'what/how/why' questions about the DerivaML ecosystem before routing to more specific skills." The word "ALWAYS" combined with a broad trigger set risks over-triggering; it may fire on queries that should go directly to `execution-lifecycle` or `dataset-lifecycle`.
+
+### Cross-references
+
+Cross-references are strong. Domain skills consistently point to related skills:
+
+- `execution-lifecycle` references `dataset-lifecycle`, `create-feature`, `ml-data-engineering`, `configure-experiment`, `write-hydra-config`, `run-notebook`.
+- `create-feature` references `dataset-lifecycle` and `execution-lifecycle`.
+- `troubleshoot-execution` correctly separates tier-2 errors from tier-1 (generic catalog) errors with explicit `/deriva:troubleshoot-deriva-errors` references.
+- Tier-1 references use the `(tier-1; deriva-skills)` annotation convention as documented in CLAUDE.md.
+
+The main gap: no skill cross-references the maintenance tools (`reindex_vocabularies`, `resync_indexes`), so the cross-reference web does not surface them even indirectly.
+
+### Code examples
+
+Code examples are present throughout and generally concrete. The `execution-lifecycle` skill has especially strong examples covering all three paths (MCP tools, Python API, CLI). The `create-feature` and `dataset-lifecycle` skills both include realistic tool calls with actual RID shapes.
+
+One concern: `manage-storage/SKILL.md` line 184 shows `deriva_ml_cache_dataset(hostname=..., asset_rid="3WSE")` — this tool does not have an `asset_rid` parameter (it has `dataset_rid`). This is an incorrect example.
+
+### Failure-mode coverage
+
+Failure modes are well-covered for the main workflows. `troubleshoot-execution` is dedicated to failure recovery. `execution-lifecycle` has a "Critical Rules" section. `dataset-lifecycle` mentions what happens when element types are not registered. `create-feature` covers the case where a feature already exists.
+
+The main failure-mode gap is in `work-with-assets`: the skill covers discovery, download, and upload at a high level but does not give concrete recovery guidance for common asset upload failures (timeout, permission denied on hatrac, asset already exists at path).
+
+### v3.0 API drift risk
+
+Three concrete v3.0-era drift issues found:
+
+1. **`status="success"` in `deriva_ml_denormalize_dataset` example** — `ml-data-engineering/references/denormalize-guide.md` line 91 shows `"status": "success"` in the response JSON for `deriva_ml_denormalize_dataset`. This tool's response does NOT have a `status` field at all (it uses `mode` as the top-level discriminator). This is a phantom field that does not exist in the actual v3.0 wire shape.
+
+2. **`deriva_ml_update_execution` accepts `status` and `message` (false)** — Multiple skills document the call signature `deriva_ml_update_execution(hostname, catalog_id, execution_rid, status="Failed", message="...")`. This is incorrect: the tool only accepts `description`. Files affected:
+   - `troubleshoot-execution/SKILL.md:129`
+   - `execution-lifecycle/references/workflow.md:38, 123`
+   - `execution-lifecycle/references/concepts.md:114, 120`
+   - `run-notebook/references/workflow.md:262`
+   - `api-naming-conventions/SKILL.md:179`
+
+   This is the highest-severity drift issue: an LLM following this guidance will call the tool with the wrong parameters and get an error.
+
+3. **`cache_path` as top-level field** — `manage-storage/SKILL.md:82` lists `cache_path` as a direct response field of `deriva_ml_bag_info`. In v3.0, `cache_path` moved under the `bag_info` sub-object for `derive_ml_cache_dataset`. For `derive_ml_bag_info` (the read tool), `cache_path` may still be top-level — the source code shows `return json.dumps(info, default=str)` which passes through whatever `ml.bag_info()` returns. This should be verified against the actual `bag_info` return shape, but may be correct for the read tool.
+
+---
+
+## Part D: deriva-ml-context skill
+
+**File:** `/Users/carl/GitHub/DerivaML/deriva-ml-skills/skills/deriva-ml-context/SKILL.md`
+
+### Steering principle coverage
+
+The skill correctly carries the load-bearing principle: "In a deriva-ml-loaded catalog you must use the deriva-ml abstractions for them — the `deriva_ml_*` MCP tools listed above and the deriva-ml Python API — NOT the raw `insert_entities` / `update_entities` / `get_entities` core tools from `deriva-mcp-core`."
+
+It enumerates six concrete reasons why raw primitives are wrong (business logic bypass, FK validation, provenance tracking, version management, RAG re-indexing, audit emission). This is thorough and actionable.
+
+### Structure for LLM internalization
+
+The skill is well-structured for an always-on context:
+
+- Opens with a concise "What is DerivaML?" paragraph.
+- Presents the five abstractions in a scannable table with primary skill pointers and key MCP tools per abstraction.
+- Explains the stateless model (always pass hostname= and catalog_id=).
+- Delivers the steering principle with a concrete enumeration of what gets bypassed.
+- Explains how to extend built-in vocabularies (the `add_term` generic approach since dedicated extender tools were removed).
+- Closes with a "when to reach back to raw catalog surface" section that draws the tier-1/tier-2 boundary cleanly.
+
+### Observations
+
+- The `disable-model-invocation: false` flag is correct for an always-on skill.
+- The trigger set in the description is appropriately broad: it matches on 'derivaml', 'deriva-ml', 'dataset', 'workflow', 'execution', etc.
+- One potential issue: the table lists `deriva_ml_add_feature_value` (singular) in the Feature row, but the correct tool name is `deriva_ml_add_feature_values` (plural). This is a minor naming inconsistency but unlikely to cause runtime errors since the detailed instructions in `create-feature` use the correct plural form.
+- The skill correctly notes that the 24-skill count in CLAUDE.md is inconsistent with the actual 23 skills (implied by stating "~24 skills").
+
+Overall, `deriva-ml-context` is the most carefully written skill in the plugin. It delivers its steering purpose clearly and would be internalized effectively by an LLM.
+
+---
+
+## Top-line findings
+
+1. **Two maintenance tools are completely invisible.** `deriva_ml_reindex_vocabularies` and `deriva_ml_resync_indexes` have zero skill coverage. The cross-user freshness gap (workflow 9) is the most impactful consequence: users experiencing stale RAG views from collaborator edits have no documented path to resolution. Both tools need at least a single skill mention with a trigger scenario.
+
+2. **`deriva_ml_update_execution` is documented with a false signature across at least 5 skill files.** The skills claim it accepts `status=` and `message=` parameters; the actual tool only accepts `description=`. Any LLM following this guidance will generate a failing tool call. This is the highest-severity correctness bug in the skill set.
+
+3. **The cross-user workflow coverage gap is total.** Workflow 9 (cross-user visibility / `resync_indexes`) is taught nowhere. The `deriva-ml-mcp` CLAUDE.md documents it as a known limitation with a manual bridge — that bridge needs a skill or at least a mention in `execution-lifecycle` or `troubleshoot-execution`.
+
+4. **Core workflow coverage is solid.** 8 of 10 workflows have meaningful coverage (4 fully, 4 partially). The execution lifecycle, feature lifecycle, dataset operations, and caching workflows are particularly well-documented with concrete examples and cross-skill reinforcement.
+
+5. **`deriva-ml-context` is the strongest skill and correctly carries its load-bearing role.** The steering principle (DerivaML abstractions > raw primitives), the stateless model explanation, and the vocabulary extension pattern are all present and accurate. This skill alone prevents the most common LLM mistake (using raw entity CRUD for ML domain objects).

--- a/docs/superpowers/notes/audit-2026-04-27-tests.md
+++ b/docs/superpowers/notes/audit-2026-04-27-tests.md
@@ -1,0 +1,215 @@
+# Test Coverage Audit — deriva-ml-mcp
+
+_Audited: 2026-04-27 against commit HEAD (v3.0.0)._
+
+## Part A: Quantitative Coverage
+
+### Overall
+
+- **287 tests collected** (14 deselected — integration suite gated by `@pytest.mark.integration`)
+- **287 pass / 0 fail / 0 skip**
+- **Overall line coverage: 95%** (1763 / 1848 statements)
+- **Time: 3.57 s**
+
+### Per-module coverage
+
+| Module | Coverage | Uncovered lines |
+|---|---|---|
+| `__init__.py` | 100% | — |
+| `_helpers.py` | 86% | 200, 320-325 |
+| `_response_models.py` | 100% | — |
+| `_version.py` | 0% | 3-24 (auto-generated; excluded by design) |
+| `ml_context.py` | 100% | — |
+| `plugin.py` | 100% | — |
+| `prompts.py` | 100% | — |
+| `resources/__init__.py` | 100% | — |
+| `resources/ml.py` | 95% | 320-321, 348-349, 376-377 |
+| `resources/rag.py` | 94% | 182, 311-313, 318-320, 325-333, 513-520, 539-546, 902 |
+| `tools/__init__.py` | 100% | — |
+| `tools/asset.py` | 100% | — |
+| `tools/dataset/__init__.py` | 100% | — |
+| `tools/dataset/complex.py` | 97% | 317, 521-522 |
+| `tools/dataset/mutate.py` | 94% | 216-217, 322-323, 402-403, 550-551, 714-715 |
+| `tools/execution.py` | 91% | 252-253, 272-273, 529-530, 767-768, 862-863, 922-923, 978-979, 1070-1071, 1155-1156, 1246-1247, 1319-1320 |
+| `tools/feature.py` | 96% | 360, 363, 372, 379-380 |
+| `tools/maintenance.py` | 100% | — |
+| `tools/workflow.py` | 96% | 410-411, 514-515 |
+
+**Modules with <80% coverage:** `_helpers.py` (86%) and `_version.py` (0%, intentionally excluded). No module other than the auto-generated version file is below 80%.
+
+**Uncovered line analysis:**
+
+- `_helpers.py:200` — the `KeyError` branch in `_read_rid` when a dict member has neither `"RID"` nor the configured `rid_key`. Never hit directly; the helper is exercised through domain tests but only via object-path (not dict-path with a missing key).
+- `_helpers.py:320-325` — the fallback branches in `_row_rid_for`'s inner `extract()` closure: the `"RID" in row` branch (line 320-321) and the `.endswith(".RID")` loop (lines 322-325). Only the `preferred` branch is exercised in practice.
+- `resources/ml.py:320-321, 348-349, 376-377` — error-envelope catch blocks for the `ml/asset-tables`, `ml/asset/{rid}`, and `ml/registries` resources. Happy paths are tested; no error-path tests for these three resources (see Part B).
+- `resources/rag.py:311-313, 318-320, 325-333` — the `_fetch_dataset_rows`, `_fetch_workflow_rows`, and `_fetch_execution_rows` helpers. These are called via the `on_catalog_connect` hooks; the hook tests mock the store interaction rather than invoking these functions through the hook, so the function bodies go untested. Lines 513-520 and 539-546 are the exception-swallowing branches in `_reindex_workflow` and `_reindex_execution` (only the dataset exception swallow is tested in `test_rag.py`). Line 902 is the `continue` branch in `_write_vocab_chunks` when a serializer returns `None` for a term — `test_write_vocab_chunks_empty_terms_drains_only` does not hit the serializer-returns-None branch inside the loop.
+- `tools/dataset/mutate.py:216-217, 322-323, 402-403, 550-551, 714-715` — all are `_reindex_dataset` exception-swallowing catch blocks (the `except Exception: logger...; return 0` pattern). Only `create_dataset`'s reindex failure test exists; the analogous branches for `add_dataset_members`, `delete_dataset_members`, `update_dataset`, and `increment_dataset_version` are not exercised.
+- `tools/execution.py` uncovered pairs — most are `_reindex_execution` exception-swallowing blocks (`862-863, 922-923, 978-979, 1070-1071, 1155-1156, 1319-1320`). Lines `252-253` and `272-273` are the exception-swallow branches in `_get_execution_detail_impl` for `list_assets` failures (input and output asset enumeration). Lines `529-530` are the `preflight_count=True` branch inside `find_workflow_executions` — this tool has no preflight test.
+- `tools/workflow.py:410-411, 514-515` — exception-swallowing blocks for `_reindex_workflow` in `create_workflow` and `update_workflow`. Only `create_workflow`'s reindex is tested; `update_workflow`'s reindex failure block is untested.
+
+---
+
+## Part B: Qualitative Coverage
+
+### Happy path vs. error path
+
+Balance is excellent across all five domains. Every tool in the dataset, workflow, execution, feature, and asset modules has at minimum one success test and one error test. Read-only tools (`list_*`, `get_*`) confirm `mock_audit.call_count == 0` on failure, and mutating tools confirm `_success_calls(mock_audit, "deriva_ml_<op>_failed")` is non-empty. No tool is left with a happy-path test only.
+
+The one partial gap: `find_workflow_executions` in `tools/execution.py` has success and error tests but no `preflight_count=True` test, leaving line 529-530 uncovered. The equivalent branch in `list_executions`, `list_datasets`, `list_workflows`, and `list_features` is covered.
+
+### Wire-shape assertions
+
+Wire-shape discipline is very strong. Every test that calls a tool does:
+
+```python
+payload = json.loads(result)
+assert payload["status"] == "created"
+assert payload["workflow_rid"] == "1-NEW"
+```
+
+No test inspects internal Python state instead of the JSON wire. The `extra="forbid"` Pydantic models provide an additional safety net: if a helper builds the wrong shape, `model_dump_json` would raise a `ValidationError` and the test would fail at the `json.loads` step or see `{"error": ...}` in the payload.
+
+### Audit assertions
+
+All `mutates=True` tools have dual-patch audit coverage via `make_patch_audit(module)` or `_patch_audit()` context managers. Tests assert both the positive event (`_success_calls(mock_audit, "deriva_ml_<op>")`) and the negative event (`_success_calls(mock_audit, "deriva_ml_<op>_failed")`). Spot checks:
+
+- `test_create_workflow_success_emits_audit` (workflow.py:227): asserts `kwargs["workflow_rid"]`, `kwargs["status"]`, and confirms `"description" not in kwargs` (which verifies cardinality of the audit payload, not just presence).
+- `test_create_execution_failure_emits_failed_audit` (execution.py:377): asserts `error_type` in failed audit kwargs.
+
+`mutates=False` tools (maintenance, read-only tools) are tested with `mock_audit.assert_not_called()` to confirm no audit fires.
+
+### Dual-mode (tool + resource) coverage
+
+Per the plugin's dual-mode policy, every domain ships both a tool and a resource. Coverage:
+
+| Domain | Tool tests | Resource tests |
+|---|---|---|
+| Dataset | 72 tests (read.py, mutate.py, complex.py split) | `test_ml_datasets_*`, `test_ml_dataset_detail_*`, `test_ml_dataset_members_*` |
+| Workflow | 18 tests | `test_ml_workflows_*`, `test_ml_workflow_detail_*` |
+| Execution | 40 tests | `test_ml_executions_*`, `test_ml_execution_detail_*` |
+| Feature | 25 tests | `test_ml_features_for_table_*` |
+| Asset | 17 tests | `test_ml_asset_tables_smoke`, `test_ml_asset_detail_*` |
+
+Each resource has at least one happy-path test. Error-path coverage is partial: the dataset, workflow, execution, and feature resources have error-path tests, but the three asset/registry resources (`ml/asset-tables`, `ml/asset/{rid}`, `ml/registries`) are missing error-path tests. This leaves their exception-envelope catch blocks (lines 320-321, 348-349, 376-377 in `resources/ml.py`) uncovered.
+
+### RAG re-index pattern coverage
+
+The pattern is well tested for the `create_*` branch of each domain that participates in RAG:
+
+- `test_create_dataset_triggers_surgical_reindex` — asserts `_reindex_dataset` awaited with correct `(host, cat, rid)`.
+- `test_create_workflow_triggers_surgical_reindex` — same for workflow.
+- `test_create_execution_triggers_surgical_reindex` — same for execution.
+- `test_create_execution_dry_run_skips_reindex` — confirms no reindex on dry-run.
+- `test_create_execution_dataset_triggers_both_reindexes` — two separate asserts for dataset and execution reindex.
+- `test_create_dataset_reindex_failure_does_not_fail_tool` — confirms the exception-swallow policy.
+
+**Gaps:** `update_workflow` calls `_reindex_workflow` (lines 511-513 in `workflow.py`) but there is no test asserting it. Multiple `_reindex_dataset` exception-swallow branches for `add_dataset_members`, `delete_dataset_members`, `update_dataset`, and `increment_dataset_version` are untested (mutate.py lines 322-323, 402-403, 550-551, 714-715). The `_reindex_workflow` and `_reindex_execution` exception-swallow blocks are also untested (workflow.py 410-411; execution.py 862-863, etc.). Feature tools do not call any reindex function, which is correct — features are not in the per-user RAG index.
+
+### Pagination edge cases
+
+Coverage is thorough for the primary paginated tools:
+
+- **Small page / cursor advancement:** tested for `list_datasets`, `list_workflows`, `list_executions`, `list_dataset_members` — each has a two-page cursor walk test.
+- **Cap to `_MAX_LIMIT`:** `test_list_datasets_pagination_caps_limit_and_advances_cursor` explicitly passes 2500 rows and verifies cap to 1000.
+- **`preflight_count=True` branch:** tested for `list_datasets`, `list_workflows`, `list_executions`, `list_features`, `list_feature_values`. The `preflight_count` assertions are minimal (`"action_required" in out`) — they confirm key presence but not the value of `action_required`. A stronger assertion would pin the human-readable message text.
+- **`direction="both"` cursor incoherence warning:** `test_list_dataset_relations_after_rid_with_both_emits_warning` exists and asserts `"warning" in out`.
+- **`after_rid` respects single-direction:** `test_list_dataset_relations_after_rid_respected_in_single_direction` exists.
+
+**Gap:** `find_workflow_executions` has no `preflight_count=True` test (lines 528-530 in `execution.py` uncovered). `list_execution_children` and `list_execution_parents` have no cursor advancement tests — only success and error paths.
+
+### v3.0 wire-break coverage (11 wire breaks)
+
+Per the v3.0 migration map in CLAUDE.md, the 11 breaks are:
+
+| Wire break | Test assertion |
+|---|---|
+| `add_dataset_members`: `status="added"` | `test_add_dataset_members_success`: `assert out["status"] == "added"` ✓ |
+| `delete_dataset_members`: `status="removed"` | `test_delete_dataset_members_success`: `assert out["status"] == "removed"` ✓ |
+| `add_dataset_element_type`: `status="created"` | `test_add_dataset_element_type_success`: `assert out == {"status": "created", ...}` ✓ |
+| `increment_dataset_version`: `status="incremented"` | test asserts `assert out["status"] == "incremented"` ✓ |
+| `cache_dataset`: `status="cached"` | `test_cache_dataset_success` asserts `out["status"] == "cached"` ✓ |
+| `cache_dataset`: bag-info nested under `bag_info` | `assert out["bag_info"]["cache_status"] == "cached_materialized"` ✓ |
+| `split_dataset`: `status="split"` | asserts `out["status"] == "split"` ✓ |
+| `start_execution` no-op: `status="already_running"` (no `note`) | `test_start_execution_idempotent_when_already_running`: `assert payload["status"] == "already_running"` and `assert "note" not in payload` ✓ |
+| `abort_execution` no-op: `status="already_aborted"` | `test_abort_execution_idempotent_when_already_aborted`: `assert payload["status"] == "already_aborted"` ✓ |
+| `abort_execution`: `reason` always present | `assert payload["reason"] is None` ✓ |
+| `update_dataset` description-only: `dataset_types/added/removed` always present (null) | `test_update_dataset_description_only`: `assert out["dataset_types"] is None; assert out["added"] is None; assert out["removed"] is None` ✓ |
+
+**All 11 v3.0 wire breaks are explicitly tested by value-level assertions.** This is the strongest part of the test suite.
+
+One marginal gap: `create_execution_dataset`'s v3.0 contract says `dataset_types` is always present (null when omitted by caller). The only success test (`test_create_execution_dataset_success_emits_audit`) passes `dataset_types=["Training"]` explicitly; there is no test passing `dataset_types=None` and asserting `payload["dataset_types"] is None`.
+
+### Mocking discipline
+
+Mocking is well-structured. Centralized fixtures in `conftest.py` (`ctx`, `mock_ml`, `capturing_mcp`) are used consistently. Each domain module adds a local `<domain>_ctx` fixture that registers its tools under `mock_ml`.
+
+**Duplication:** `_make_dataset_mock`, `_make_workflow_mock`, `_make_execution_record_mock`, and `_make_feature_mock` factories are defined once in each of `test_dataset.py`, `test_resources.py`, `test_execution.py`, and `test_workflow.py`. The resource test file re-defines all four locally (e.g., `test_resources.py:60-130`). This is not incorrect — the shapes differ slightly between tool and resource tests — but there is non-trivial duplication. A shared `tests/_factories.py` would DRY these up.
+
+Direct `MagicMock()` construction is used inside test functions and local factory helpers (e.g., `test_resources.py:60`, `test_feature.py:20`). This is appropriate: the factories are lean and specific to their context. No test constructs a god-MagicMock that preconfigures 15+ attributes.
+
+### Async test harness
+
+`pyproject.toml` sets `asyncio_mode = "auto"`. All async test functions (`async def test_*`) run automatically without `@pytest.mark.asyncio` decorators. The harness is `pytest-asyncio 1.3.0`. No inconsistency found — there are no sync wrapper functions calling `asyncio.run()` or mixing anyio with asyncio. This is applied uniformly across all 12 test files.
+
+### Test naming + organization
+
+Test names follow the pattern `test_<tool_name>_<scenario>` consistently. Finding the tests for a given tool is straightforward: `grep "def test_" tests/test_workflow.py` returns names like `test_create_workflow_success_emits_audit`, `test_create_workflow_dedup_exists`, etc.
+
+Tests within each file are organized in sections delimited by `# -----------` comments matching the tool name. This is uniform across all domain test files.
+
+No orphan tests were found. All tool names referenced in test functions correspond to tools registered in `test_plugin.py::test_all_registered_tools_exact`.
+
+---
+
+## Part C: Test Design Quality
+
+### Test interdependence
+
+Tests are independent. Each `async def test_*` function receives fresh fixture instances (all fixtures are function-scoped except the integration session fixtures). Running `uv run pytest tests/test_workflow.py` alone yields 18 pass, confirming no hidden state from other modules leaks in. The `_set_plugin_context(None)` teardown in `conftest.py`'s `ctx` fixture (line 33) cleans up the contextvar between tests.
+
+### Fixture quality
+
+Fixtures are focused. `conftest.py` provides exactly three function-scoped fixtures (`capturing_mcp`, `ctx`, `mock_ml`) plus two session-scoped integration fixtures. Each domain file adds one `<domain>_ctx` fixture that does a single job: patch `get_ml`, import the module, call `register(ctx)`, yield.
+
+The `_CapturingMCP` class in `tests/_helpers.py` is a clean stand-in that only stores decoratee references — no side effects, no state bleed between tests.
+
+### Test brittleness
+
+Low brittleness overall. Tests assert on behavior (JSON payload shape, method call counts/arguments) rather than log message text. Exception: error-path tests do string-match the exception message (`assert "kaboom" in payload["error"]`), which is slightly brittle to rewording — but this is a minor concern.
+
+Two patterns that could become brittle:
+
+1. `test_plugin.py::test_all_registered_tools_exact` uses an exact frozenset equality check. This is intentionally strict (it catches both missing and extra tools), so brittleness here is by design and desirable.
+2. `test_prompts.py::test_prompts_are_ascii` could give a misleading failure if the `prompts.py` template strings ever intentionally include Unicode (e.g., arrow characters in formatting). The 100-char floor test is similarly a weak proxy for "prompt text exists."
+
+### Assertion specificity
+
+Assertion specificity is high in tool tests. The standard pattern:
+
+```python
+payload = json.loads(result)
+assert payload["status"] == "created"
+assert payload["workflow_rid"] == "1-NEW"
+```
+
+is used throughout and tests exact values.
+
+Weaker assertions exist in a small number of places:
+
+- **Preflight `action_required`:** `assert "action_required" in out` (7 occurrences across test files) confirms key presence but not the message content. This matters because a broken preflight that returned an empty string would pass.
+- **Error message substring:** `assert "kaboom" in payload["error"]` is a substring match, not an exact comparison. Acceptable for readability, but a future refactor that changes error wrapping could obscure the original message.
+- **`test_ml_asset_tables_smoke`:** named "smoke" — confirms `count == 2` and the set of names, but does not verify the per-table `schema` field shape.
+
+---
+
+## Top-line findings
+
+- **Coverage is genuinely strong at 95% overall.** All 287 unit tests pass, all 11 v3.0 wire-break contracts are verified by value-level assertions, and every mutating tool has both success-path and failure-path audit assertions. This is a well-maintained test suite.
+
+- **Three resources are missing error-path tests.** `ml/asset-tables`, `ml/asset/{rid}`, and `ml/registries` in `resources/ml.py` have no exception-path tests, leaving their catch blocks (lines 320-321, 348-349, 376-377) uncovered. Each needs a single test that makes `get_ml` raise and asserts `"error" in payload`.
+
+- **Reindex coverage is incomplete for update operations.** `update_workflow` calls `_reindex_workflow` (workflow.py:511-513) but has no test asserting this. Multiple mutating dataset tools (`add_dataset_members`, `delete_dataset_members`, `update_dataset`, `increment_dataset_version`) have no tests for their reindex exception-swallow branches. These are not critical bugs but are observable gaps given the thorough create-path reindex tests.
+
+- **`find_workflow_executions` is missing a `preflight_count=True` test.** It's the only paginated tool without this coverage (lines 528-530 in execution.py uncovered). A two-line test modeled on `test_list_executions_preflight` would close it.
+
+- **Mock factory duplication across test files.** `_make_dataset_mock`, `_make_workflow_mock`, and `_make_execution_record_mock` are redefined independently in `test_resources.py`, `test_execution.py`, and `test_workflow.py`. Negligible runtime impact, but a shape change to the mock API requires updates in multiple places. Consolidating into `tests/_factories.py` (parallel to `tests/_helpers.py`) would improve maintainability.

--- a/docs/superpowers/plans/2026-04-28-v3.1.0-sort-and-feature-limits.md
+++ b/docs/superpowers/plans/2026-04-28-v3.1.0-sort-and-feature-limits.md
@@ -1,0 +1,1186 @@
+# deriva-ml-mcp v3.1.0 — Sort + Feature-Value Limits Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the three new optional parameters from deriva-ml v1.31.0 (`sort=`, `materialize_limit=`, `execution_rids=`) through the MCP tool surface, plus pin the deriva-ml dependency.
+
+**Architecture:** Three additive parameter exposures across four tools: `sort: bool = False` on the three activity-log paginated tools (`list_executions`, `list_datasets`, `list_workflows`), and `execution_rids: list[str] | None = None` + `max_results: int = 50_000` on `list_feature_values`. The `_list_*_impl` helpers gain a `sort` kwarg that switches the post-fetch RID sort behavior depending on whether the caller wants RCT-desc (sorted by deriva-ml) or RID-asc (the existing default for stable pagination). `list_feature_values` translates `DerivaMLMaterializeLimitExceeded` from deriva-ml into a clear MCP error envelope. No new tools, no new resources, no `compare_metrics` (a planned skill teaches the cross-execution comparison pattern explicitly using these primitives).
+
+**Tech Stack:** Python 3.13+, deriva-ml v1.31+, deriva-mcp-core, FastMCP, Pydantic v2, pytest, ruff.
+
+---
+
+## File Structure
+
+**Modify:**
+- `pyproject.toml` — pin `deriva-ml>=1.31.0`.
+- `src/deriva_ml_mcp/tools/execution.py` — add `sort=` to `_list_executions_impl` and the `deriva_ml_list_executions` wrapper. Add `sort=` to `find_workflow_executions` (it shares the same impl helper).
+- `src/deriva_ml_mcp/tools/dataset/read.py` — add `sort=` to `_list_datasets_impl` and the `deriva_ml_list_datasets` wrapper.
+- `src/deriva_ml_mcp/tools/workflow.py` — add `sort=` to `_list_workflows_impl` and the `deriva_ml_list_workflows` wrapper.
+- `src/deriva_ml_mcp/tools/feature.py` — add `execution_rids=` and `max_results=` to `deriva_ml_list_feature_values` wrapper. Translate the new exception.
+- `tests/test_execution.py` — add `sort=True` test for `list_executions` (mocks `find_executions(sort=True)`).
+- `tests/test_dataset.py` — add `sort=True` test for `list_datasets`.
+- `tests/test_workflow.py` — add `sort=True` test for `list_workflows`.
+- `tests/test_feature.py` — add tests for `execution_rids=` (forwarded to deriva-ml) and `max_results=` (translation of `DerivaMLMaterializeLimitExceeded`).
+- `CLAUDE.md` — document the new parameters and the v3.1.0 release shape.
+
+**Don't modify:**
+- Resources (`resources/ml.py`). Resources keep their current RID-asc default for snapshot stability. Users wanting "recent first" use the tool with `sort=True`.
+- `_response_models.py`. Wire shapes are unchanged — the new parameters only affect what data is returned, not its shape.
+- The `_get_*_detail_impl` family. These are by-RID lookups that don't paginate.
+
+---
+
+## Wire-shape impact summary
+
+For the **v3.1.0 changelog**:
+
+1. **`list_executions`, `list_datasets`, `list_workflows`** gain a new optional `sort: bool = False` parameter. Default `False` preserves current behavior (RID-asc). When `sort=True`, results are RCT-desc (newest-first).
+
+2. **`find_workflow_executions`** gains the same `sort: bool = False` (it shares the executions impl).
+
+3. **`list_feature_values`** gains:
+   - `execution_rids: list[str] | None = None` — forwarded to deriva-ml's `feature_values(execution_rids=...)`. Empty list short-circuits to no rows (existing deriva-ml semantics).
+   - `max_results: int = 50_000` — caller-controllable cap on the materialized result set. **This is a behavior tightening** — queries that previously OOMed silently will now return an `{"error": "result set exceeds max_results=50000; pass execution_rids=... to narrow the query, or raise max_results"}` envelope.
+
+4. **`deriva-ml` is now pinned to `>=1.31.0`**. Previously declared with no constraint (audit finding). Closes a deployment risk.
+
+No new tools, no new resources, no Pydantic response model changes.
+
+---
+
+## Tasks
+
+### Task 1: Branch + version pin
+
+**Files:**
+- Branch: `feature/v3.1-sort-and-feature-limits`
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Create branch off main**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && git checkout main && git pull && git checkout -b feature/v3.1-sort-and-feature-limits
+```
+
+- [ ] **Step 2: Pin deriva-ml dependency in pyproject.toml**
+
+Find the `dependencies = [...]` block in `pyproject.toml`:
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && grep -B 2 -A 8 'dependencies = \[' pyproject.toml | head -20
+```
+
+You should see the `"deriva-ml",` line as a bare unconstrained entry. Use the Edit tool to change:
+
+```python
+    "deriva-ml",
+```
+
+to:
+
+```python
+    "deriva-ml>=1.31.0",
+```
+
+- [ ] **Step 3: Run uv sync to update the lockfile**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && uv sync
+```
+
+Expected: lockfile updates. The local editable install via `[tool.uv.sources]` keeps pointing at `../deriva-ml`, so the actual installed version is whatever's checked out there (which IS v1.31.0 — we just released it).
+
+- [ ] **Step 4: Verify import of new symbols works**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && uv run python -c "
+from deriva_ml import DerivaMLMaterializeLimitExceeded
+from deriva_ml.core.sort import SortSpec
+print('imports OK')
+"
+```
+
+Expected: `imports OK`. If either symbol fails to import, the deriva-ml version is too old — re-check Task 12 of the deriva-ml plan landed.
+
+- [ ] **Step 5: Run tests + lint to confirm baseline**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && uv run pytest 2>&1 | tail -3 && uv run ruff check src tests && uv run ruff format --check src tests
+```
+
+Expected: 287 passed (the v3.0.0 test count; should be unchanged), ruff clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && git add pyproject.toml uv.lock && git commit -m "$(cat <<'EOF'
+chore(deps): pin deriva-ml>=1.31.0
+
+deriva-ml v1.31.0 introduced the sort=, materialize_limit=, and
+execution_rids= parameters that this plugin v3.1.0 consumes.
+Previously this dependency was declared without a version constraint
+(audit finding: deployment risk). Pin to the floor that contains the
+new symbols.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Add `sort=` to `_list_executions_impl` + `deriva_ml_list_executions` + `deriva_ml_find_workflow_executions`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/tools/execution.py`
+- Test: `tests/test_execution.py`
+
+The execution impl helper is shared by two wrapper tools (`list_executions` and `find_workflow_executions`), so both wrappers need the new parameter and forward it.
+
+- [ ] **Step 1: Read the existing impl + both wrappers**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && grep -B 2 -A 50 "def _list_executions_impl\b" src/deriva_ml_mcp/tools/execution.py | head -60
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && grep -B 2 -A 80 "async def deriva_ml_list_executions\b" src/deriva_ml_mcp/tools/execution.py | head -100
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && grep -B 2 -A 80 "async def deriva_ml_find_workflow_executions\b" src/deriva_ml_mcp/tools/execution.py | head -100
+```
+
+The current impl does:
+
+```python
+executions = sorted(
+    ml.find_executions(workflow=workflow_rid, status=status_enum),
+    key=lambda e: getattr(e, "execution_rid", "") or "",
+)
+```
+
+The post-fetch `sorted(...)` is the source of "RID-ascending" behavior at the wire. Under `sort=True` we want to keep deriva-ml's RCT-desc order, so we MUST skip the post-fetch sort in that case.
+
+- [ ] **Step 2: Update `_list_executions_impl` signature and body**
+
+In `src/deriva_ml_mcp/tools/execution.py`, find:
+
+```python
+def _list_executions_impl(
+    ml: Any,
+    *,
+    workflow_rid: str | None,
+    status: str | None,
+    after_rid: str | None,
+    limit: int,
+) -> ExecutionListResponse:
+```
+
+Replace with:
+
+```python
+def _list_executions_impl(
+    ml: Any,
+    *,
+    workflow_rid: str | None,
+    status: str | None,
+    after_rid: str | None,
+    limit: int,
+    sort: bool = False,
+) -> ExecutionListResponse:
+```
+
+Update the docstring `Args:` block to add (after the `limit:` entry):
+
+```
+        sort: If True, results are ordered newest-first by record
+            creation time (RCT desc) -- forwarded to
+            ``deriva_ml.DerivaML.find_executions(sort=True)``.
+            If False (default), results are RID-ascending for stable
+            cursor pagination. Note that under ``sort=True`` the
+            ``after_rid`` cursor still works ("skip up to this RID
+            in the RCT-sorted result"), but pagination through very
+            large sorted result sets is bounded by the internal
+            fetch cap.
+```
+
+Now update the body. Find:
+
+```python
+    status_enum = ExecutionStatus(status) if status else None
+    executions = sorted(
+        ml.find_executions(workflow=workflow_rid, status=status_enum),
+        key=lambda e: getattr(e, "execution_rid", "") or "",
+    )
+```
+
+Replace with:
+
+```python
+    status_enum = ExecutionStatus(status) if status else None
+    raw = list(
+        ml.find_executions(
+            workflow=workflow_rid,
+            status=status_enum,
+            sort=True if sort else None,
+        )
+    )
+    # Keep stable RID-ascending order for the default path; under
+    # sort=True we honor the catalog-side RCT-desc ordering and skip
+    # the post-fetch sort (sorting by RID would clobber the RCT order).
+    if sort:
+        executions = raw
+    else:
+        executions = sorted(
+            raw,
+            key=lambda e: getattr(e, "execution_rid", "") or "",
+        )
+```
+
+- [ ] **Step 3: Update the `deriva_ml_list_executions` wrapper signature**
+
+Find the `async def deriva_ml_list_executions(...)` signature (around line 381). Add `sort: bool = False` as the LAST parameter (just before the closing `)`):
+
+```python
+    async def deriva_ml_list_executions(
+        hostname: str,
+        catalog_id: str,
+        workflow_rid: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        after_rid: str | None = None,
+        preflight_count: bool = False,
+        sort: bool = False,
+    ) -> str:
+```
+
+Update the docstring `Args:` block to add a `sort:` entry after `preflight_count:`:
+
+```
+            sort: If True, return results newest-first by record
+                creation time. Recommended for "show me the most
+                recent runs" queries. Default False preserves the
+                stable RID-ascending order used for cursor pagination.
+```
+
+- [ ] **Step 4: Forward `sort` from the wrapper to the impl**
+
+Find the `_list_executions_impl(...)` call inside the wrapper body (around line 425). It looks like:
+
+```python
+                payload = _list_executions_impl(
+                    ml,
+                    workflow_rid=workflow_rid,
+                    status=status,
+                    after_rid=after_rid,
+                    limit=capped,
+                )
+```
+
+Add a `sort=sort,` kwarg:
+
+```python
+                payload = _list_executions_impl(
+                    ml,
+                    workflow_rid=workflow_rid,
+                    status=status,
+                    after_rid=after_rid,
+                    limit=capped,
+                    sort=sort,
+                )
+```
+
+- [ ] **Step 5: Update `deriva_ml_find_workflow_executions` analogously**
+
+Find the `async def deriva_ml_find_workflow_executions(...)` signature (around line 490). Add `sort: bool = False` as the last parameter. Add the same `sort:` Args entry to the docstring. Forward `sort=sort` to the `_list_executions_impl(...)` call inside its body.
+
+- [ ] **Step 6: Verify the resource caller doesn't need updating**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && grep -B 1 -A 8 "_list_executions_impl" src/deriva_ml_mcp/resources/ml.py
+```
+
+The resource calls `_list_executions_impl(ml, after_rid=None, limit=_MAX_LIMIT)` — no `sort` kwarg means the impl uses the default `sort=False`. The resource keeps its current RID-asc behavior. Good.
+
+- [ ] **Step 7: Add wrapper test for sort=True**
+
+Open `tests/test_execution.py` and find an existing list_executions test (e.g., `test_list_executions_success` or similar) for context.
+
+Add this new test at the end of the same section:
+
+```python
+async def test_list_executions_sort_forwards_to_deriva_ml(execution_ctx, capturing_mcp, mock_ml):
+    """sort=True forwards sort=True to deriva_ml.find_executions and skips post-fetch RID sort."""
+    # Mock find_executions to return records in RCT-desc-ish order
+    # (the mock simulates what deriva-ml returns when sort=True).
+    record_a = _make_execution_record_mock(execution_rid="1-EXEC-NEWEST")
+    record_b = _make_execution_record_mock(execution_rid="1-EXEC-OLDER")
+    mock_ml.find_executions.return_value = iter([record_a, record_b])
+
+    result = await capturing_mcp.tools["deriva_ml_list_executions"](
+        hostname="h", catalog_id="1", sort=True
+    )
+    payload = json.loads(result)
+
+    # Confirm the deriva-ml call received sort=True
+    mock_ml.find_executions.assert_called_once()
+    assert mock_ml.find_executions.call_args.kwargs.get("sort") is True
+
+    # Confirm the wire response preserved the RCT-desc order (NOT
+    # re-sorted by RID).
+    rids = [e["rid"] for e in payload["executions"]]
+    assert rids == ["1-EXEC-NEWEST", "1-EXEC-OLDER"]
+
+
+async def test_list_executions_sort_default_preserves_rid_sort(execution_ctx, capturing_mcp, mock_ml):
+    """sort=False (default) calls find_executions with sort=None and re-sorts by RID asc."""
+    # Records intentionally NOT in RID order from the mock; the
+    # wrapper should re-sort them ascending.
+    record_z = _make_execution_record_mock(execution_rid="1-Z")
+    record_a = _make_execution_record_mock(execution_rid="1-A")
+    mock_ml.find_executions.return_value = iter([record_z, record_a])
+
+    result = await capturing_mcp.tools["deriva_ml_list_executions"](
+        hostname="h", catalog_id="1"
+    )
+    payload = json.loads(result)
+
+    # find_executions called with sort=None (the False -> None mapping)
+    assert mock_ml.find_executions.call_args.kwargs.get("sort") is None
+    # Wire response is RID-ascending
+    rids = [e["rid"] for e in payload["executions"]]
+    assert rids == ["1-A", "1-Z"]
+```
+
+If `_make_execution_record_mock` already exists in this file with a different signature, adjust the calls to match (the test fixture surface varies — read the existing tests first to see how mocks are constructed).
+
+- [ ] **Step 8: Run tests + lint**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && uv run pytest tests/test_execution.py -v 2>&1 | tail -15 && uv run ruff check src/deriva_ml_mcp/tools/execution.py tests/test_execution.py && uv run ruff format src/deriva_ml_mcp/tools/execution.py tests/test_execution.py
+```
+
+Expected: all execution tests pass, ruff clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && git add src/deriva_ml_mcp/tools/execution.py tests/test_execution.py && git commit -m "$(cat <<'EOF'
+feat(executions): expose sort= parameter on list_executions and find_workflow_executions
+
+Both wrappers and the shared _list_executions_impl helper accept an
+optional sort=False parameter. When True, forwards sort=True to
+deriva-ml's find_executions (RCT-desc order) and skips the post-fetch
+RID sort. Default False preserves the stable RID-ascending order used
+for cursor pagination.
+
+Tests cover both branches (sort=True → forwards + preserves order;
+sort=False → calls deriva-ml with sort=None + re-sorts by RID).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Add `sort=` to `_list_datasets_impl` + `deriva_ml_list_datasets`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/tools/dataset/read.py`
+- Test: `tests/test_dataset.py`
+
+Same pattern as Task 2 but for datasets.
+
+- [ ] **Step 1: Update `_list_datasets_impl` signature and body**
+
+Find:
+
+```python
+def _list_datasets_impl(
+    ml: Any,
+    *,
+    after_rid: str | None,
+    limit: int,
+    include_deleted: bool = False,
+) -> DatasetListResponse:
+```
+
+Replace with:
+
+```python
+def _list_datasets_impl(
+    ml: Any,
+    *,
+    after_rid: str | None,
+    limit: int,
+    include_deleted: bool = False,
+    sort: bool = False,
+) -> DatasetListResponse:
+```
+
+Add the `sort:` `Args:` entry to the docstring (use the same wording as Task 2 Step 2, substituting "datasets" for "executions").
+
+In the body, find:
+
+```python
+    datasets = sorted(
+        ml.find_datasets(deleted=include_deleted),
+        key=lambda d: d.dataset_rid,
+    )
+```
+
+Replace with:
+
+```python
+    raw = list(
+        ml.find_datasets(
+            deleted=include_deleted,
+            sort=True if sort else None,
+        )
+    )
+    if sort:
+        datasets = raw
+    else:
+        datasets = sorted(raw, key=lambda d: d.dataset_rid)
+```
+
+- [ ] **Step 2: Update `deriva_ml_list_datasets` wrapper**
+
+Find the `async def deriva_ml_list_datasets(...)` signature in the same file. Add `sort: bool = False` as the LAST parameter. Add a `sort:` `Args:` entry to the docstring (analogous to Task 2 Step 3). Forward `sort=sort` to the `_list_datasets_impl(...)` call inside the wrapper body.
+
+- [ ] **Step 3: Verify resource caller**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && grep -B 1 -A 6 "_list_datasets_impl" src/deriva_ml_mcp/resources/ml.py
+```
+
+Should call without `sort=`, falling through to the default `sort=False`.
+
+- [ ] **Step 4: Add wrapper tests**
+
+Open `tests/test_dataset.py`. Find an existing list_datasets test for context. Add two new tests at the end of the `list_datasets` test section:
+
+```python
+async def test_list_datasets_sort_forwards_to_deriva_ml(dataset_ctx, capturing_mcp, mock_ml):
+    """sort=True forwards sort=True to deriva_ml.find_datasets and skips post-fetch RID sort."""
+    ds_a = _make_dataset_mock(dataset_rid="1-DS-NEWEST")
+    ds_b = _make_dataset_mock(dataset_rid="1-DS-OLDER")
+    mock_ml.find_datasets.return_value = iter([ds_a, ds_b])
+
+    result = await capturing_mcp.tools["deriva_ml_list_datasets"](
+        hostname="h", catalog_id="1", sort=True
+    )
+    payload = json.loads(result)
+
+    mock_ml.find_datasets.assert_called_once()
+    assert mock_ml.find_datasets.call_args.kwargs.get("sort") is True
+    rids = [d["rid"] for d in payload["datasets"]]
+    assert rids == ["1-DS-NEWEST", "1-DS-OLDER"]
+
+
+async def test_list_datasets_sort_default_preserves_rid_sort(dataset_ctx, capturing_mcp, mock_ml):
+    """sort=False (default) calls find_datasets with sort=None and re-sorts by RID asc."""
+    ds_z = _make_dataset_mock(dataset_rid="1-Z")
+    ds_a = _make_dataset_mock(dataset_rid="1-A")
+    mock_ml.find_datasets.return_value = iter([ds_z, ds_a])
+
+    result = await capturing_mcp.tools["deriva_ml_list_datasets"](
+        hostname="h", catalog_id="1"
+    )
+    payload = json.loads(result)
+
+    assert mock_ml.find_datasets.call_args.kwargs.get("sort") is None
+    rids = [d["rid"] for d in payload["datasets"]]
+    assert rids == ["1-A", "1-Z"]
+```
+
+If `_make_dataset_mock` requires extra fields, check the existing tests' usage and supply matching defaults.
+
+- [ ] **Step 5: Run tests + lint**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && uv run pytest tests/test_dataset.py -v -k "list_datasets" 2>&1 | tail -10 && uv run ruff check src/deriva_ml_mcp/tools/dataset/read.py tests/test_dataset.py && uv run ruff format src/deriva_ml_mcp/tools/dataset/read.py tests/test_dataset.py
+```
+
+Expected: all list_datasets tests pass, ruff clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && git add src/deriva_ml_mcp/tools/dataset/read.py tests/test_dataset.py && git commit -m "$(cat <<'EOF'
+feat(datasets): expose sort= parameter on list_datasets
+
+Same three-state semantics as list_executions: sort=False (default)
+preserves RID-asc order for stable cursoring; sort=True forwards
+sort=True to deriva-ml's find_datasets (RCT-desc order) and skips
+the post-fetch RID sort.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Add `sort=` to `_list_workflows_impl` + `deriva_ml_list_workflows`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/tools/workflow.py`
+- Test: `tests/test_workflow.py`
+
+Same pattern as Tasks 2 and 3.
+
+- [ ] **Step 1: Update `_list_workflows_impl` signature and body**
+
+Find:
+
+```python
+def _list_workflows_impl(
+    ml: Any,
+    *,
+    after_rid: str | None,
+    limit: int,
+) -> WorkflowListResponse:
+```
+
+Replace with:
+
+```python
+def _list_workflows_impl(
+    ml: Any,
+    *,
+    after_rid: str | None,
+    limit: int,
+    sort: bool = False,
+) -> WorkflowListResponse:
+```
+
+Add the `sort:` `Args:` entry. Update the body — find:
+
+```python
+    workflows = sorted(ml.find_workflows(), key=lambda w: w.rid)
+```
+
+Replace with:
+
+```python
+    raw = list(ml.find_workflows(sort=True if sort else None))
+    if sort:
+        workflows = raw
+    else:
+        workflows = sorted(raw, key=lambda w: w.rid)
+```
+
+- [ ] **Step 2: Update `deriva_ml_list_workflows` wrapper**
+
+Find the `async def deriva_ml_list_workflows(...)` signature. Add `sort: bool = False` as the LAST parameter. Add a `sort:` `Args:` entry. Forward `sort=sort` to the `_list_workflows_impl(...)` call.
+
+- [ ] **Step 3: Add wrapper tests**
+
+Open `tests/test_workflow.py`. Add at the end of the list_workflows test section:
+
+```python
+async def test_list_workflows_sort_forwards_to_deriva_ml(workflow_ctx, capturing_mcp, mock_ml):
+    """sort=True forwards sort=True to deriva_ml.find_workflows and skips post-fetch RID sort."""
+    wf_a = _make_workflow_mock(rid="1-WF-NEWEST")
+    wf_b = _make_workflow_mock(rid="1-WF-OLDER")
+    mock_ml.find_workflows.return_value = [wf_a, wf_b]
+
+    result = await capturing_mcp.tools["deriva_ml_list_workflows"](
+        hostname="h", catalog_id="1", sort=True
+    )
+    payload = json.loads(result)
+
+    mock_ml.find_workflows.assert_called_once()
+    assert mock_ml.find_workflows.call_args.kwargs.get("sort") is True
+    rids = [w["rid"] for w in payload["workflows"]]
+    assert rids == ["1-WF-NEWEST", "1-WF-OLDER"]
+
+
+async def test_list_workflows_sort_default_preserves_rid_sort(workflow_ctx, capturing_mcp, mock_ml):
+    """sort=False (default) calls find_workflows with sort=None and re-sorts by RID asc."""
+    wf_z = _make_workflow_mock(rid="1-Z")
+    wf_a = _make_workflow_mock(rid="1-A")
+    mock_ml.find_workflows.return_value = [wf_z, wf_a]
+
+    result = await capturing_mcp.tools["deriva_ml_list_workflows"](
+        hostname="h", catalog_id="1"
+    )
+    payload = json.loads(result)
+
+    assert mock_ml.find_workflows.call_args.kwargs.get("sort") is None
+    rids = [w["rid"] for w in payload["workflows"]]
+    assert rids == ["1-A", "1-Z"]
+```
+
+- [ ] **Step 4: Run tests + lint**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && uv run pytest tests/test_workflow.py -v 2>&1 | tail -10 && uv run ruff check src/deriva_ml_mcp/tools/workflow.py tests/test_workflow.py && uv run ruff format src/deriva_ml_mcp/tools/workflow.py tests/test_workflow.py
+```
+
+Expected: all workflow tests pass, ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && git add src/deriva_ml_mcp/tools/workflow.py tests/test_workflow.py && git commit -m "$(cat <<'EOF'
+feat(workflows): expose sort= parameter on list_workflows
+
+Same three-state semantics as list_executions / list_datasets.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Add `execution_rids=` and `max_results=` to `deriva_ml_list_feature_values`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/tools/feature.py`
+- Test: `tests/test_feature.py`
+
+This is the largest behavior change in the PR. Two new parameters; one of them (`max_results`) introduces a behavior tightening.
+
+- [ ] **Step 1: Read the existing wrapper**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && grep -B 2 -A 130 "async def deriva_ml_list_feature_values" src/deriva_ml_mcp/tools/feature.py | head -150
+```
+
+Note the existing structure: builds `selector_fn`, then `with deriva_call(): ... records = list(ml.feature_values(...))` (or `ds.feature_values(...)` if `dataset_rid` is set), then optional `preflight_count` branch, then sort + paginate + serialize.
+
+- [ ] **Step 2: Add the import for the new exception**
+
+At the top of `src/deriva_ml_mcp/tools/feature.py`, find the existing `from deriva_ml import ...` block. Add `DerivaMLMaterializeLimitExceeded` to it (alphabetized).
+
+- [ ] **Step 3: Update the signature**
+
+Find:
+
+```python
+    @ctx.tool(mutates=False)
+    async def deriva_ml_list_feature_values(
+        hostname: str,
+        catalog_id: str,
+        table: str,
+        feature_name: str,
+        selector: Literal[
+            "none",
+            "newest",
+            "first",
+            "latest",
+            "majority_vote",
+            "by_workflow",
+            "by_execution",
+        ] = "none",
+        selector_workflow: str | None = None,
+        selector_execution_rid: str | None = None,
+        dataset_rid: str | None = None,
+        limit: int = 100,
+        after_rid: str | None = None,
+        preflight_count: bool = False,
+    ) -> str:
+```
+
+Replace with (adds `execution_rids` and `max_results` as the last two parameters):
+
+```python
+    @ctx.tool(mutates=False)
+    async def deriva_ml_list_feature_values(
+        hostname: str,
+        catalog_id: str,
+        table: str,
+        feature_name: str,
+        selector: Literal[
+            "none",
+            "newest",
+            "first",
+            "latest",
+            "majority_vote",
+            "by_workflow",
+            "by_execution",
+        ] = "none",
+        selector_workflow: str | None = None,
+        selector_execution_rid: str | None = None,
+        dataset_rid: str | None = None,
+        limit: int = 100,
+        after_rid: str | None = None,
+        preflight_count: bool = False,
+        execution_rids: list[str] | None = None,
+        max_results: int = 50_000,
+    ) -> str:
+```
+
+- [ ] **Step 4: Update the docstring**
+
+In the same wrapper's docstring:
+
+(a) Add to the `Args:` block (after `preflight_count:`):
+
+```
+            execution_rids: Optional filter -- when set, only feature
+                rows whose ``Execution`` value is in this list are
+                materialized. Forwarded server-side to deriva-ml's
+                ``feature_values(execution_rids=...)``. Lets compare-
+                runs workflows fetch values across N executions in a
+                single catalog round-trip rather than N sequential
+                queries. Empty list short-circuits to no rows.
+            max_results: Cap on rows materialized into memory before
+                pagination (default 50000). Returns
+                ``{"error": "..."}`` if the result set exceeds the cap;
+                the error message names the cap and suggests passing
+                ``execution_rids=`` to narrow. Increase if you have a
+                catalog where 50K is too tight; decrease if the LLM
+                runs in a memory-constrained environment.
+```
+
+(b) Add to the `Raises:` block (or update the existing `RuntimeError` entry):
+
+```
+            DerivaMLMaterializeLimitExceeded: When the result set
+                exceeds ``max_results``. Translated to
+                ``{"error": "..."}`` on the wire.
+```
+
+- [ ] **Step 5: Forward `execution_rids` and `max_results` to deriva-ml**
+
+Find the existing `feature_values(...)` call(s). They look like:
+
+```python
+                if dataset_rid is not None:
+                    ds = ml.lookup_dataset(dataset_rid)
+                    records = list(ds.feature_values(table, feature_name, selector=selector_fn))
+                else:
+                    records = list(ml.feature_values(table, feature_name, selector=selector_fn))
+```
+
+Replace with:
+
+```python
+                if dataset_rid is not None:
+                    ds = ml.lookup_dataset(dataset_rid)
+                    records = list(
+                        ds.feature_values(
+                            table,
+                            feature_name,
+                            selector=selector_fn,
+                            materialize_limit=max_results,
+                            execution_rids=execution_rids,
+                        )
+                    )
+                else:
+                    records = list(
+                        ml.feature_values(
+                            table,
+                            feature_name,
+                            selector=selector_fn,
+                            materialize_limit=max_results,
+                            execution_rids=execution_rids,
+                        )
+                    )
+```
+
+- [ ] **Step 6: Translate `DerivaMLMaterializeLimitExceeded` to a clear error envelope**
+
+The existing wrapper has an outer `try: ... except Exception as exc: return _error_envelope(...)`. The default `_error_envelope` returns `{"error": str(exc)}`, which would already work — `DerivaMLMaterializeLimitExceeded.__str__` returns a useful message including both numbers and the suggestion to narrow. But we want to ensure the error message is LLM-friendly.
+
+Find the existing `except Exception as exc:` block at the end of the wrapper body and PRECEDE it with a more specific catch:
+
+```python
+        except DerivaMLMaterializeLimitExceeded as exc:
+            # Translate the deriva-ml exception to a clear error envelope.
+            # The exception's __str__ already names the cap and suggests
+            # passing execution_rids=...; we just route it through the
+            # standard _error_envelope so audit/logging are uniform.
+            return _error_envelope(
+                exc,
+                operation="list_feature_values",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,
+            )
+        except Exception as exc:
+            return _error_envelope(
+                exc,
+                operation="list_feature_values",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,
+            )
+```
+
+(The two `except` blocks have identical bodies; the more specific one comes first so future changes can specialize it.)
+
+- [ ] **Step 7: Add wrapper tests**
+
+Open `tests/test_feature.py`. Find the existing `list_feature_values` tests. Add at the end of that section:
+
+```python
+async def test_list_feature_values_forwards_execution_rids(feature_ctx, capturing_mcp, mock_ml):
+    """execution_rids= is forwarded to deriva-ml's feature_values(execution_rids=...)."""
+    record = _make_feature_record_mock(rid="1-FV-A")
+    mock_ml.feature_values.return_value = iter([record])
+
+    result = await capturing_mcp.tools["deriva_ml_list_feature_values"](
+        hostname="h",
+        catalog_id="1",
+        table="Image",
+        feature_name="Quality",
+        execution_rids=["1-EXEC-A", "1-EXEC-B"],
+    )
+    payload = json.loads(result)
+
+    mock_ml.feature_values.assert_called_once()
+    assert mock_ml.feature_values.call_args.kwargs.get("execution_rids") == [
+        "1-EXEC-A",
+        "1-EXEC-B",
+    ]
+    assert payload["count"] == 1
+
+
+async def test_list_feature_values_default_max_results_passed(feature_ctx, capturing_mcp, mock_ml):
+    """The default max_results=50000 is forwarded as materialize_limit=50000."""
+    record = _make_feature_record_mock(rid="1-FV-A")
+    mock_ml.feature_values.return_value = iter([record])
+
+    await capturing_mcp.tools["deriva_ml_list_feature_values"](
+        hostname="h", catalog_id="1", table="Image", feature_name="Quality"
+    )
+
+    mock_ml.feature_values.assert_called_once()
+    assert mock_ml.feature_values.call_args.kwargs.get("materialize_limit") == 50_000
+
+
+async def test_list_feature_values_max_results_translates_to_error_envelope(
+    feature_ctx, capturing_mcp, mock_ml
+):
+    """When deriva-ml raises DerivaMLMaterializeLimitExceeded, wire returns {"error": ...}."""
+    from deriva_ml import DerivaMLMaterializeLimitExceeded
+
+    mock_ml.feature_values.side_effect = DerivaMLMaterializeLimitExceeded(
+        actual_count=12_345,
+        limit=100,
+    )
+    result = await capturing_mcp.tools["deriva_ml_list_feature_values"](
+        hostname="h",
+        catalog_id="1",
+        table="Image",
+        feature_name="Quality",
+        max_results=100,
+    )
+    payload = json.loads(result)
+    assert "error" in payload
+    # Message contains the cap and the actual count
+    assert "100" in payload["error"]
+    assert "12345" in payload["error"]
+```
+
+If `_make_feature_record_mock` doesn't exist with that name, search for an analogous fixture (`_make_feature_mock`, etc.) and use it. The mock just needs to expose a `RID` attribute and a `model_dump()` method.
+
+- [ ] **Step 8: Run tests + lint**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && uv run pytest tests/test_feature.py -v 2>&1 | tail -15 && uv run ruff check src/deriva_ml_mcp/tools/feature.py tests/test_feature.py && uv run ruff format src/deriva_ml_mcp/tools/feature.py tests/test_feature.py
+```
+
+Expected: all feature tests pass, ruff clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && git add src/deriva_ml_mcp/tools/feature.py tests/test_feature.py && git commit -m "$(cat <<'EOF'
+feat(feature_values): expose execution_rids= and max_results= parameters
+
+Forwards the v1.31.0 deriva-ml parameters through the MCP wire:
+- execution_rids: server-side filter to a known set of execution RIDs.
+  Lets compare-runs workflows fetch values across N executions in a
+  single round-trip rather than N sequential queries.
+- max_results: caller-controlled materialization cap (default 50000).
+  Translates DerivaMLMaterializeLimitExceeded to a clear error envelope
+  with both numbers and a remediation suggestion.
+
+BREAKING (well, behavior-tightening): queries that previously OOMed
+silently when materializing huge result sets now return a clear error
+envelope. Migration: pass execution_rids= to narrow, or raise
+max_results.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Verify nothing else slipped through
+
+**Files:**
+- Touch: nothing (verification only)
+
+- [ ] **Step 1: Confirm full test suite passes**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && uv run pytest 2>&1 | tail -5
+```
+
+Expected: 287 + 8 new tests (4 sort tests across 3 list tools = 6 sort tests, plus 3 feature tests) = 293 passing. The exact count may differ if prior tasks added more tests; the important thing is "everything passes."
+
+- [ ] **Step 2: Confirm lint + format clean**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && uv run ruff check src tests && uv run ruff format --check src tests
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Grep for any leftover hardcoded behavior**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && grep -rn "find_executions\|find_datasets\|find_workflows" src/deriva_ml_mcp/tools/ src/deriva_ml_mcp/resources/
+```
+
+Inspect each call site and confirm:
+- Tool wrappers and impl helpers that take `sort=` forward it to the call.
+- Resource calls (in `resources/ml.py`) DO NOT pass `sort=` — they use the default `sort=False` (current behavior preserved for snapshot stability).
+
+If any tool-side call site is missing the `sort` forward, fix it before committing.
+
+- [ ] **Step 4: Verify the MCP signatures match the deriva-ml signatures for the new params**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && uv run python -c "
+from deriva_ml_mcp.tools.execution import _list_executions_impl
+from deriva_ml_mcp.tools.workflow import _list_workflows_impl
+from deriva_ml_mcp.tools.dataset.read import _list_datasets_impl
+import inspect
+print('list_executions_impl:', list(inspect.signature(_list_executions_impl).parameters.keys()))
+print('list_datasets_impl:', list(inspect.signature(_list_datasets_impl).parameters.keys()))
+print('list_workflows_impl:', list(inspect.signature(_list_workflows_impl).parameters.keys()))
+"
+```
+
+Expected: all three contain `'sort'` as the last parameter.
+
+- [ ] **Step 5: No commit needed if everything passes**
+
+If anything failed in steps 1-4, fix and commit. Otherwise this task is verification-only.
+
+---
+
+### Task 7: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Find the v3.0 release notes section**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && grep -B 2 -A 8 "v3.0 swept" CLAUDE.md | head -30
+```
+
+This section was added when v3.0.0 shipped. We'll append a similar section for v3.1.
+
+- [ ] **Step 2: Append the v3.1 release notes**
+
+Use the Edit tool. Find the closing of the existing v3.0 description block — likely the line that says "This closes PR 3 of #6." and is followed by a blank line. Insert AFTER that block:
+
+```
+
+
+v3.1 exposes three new optional parameters from the deriva-ml v1.31.0
+release through the MCP tool surface:
+
+- ``deriva_ml_list_executions``, ``deriva_ml_list_datasets``,
+  ``deriva_ml_list_workflows`` (and ``deriva_ml_find_workflow_executions``
+  which shares the executions impl) accept an optional ``sort: bool =
+  False``. Default ``False`` preserves the current RID-ascending order
+  used for stable cursor pagination. ``True`` returns results
+  newest-first by record creation time (RCT desc) -- recommended for
+  "show me what's recent" queries.
+- ``deriva_ml_list_feature_values`` accepts:
+  - ``execution_rids: list[str] | None = None`` -- server-side filter
+    to a known set of execution RIDs. Empty list short-circuits.
+    Recommended for cross-execution comparison queries (e.g. "give
+    me the F1 score for each of these 5 runs in one round-trip").
+  - ``max_results: int = 50_000`` -- caller-controlled cap on rows
+    materialized before pagination. The MCP wrapper translates
+    deriva-ml's ``DerivaMLMaterializeLimitExceeded`` into a clear
+    error envelope. Behavior tightening: queries that previously
+    OOMed silently now return ``{"error": "...exceeds max_results..."}``.
+- ``deriva-ml`` is now pinned to ``>=1.31.0`` (was unpinned;
+  audit-flagged deployment risk).
+
+Resource shapes are unchanged. Resources keep RID-ascending defaults
+for snapshot stability; users who want recent-first content use the
+tool with ``sort=True``.
+
+This release does NOT add a ``compare_metrics`` tool. The
+cross-execution comparison workflow is taught at the skill layer
+(``compare-model-runs`` skill in ``deriva-ml-skills``) which respects
+both metric-storage patterns: features-as-scalars (use
+``execution_rids=`` on ``list_feature_values``) and metrics-as-JSONL-
+asset files (download via ``work-with-assets``, parse locally).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && git add CLAUDE.md && git commit -m "$(cat <<'EOF'
+docs(claude): document v3.1 sort + feature-value-limits surface
+
+Adds a v3.1 section after the v3.0 description, documenting the four
+new parameters (sort= on three list tools + execution_rids + max_results
+on list_feature_values) and the deriva-ml version pin. Also notes the
+intentional non-decision: no compare_metrics tool; the cross-execution
+comparison workflow is taught at the skill layer to respect both
+metric-storage patterns.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: PR, merge, and minor-version release
+
+**Files:**
+- Touch: nothing in the repo (release ops only)
+
+- [ ] **Step 1: Push branch**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && git push -u origin feature/v3.1-sort-and-feature-limits
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && gh pr create --title "v3.1.0: Expose sort=, execution_rids=, max_results= from deriva-ml v1.31.0" --body "$(cat <<'EOF'
+## Summary
+
+Exposes the three new optional parameters from deriva-ml v1.31.0
+through the MCP tool surface. Closes the structural-friction action
+items F1 (sort), F2 (materialize cap), and the F3 backend
+(execution_rids batch filter) from the comprehensive audit.
+
+## Changes
+
+### `sort=` on list tools (4 tools)
+
+- ``list_executions``, ``list_datasets``, ``list_workflows``, and
+  ``find_workflow_executions`` accept ``sort: bool = False``.
+- Default ``False`` preserves RID-asc order (stable cursor pagination).
+- ``True`` forwards ``sort=True`` to deriva-ml's ``find_*`` (RCT desc)
+  and skips the post-fetch RID re-sort.
+
+### `execution_rids=` and `max_results=` on `list_feature_values`
+
+- ``execution_rids: list[str] | None = None`` -- forwards to
+  deriva-ml's ``feature_values(execution_rids=...)``.
+- ``max_results: int = 50_000`` -- forwarded as ``materialize_limit=``.
+  ``DerivaMLMaterializeLimitExceeded`` is translated to a clear error
+  envelope with both numbers + remediation suggestion.
+
+### Version pin
+
+- ``deriva-ml`` is now ``>=1.31.0`` (was unpinned; audit fix).
+
+## Wire-shape impact
+
+- **Additive parameters** -- existing callers see no change.
+- **Behavior tightening on `list_feature_values`** -- queries that
+  previously OOMed silently now return
+  ``{"error": "result set exceeds max_results=50000; pass execution_rids=... to narrow the query, or raise max_results"}``.
+  Documented in CLAUDE.md as a v3.1 release note. Migration: pass
+  ``execution_rids=`` or raise ``max_results=``.
+
+## What this does NOT do
+
+- No ``compare_metrics`` tool. The audit's F3 friction is closed at the
+  primitive layer (``execution_rids=`` exposes the batch filter); a
+  follow-up ``compare-model-runs`` skill teaches the comparison
+  workflow respecting both metric-storage patterns (features-as-scalars
+  and metrics-as-JSONL-asset).
+- No resource shape changes. Resources stay RID-asc for snapshot
+  stability.
+- No new tools, no new resources, no new Pydantic models.
+
+## Test plan
+
+- [x] All 287 prior tests still pass
+- [x] 6 new sort tests (2 each on list_executions / list_datasets /
+      list_workflows -- forwards-on-True, preserves-RID-on-False)
+- [x] 3 new feature_values tests (forwards execution_rids,
+      forwards default max_results, translates exception to error envelope)
+- [x] Resources unchanged: ``ml/executions``, ``ml/datasets``,
+      ``ml/workflows`` still return RID-asc results
+- [x] Lint + format clean
+- [x] CLAUDE.md updated with v3.1 release notes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Merge**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && gh pr merge --merge --delete-branch
+```
+
+- [ ] **Step 4: Bump minor version + tag + push**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && git checkout main && git pull && uv run bump-version minor 2>&1 | tail -10
+```
+
+Expected output (final lines):
+
+```
+New version tag: v3.1.0
+Release process complete!
+```
+
+- [ ] **Step 5: Verify the tag landed**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp && git log --oneline -3 && git tag --sort=-version:refname | head -3
+```
+
+Expected: top tag is `v3.1.0`; top commit is the version bump.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+- F1 (sort on 3 list tools + find_workflow_executions): Tasks 2, 3, 4 cover the three impl helpers; the wrappers thread `sort=bool` through. ✓
+- F2 (`max_results` cap on `list_feature_values`): Task 5 adds the parameter, the forward, and the exception-translation. ✓
+- F3 backend (`execution_rids` on `list_feature_values`): Task 5 also covers this. ✓
+- Version pin: Task 1. ✓
+- CLAUDE.md update: Task 7. ✓
+- Final release: Task 8. ✓
+
+**2. Placeholder scan:** No "TBD", "implement later", "etc." All test code blocks include actual assertions. All `Edit` instructions show the exact `old_string` and `new_string` content (or specify enough context for a unique match).
+
+**3. Type consistency:**
+
+- `sort: bool = False` is the parameter name and type used consistently across Tasks 2, 3, 4 (all three list tools and the impl helpers).
+- `execution_rids: list[str] | None = None` matches the deriva-ml v1.31.0 parameter name and type.
+- `max_results: int = 50_000` is the MCP-wire name; it forwards as `materialize_limit=max_results` to deriva-ml. The naming asymmetry is intentional (audit-driven: `max_results` is the LLM-friendly name, `materialize_limit` is the library-internal name).
+- `True if sort else None` mapping is consistent across all three impls (Tasks 2, 3, 4 use the same idiom to translate the bool into deriva-ml's three-state).
+- `_list_executions_impl` is shared by both `list_executions` and `find_workflow_executions` (Task 2 mentions both).
+
+**Known scope decisions:**
+
+- **No `compare_metrics` tool.** Audit F3 is "closed enough" by exposing `execution_rids=` at the primitive layer. The cross-execution comparison workflow is taught at the skill layer (separate todo).
+- **Resources stay RID-asc.** Wire stability for snapshots matters more than semantic improvement; users who want "recent" content use the tool with `sort=True`.
+- **`sort` is `bool` (not `bool | Callable | None`).** MCP can't carry callables. The library still supports the three-state for direct Python users.
+- **`sort=False` is mapped to deriva-ml `sort=None`** (not `sort=False`). The library rejects `False` explicitly with a `TypeError` ("sort must be None, True, or a callable"), so we have to translate. Tasks 2, 3, 4 use the `True if sort else None` idiom to handle this.
+
+---
+
+## Execution choice
+
+After running this plan, the v3.1.0 milestone unblocks the structural-friction action items from the comprehensive audit. The companion `compare-model-runs` skill addition (in `deriva-ml-skills`) is a separate follow-up plan.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "deriva-mcp-core",
-    "deriva-ml",
+    "deriva-ml>=1.31.0",
 ]
 
 [project.optional-dependencies]

--- a/src/deriva_ml_mcp/tools/dataset/read.py
+++ b/src/deriva_ml_mcp/tools/dataset/read.py
@@ -87,6 +87,7 @@ def _list_datasets_impl(
     after_rid: str | None,
     limit: int,
     include_deleted: bool = False,
+    sort: bool = False,
 ) -> DatasetListResponse:
     """Fetch + paginate datasets. Pure helper -- shared by tool and resource.
 
@@ -95,14 +96,31 @@ def _list_datasets_impl(
         after_rid: Cursor for cursor pagination.
         limit: Max datasets per page (already capped by caller).
         include_deleted: Forward to ``find_datasets(deleted=...)``.
+        sort: If True, results are ordered newest-first by record
+            creation time (RCT desc) -- forwarded to
+            ``deriva_ml.DerivaML.find_datasets(sort=True)``. If False
+            (default), results are RID-ascending for stable cursor
+            pagination. Note that under ``sort=True`` the ``after_rid``
+            cursor still works ("skip up to this RID in the RCT-sorted
+            result"), but pagination through very large sorted result
+            sets is bounded by the internal fetch cap.
 
     Returns:
         ``DatasetListResponse`` -- see ``deriva_ml_mcp._response_models``.
     """
-    datasets = sorted(
-        ml.find_datasets(deleted=include_deleted),
-        key=lambda d: d.dataset_rid,
+    raw = list(
+        ml.find_datasets(
+            deleted=include_deleted,
+            sort=True if sort else None,
+        )
     )
+    # Keep stable RID-ascending order for the default path; under
+    # sort=True we honor the catalog-side RCT-desc ordering and skip
+    # the post-fetch sort (sorting by RID would clobber the RCT order).
+    if sort:
+        datasets = raw
+    else:
+        datasets = sorted(raw, key=lambda d: d.dataset_rid)
     page, truncated, next_after = _paginate(
         datasets,
         after_rid=after_rid,
@@ -220,6 +238,7 @@ def register(ctx: PluginContext) -> None:
         limit: int = 100,
         after_rid: str | None = None,
         preflight_count: bool = False,
+        sort: bool = False,
     ) -> str:
         """Browse all datasets in the catalog with optional pagination.
 
@@ -230,6 +249,10 @@ def register(ctx: PluginContext) -> None:
             limit: Max datasets per page (default 100, max 1000).
             after_rid: RID of last row from previous page to advance cursor.
             preflight_count: If True, return only total count.
+            sort: If True, return results newest-first by record
+                creation time. Recommended for "show me the most
+                recent datasets" queries. Default False preserves the
+                stable RID-ascending order used for cursor pagination.
 
         Returns:
             Preflight:
@@ -266,6 +289,7 @@ def register(ctx: PluginContext) -> None:
                     after_rid=after_rid,
                     limit=capped,
                     include_deleted=include_deleted,
+                    sort=sort,
                 )
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:

--- a/src/deriva_ml_mcp/tools/execution.py
+++ b/src/deriva_ml_mcp/tools/execution.py
@@ -161,6 +161,7 @@ def _list_executions_impl(
     status: str | None,
     after_rid: str | None,
     limit: int,
+    sort: bool = False,
 ) -> ExecutionListResponse:
     """Fetch + paginate executions. Pure helper -- shared by tool and resource.
 
@@ -170,15 +171,36 @@ def _list_executions_impl(
         status: Optional ``ExecutionStatus`` value (string).
         after_rid: Cursor for cursor pagination.
         limit: Max executions per page (already capped by caller).
+        sort: If True, results are ordered newest-first by record
+            creation time (RCT desc) -- forwarded to
+            ``deriva_ml.DerivaML.find_executions(sort=True)``. If False
+            (default), results are RID-ascending for stable cursor
+            pagination. Note that under ``sort=True`` the ``after_rid``
+            cursor still works ("skip up to this RID in the RCT-sorted
+            result"), but pagination through very large sorted result
+            sets is bounded by the internal fetch cap.
 
     Returns:
         ``ExecutionListResponse`` -- see ``deriva_ml_mcp._response_models``.
     """
     status_enum = ExecutionStatus(status) if status else None
-    executions = sorted(
-        ml.find_executions(workflow=workflow_rid, status=status_enum),
-        key=lambda e: getattr(e, "execution_rid", "") or "",
+    raw = list(
+        ml.find_executions(
+            workflow=workflow_rid,
+            status=status_enum,
+            sort=True if sort else None,
+        )
     )
+    # Keep stable RID-ascending order for the default path; under
+    # sort=True we honor the catalog-side RCT-desc ordering and skip
+    # the post-fetch sort (sorting by RID would clobber the RCT order).
+    if sort:
+        executions = raw
+    else:
+        executions = sorted(
+            raw,
+            key=lambda e: getattr(e, "execution_rid", "") or "",
+        )
     page, truncated, next_after = _paginate(
         executions,
         after_rid=after_rid,
@@ -381,6 +403,7 @@ def register(ctx: PluginContext) -> None:
         limit: int = 100,
         after_rid: str | None = None,
         preflight_count: bool = False,
+        sort: bool = False,
     ) -> str:
         """Browse executions in the catalog, optionally filtered by workflow or status.
 
@@ -393,6 +416,10 @@ def register(ctx: PluginContext) -> None:
             limit: Max executions per page (default 100, max 1000).
             after_rid: RID of last row from previous page to advance cursor.
             preflight_count: If True, return only total count.
+            sort: If True, return results newest-first by record
+                creation time. Recommended for "show me the most
+                recent runs" queries. Default False preserves the
+                stable RID-ascending order used for cursor pagination.
 
         Returns:
             Page: ``{"executions": [...], "count",
@@ -430,6 +457,7 @@ def register(ctx: PluginContext) -> None:
                     status=status,
                     after_rid=after_rid,
                     limit=capped,
+                    sort=sort,
                 )
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
@@ -490,6 +518,7 @@ def register(ctx: PluginContext) -> None:
         limit: int = 100,
         after_rid: str | None = None,
         preflight_count: bool = False,
+        sort: bool = False,
     ) -> str:
         """Find all executions of a specific workflow.
 
@@ -504,6 +533,10 @@ def register(ctx: PluginContext) -> None:
             limit: Max executions per page (default 100, max 1000).
             after_rid: RID of last row from previous page to advance cursor.
             preflight_count: If True, return only total count.
+            sort: If True, return results newest-first by record
+                creation time. Recommended for "show me the most
+                recent runs" queries. Default False preserves the
+                stable RID-ascending order used for cursor pagination.
 
         Returns:
             Same shape as ``deriva_ml_list_executions``.
@@ -519,38 +552,30 @@ def register(ctx: PluginContext) -> None:
         try:
             with deriva_call():
                 ml = get_ml(hostname, catalog_id)
-                status_enum = ExecutionStatus(status) if status else None
-                executions = sorted(
-                    ml.find_executions(workflow=workflow_rid, status=status_enum),
-                    key=lambda e: getattr(e, "execution_rid", "") or "",
+                if preflight_count:
+                    status_enum = ExecutionStatus(status) if status else None
+                    total = len(list(ml.find_executions(workflow=workflow_rid, status=status_enum)))
+                    return PreflightCountResponse(
+                        total_count=total,
+                        action_required=(
+                            f"Found {total} executions for workflow {workflow_rid}. "
+                            "Choose a limit and call again with preflight_count=False."
+                        ),
+                    ).model_dump_json(by_alias=True)
+
+                capped = min(max(limit, 0), _MAX_LIMIT)
+                payload = _list_executions_impl(
+                    ml,
+                    workflow_rid=workflow_rid,
+                    status=status,
+                    after_rid=after_rid,
+                    limit=capped,
+                    sort=sort,
                 )
-
-            if preflight_count:
-                total = len(executions)
-                return PreflightCountResponse(
-                    total_count=total,
-                    action_required=(
-                        f"Found {total} executions for workflow {workflow_rid}. "
-                        "Choose a limit and call again with preflight_count=False."
-                    ),
-                ).model_dump_json(by_alias=True)
-
-            capped = min(max(limit, 0), _MAX_LIMIT)
-            page, truncated, next_after = _paginate(
-                executions,
-                after_rid=after_rid,
-                limit=capped,
-                key=partial(_read_rid, rid_key="execution_rid"),
-            )
             # v2.3 reuses ExecutionListResponse here -- the
             # find_workflow_executions response is shape-identical to
             # _list_executions_impl's response (filtered by workflow).
-            return ExecutionListResponse(
-                executions=[_summarize_execution(e) for e in page],
-                count=len(page),
-                truncated=truncated,
-                next_after_rid=next_after,
-            ).model_dump_json(by_alias=True)
+            return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,

--- a/src/deriva_ml_mcp/tools/feature.py
+++ b/src/deriva_ml_mcp/tools/feature.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from deriva_mcp_core import deriva_call
 from deriva_mcp_core.telemetry import audit_event
+from deriva_ml import DerivaMLMaterializeLimitExceeded
 from deriva_ml.execution.execution import ExecutionStatus
 from deriva_ml.feature import FeatureRecord
 
@@ -290,6 +291,8 @@ def register(ctx: PluginContext) -> None:
         limit: int = 100,
         after_rid: str | None = None,
         preflight_count: bool = False,
+        execution_rids: list[str] | None = None,
+        max_results: int = 50_000,
     ) -> str:
         """Query feature values for a (table, feature_name).
 
@@ -322,6 +325,20 @@ def register(ctx: PluginContext) -> None:
             limit: Max records per page (default 100, max 1000).
             after_rid: Last RID from previous page.
             preflight_count: If True, return only the materialized count.
+            execution_rids: Optional filter -- when set, only feature
+                rows whose ``Execution`` value is in this list are
+                materialized. Forwarded server-side to deriva-ml's
+                ``feature_values(execution_rids=...)``. Lets compare-
+                runs workflows fetch values across N executions in a
+                single catalog round-trip rather than N sequential
+                queries. Empty list short-circuits to no rows.
+            max_results: Cap on rows materialized into memory before
+                pagination (default 50000). Returns
+                ``{"error": "..."}`` if the result set exceeds the cap;
+                the error message names the cap and suggests passing
+                ``execution_rids=`` to narrow. Increase if you have a
+                catalog where 50K is too tight; decrease if the LLM
+                runs in a memory-constrained environment.
 
         Returns:
             Page: ``{"records": [<model_dump>, ...], "count",
@@ -332,6 +349,9 @@ def register(ctx: PluginContext) -> None:
         Raises:
             RuntimeError: Wrapped as ``{"error": ...}``, propagated from
                 ``feature_values``.
+            DerivaMLMaterializeLimitExceeded: When the result set
+                exceeds ``max_results``. Translated to
+                ``{"error": "..."}`` on the wire.
 
         Example:
             ``{"records": [{"RID": "1-AAAA", "Quality_Type": "good", ...}],
@@ -383,9 +403,25 @@ def register(ctx: PluginContext) -> None:
 
                 if dataset_rid is not None:
                     ds = ml.lookup_dataset(dataset_rid)
-                    records = list(ds.feature_values(table, feature_name, selector=selector_fn))
+                    records = list(
+                        ds.feature_values(
+                            table,
+                            feature_name,
+                            selector=selector_fn,
+                            materialize_limit=max_results,
+                            execution_rids=execution_rids,
+                        )
+                    )
                 else:
-                    records = list(ml.feature_values(table, feature_name, selector=selector_fn))
+                    records = list(
+                        ml.feature_values(
+                            table,
+                            feature_name,
+                            selector=selector_fn,
+                            materialize_limit=max_results,
+                            execution_rids=execution_rids,
+                        )
+                    )
 
             if preflight_count:
                 total = len(records)
@@ -417,6 +453,18 @@ def register(ctx: PluginContext) -> None:
                     "next_after_rid": next_after,
                 },
                 default=str,
+            )
+        except DerivaMLMaterializeLimitExceeded as exc:
+            # Translate the deriva-ml exception to a clear error envelope.
+            # The exception's __str__ already names the cap and suggests
+            # passing execution_rids=...; we just route it through the
+            # standard _error_envelope so audit/logging are uniform.
+            return _error_envelope(
+                exc,
+                operation="list_feature_values",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,
             )
         except Exception as exc:
             return _error_envelope(

--- a/src/deriva_ml_mcp/tools/workflow.py
+++ b/src/deriva_ml_mcp/tools/workflow.py
@@ -87,6 +87,7 @@ def _list_workflows_impl(
     *,
     after_rid: str | None,
     limit: int,
+    sort: bool = False,
 ) -> WorkflowListResponse:
     """Fetch + paginate workflows. Pure helper -- shared by tool and resource.
 
@@ -94,11 +95,26 @@ def _list_workflows_impl(
         ml: A connected ``deriva_ml.DerivaML`` instance.
         after_rid: Cursor for pagination.
         limit: Max workflows per page (already capped by caller).
+        sort: If True, results are ordered newest-first by record
+            creation time (RCT desc) -- forwarded to
+            ``deriva_ml.DerivaML.find_workflows(sort=True)``. If False
+            (default), results are RID-ascending for stable cursor
+            pagination. Note that under ``sort=True`` the ``after_rid``
+            cursor still works ("skip up to this RID in the RCT-sorted
+            result"), but pagination through very large sorted result
+            sets is bounded by the internal fetch cap.
 
     Returns:
         ``WorkflowListResponse`` -- see ``deriva_ml_mcp._response_models``.
     """
-    workflows = sorted(ml.find_workflows(), key=lambda w: w.rid)
+    raw = list(ml.find_workflows(sort=True if sort else None))
+    # Keep stable RID-ascending order for the default path; under
+    # sort=True we honor the catalog-side RCT-desc ordering and skip
+    # the post-fetch sort (sorting by RID would clobber the RCT order).
+    if sort:
+        workflows = raw
+    else:
+        workflows = sorted(raw, key=lambda w: w.rid)
     page, truncated, next_after = _paginate(
         workflows,
         after_rid=after_rid,
@@ -151,6 +167,7 @@ def register(ctx: PluginContext) -> None:
         limit: int = 100,
         after_rid: str | None = None,
         preflight_count: bool = False,
+        sort: bool = False,
     ) -> str:
         """Browse all workflows registered in the catalog.
 
@@ -160,6 +177,10 @@ def register(ctx: PluginContext) -> None:
             limit: Max workflows per page (default 100, max 1000).
             after_rid: RID of last row from previous page to advance cursor.
             preflight_count: If True, return only total count.
+            sort: If True, return results newest-first by record
+                creation time. Recommended for "show me the most
+                recent workflows" queries. Default False preserves the
+                stable RID-ascending order used for cursor pagination.
 
         Returns:
             Preflight:
@@ -193,7 +214,7 @@ def register(ctx: PluginContext) -> None:
                     ).model_dump_json(by_alias=True)
 
                 capped = min(max(limit, 0), _MAX_LIMIT)
-                payload = _list_workflows_impl(ml, after_rid=after_rid, limit=capped)
+                payload = _list_workflows_impl(ml, after_rid=after_rid, limit=capped, sort=sort)
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             # Read-only tool: log+return without an audit row.

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -65,7 +65,7 @@ async def test_list_datasets_success(dataset_ctx, capturing_mcp, mock_ml):
     assert out["truncated"] is False
     assert out["next_after_rid"] is None
     assert {d["rid"] for d in out["datasets"]} == {"1-AAAA", "1-BBBB"}
-    mock_ml.find_datasets.assert_called_once_with(deleted=False)
+    mock_ml.find_datasets.assert_called_once_with(deleted=False, sort=None)
 
 
 async def test_list_datasets_preflight_returns_count_only(dataset_ctx, capturing_mcp, mock_ml):
@@ -117,6 +117,37 @@ async def test_list_datasets_error_path(dataset_ctx, capturing_mcp, mock_ml):
         await capturing_mcp.tools["deriva_ml_list_datasets"](hostname="h", catalog_id="1")
     )
     assert out == {"error": "boom"}
+
+
+async def test_list_datasets_sort_forwards_to_deriva_ml(dataset_ctx, capturing_mcp, mock_ml):
+    """sort=True forwards sort=True to deriva_ml.find_datasets and skips post-fetch RID sort."""
+    ds_a = _make_dataset_mock(rid="1-DS-NEWEST")
+    ds_b = _make_dataset_mock(rid="1-DS-OLDER")
+    mock_ml.find_datasets.return_value = [ds_a, ds_b]
+
+    result = await capturing_mcp.tools["deriva_ml_list_datasets"](
+        hostname="h", catalog_id="1", sort=True
+    )
+    payload = json.loads(result)
+
+    mock_ml.find_datasets.assert_called_once()
+    assert mock_ml.find_datasets.call_args.kwargs.get("sort") is True
+    rids = [d["rid"] for d in payload["datasets"]]
+    assert rids == ["1-DS-NEWEST", "1-DS-OLDER"]
+
+
+async def test_list_datasets_sort_default_preserves_rid_sort(dataset_ctx, capturing_mcp, mock_ml):
+    """sort=False (default) calls find_datasets with sort=None and re-sorts by RID asc."""
+    ds_z = _make_dataset_mock(rid="1-Z")
+    ds_a = _make_dataset_mock(rid="1-A")
+    mock_ml.find_datasets.return_value = [ds_z, ds_a]
+
+    result = await capturing_mcp.tools["deriva_ml_list_datasets"](hostname="h", catalog_id="1")
+    payload = json.loads(result)
+
+    assert mock_ml.find_datasets.call_args.kwargs.get("sort") is None
+    rids = [d["rid"] for d in payload["datasets"]]
+    assert rids == ["1-A", "1-Z"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -218,6 +218,49 @@ async def test_find_workflow_executions_error_path(execution_ctx, capturing_mcp,
     assert mock_audit.call_count == 0
 
 
+async def test_list_executions_sort_forwards_to_deriva_ml(execution_ctx, capturing_mcp, mock_ml):
+    """sort=True forwards sort=True to deriva_ml.find_executions and skips post-fetch RID sort."""
+    # Mock find_executions to return records in RCT-desc-ish order
+    # (the mock simulates what deriva-ml returns when sort=True).
+    record_a = _make_execution_record_mock(rid="1-EXEC-NEWEST")
+    record_b = _make_execution_record_mock(rid="1-EXEC-OLDER")
+    mock_ml.find_executions.return_value = [record_a, record_b]
+
+    result = await capturing_mcp.tools["deriva_ml_list_executions"](
+        hostname="h", catalog_id="1", sort=True
+    )
+    payload = json.loads(result)
+
+    # Confirm the deriva-ml call received sort=True
+    mock_ml.find_executions.assert_called_once()
+    assert mock_ml.find_executions.call_args.kwargs.get("sort") is True
+
+    # Confirm the wire response preserved the RCT-desc order (NOT
+    # re-sorted by RID).
+    rids = [e["rid"] for e in payload["executions"]]
+    assert rids == ["1-EXEC-NEWEST", "1-EXEC-OLDER"]
+
+
+async def test_list_executions_sort_default_preserves_rid_sort(
+    execution_ctx, capturing_mcp, mock_ml
+):
+    """sort=False (default) calls find_executions with sort=None and re-sorts by RID asc."""
+    # Records intentionally NOT in RID order from the mock; the
+    # wrapper should re-sort them ascending.
+    record_z = _make_execution_record_mock(rid="1-Z")
+    record_a = _make_execution_record_mock(rid="1-A")
+    mock_ml.find_executions.return_value = [record_z, record_a]
+
+    result = await capturing_mcp.tools["deriva_ml_list_executions"](hostname="h", catalog_id="1")
+    payload = json.loads(result)
+
+    # find_executions called with sort=None (the False -> None mapping)
+    assert mock_ml.find_executions.call_args.kwargs.get("sort") is None
+    # Wire response is RID-ascending
+    rids = [e["rid"] for e in payload["executions"]]
+    assert rids == ["1-A", "1-Z"]
+
+
 # ---------------------------------------------------------------------------
 # list_execution_children
 # ---------------------------------------------------------------------------

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -219,8 +219,10 @@ async def test_list_feature_values_success_no_selector(feature_ctx, capturing_mc
     assert out["count"] == 3
     assert out["truncated"] is False
     assert [r["RID"] for r in out["records"]] == ["1-0000", "1-0001", "1-0002"]
-    # selector=None passed through.
-    mock_ml.feature_values.assert_called_once_with("Image", "Quality", selector=None)
+    # selector=None and new kwargs passed through.
+    mock_ml.feature_values.assert_called_once_with(
+        "Image", "Quality", selector=None, materialize_limit=50_000, execution_rids=None
+    )
 
 
 async def test_list_feature_values_selector_newest(feature_ctx, capturing_mcp, mock_ml):
@@ -326,7 +328,9 @@ async def test_list_feature_values_dataset_scope(feature_ctx, capturing_mcp, moc
     )
     assert out["count"] == 1
     mock_ml.lookup_dataset.assert_called_once_with("DS-1")
-    ds.feature_values.assert_called_once_with("Image", "Quality", selector=None)
+    ds.feature_values.assert_called_once_with(
+        "Image", "Quality", selector=None, materialize_limit=50_000, execution_rids=None
+    )
     # Top-level catalog feature_values not used in dataset mode.
     mock_ml.feature_values.assert_not_called()
 
@@ -357,6 +361,61 @@ async def test_list_feature_values_error_path(feature_ctx, capturing_mcp, mock_m
         )
     assert out == {"error": "ermrest down"}
     assert mock_audit.call_count == 0
+
+
+async def test_list_feature_values_forwards_execution_rids(feature_ctx, capturing_mcp, mock_ml):
+    """execution_rids= is forwarded to deriva-ml's feature_values(execution_rids=...)."""
+    mock_ml.feature_values.return_value = iter([_make_record_mock("1-FV-A")])
+
+    await capturing_mcp.tools["deriva_ml_list_feature_values"](
+        hostname="h",
+        catalog_id="1",
+        table="Image",
+        feature_name="Quality",
+        execution_rids=["1-EXEC-A", "1-EXEC-B"],
+    )
+
+    mock_ml.feature_values.assert_called_once()
+    assert mock_ml.feature_values.call_args.kwargs.get("execution_rids") == [
+        "1-EXEC-A",
+        "1-EXEC-B",
+    ]
+
+
+async def test_list_feature_values_default_max_results_passed(feature_ctx, capturing_mcp, mock_ml):
+    """The default max_results=50000 is forwarded as materialize_limit=50000."""
+    mock_ml.feature_values.return_value = iter([_make_record_mock("1-FV-A")])
+
+    await capturing_mcp.tools["deriva_ml_list_feature_values"](
+        hostname="h", catalog_id="1", table="Image", feature_name="Quality"
+    )
+
+    mock_ml.feature_values.assert_called_once()
+    assert mock_ml.feature_values.call_args.kwargs.get("materialize_limit") == 50_000
+
+
+async def test_list_feature_values_max_results_translates_to_error_envelope(
+    feature_ctx, capturing_mcp, mock_ml
+):
+    """When deriva-ml raises DerivaMLMaterializeLimitExceeded, wire returns {"error": ...}."""
+    from deriva_ml import DerivaMLMaterializeLimitExceeded
+
+    mock_ml.feature_values.side_effect = DerivaMLMaterializeLimitExceeded(
+        actual_count=12_345,
+        limit=100,
+    )
+    result = await capturing_mcp.tools["deriva_ml_list_feature_values"](
+        hostname="h",
+        catalog_id="1",
+        table="Image",
+        feature_name="Quality",
+        max_results=100,
+    )
+    payload = json.loads(result)
+    assert "error" in payload
+    # Message contains the cap and the actual count (verify both show up)
+    assert "100" in payload["error"]
+    assert "12345" in payload["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -118,6 +118,37 @@ async def test_list_workflows_error_path(workflow_ctx, capturing_mcp, mock_ml):
     assert mock_audit.call_count == 0
 
 
+async def test_list_workflows_sort_forwards_to_deriva_ml(workflow_ctx, capturing_mcp, mock_ml):
+    """sort=True forwards sort=True to deriva_ml.find_workflows and skips post-fetch RID sort."""
+    wf_a = _make_workflow_mock(rid="1-WF-NEWEST")
+    wf_b = _make_workflow_mock(rid="1-WF-OLDER")
+    mock_ml.find_workflows.return_value = [wf_a, wf_b]
+
+    result = await capturing_mcp.tools["deriva_ml_list_workflows"](
+        hostname="h", catalog_id="1", sort=True
+    )
+    payload = json.loads(result)
+
+    mock_ml.find_workflows.assert_called_once()
+    assert mock_ml.find_workflows.call_args.kwargs.get("sort") is True
+    rids = [w["rid"] for w in payload["workflows"]]
+    assert rids == ["1-WF-NEWEST", "1-WF-OLDER"]
+
+
+async def test_list_workflows_sort_default_preserves_rid_sort(workflow_ctx, capturing_mcp, mock_ml):
+    """sort=False (default) calls find_workflows with sort=None and re-sorts by RID asc."""
+    wf_z = _make_workflow_mock(rid="1-Z")
+    wf_a = _make_workflow_mock(rid="1-A")
+    mock_ml.find_workflows.return_value = [wf_z, wf_a]
+
+    result = await capturing_mcp.tools["deriva_ml_list_workflows"](hostname="h", catalog_id="1")
+    payload = json.loads(result)
+
+    assert mock_ml.find_workflows.call_args.kwargs.get("sort") is None
+    rids = [w["rid"] for w in payload["workflows"]]
+    assert rids == ["1-A", "1-Z"]
+
+
 # ---------------------------------------------------------------------------
 # get_workflow
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Exposes the three new optional parameters from deriva-ml v1.31.0
through the MCP tool surface. Closes the structural-friction action
items F1 (sort), F2 (materialize cap), and the F3 backend
(execution_rids batch filter) from the comprehensive audit
(`docs/superpowers/notes/audit-2026-04-27-comprehensive.md`).

## Changes

### `sort=` on list tools (4 tools)

- `list_executions`, `list_datasets`, `list_workflows`, and
  `find_workflow_executions` accept `sort: bool = False`.
- Default `False` preserves RID-asc order (stable cursor pagination).
- `True` forwards `sort=True` to deriva-ml's `find_*` (RCT desc)
  and skips the post-fetch RID re-sort.
- `find_workflow_executions` was DRY-refactored to delegate to
  the shared `_list_executions_impl` (cleanup; no wire change).

### `execution_rids=` and `max_results=` on `list_feature_values`

- `execution_rids: list[str] | None = None` — forwards to
  deriva-ml's `feature_values(execution_rids=...)`.
- `max_results: int = 50_000` — forwarded as `materialize_limit=`.
  `DerivaMLMaterializeLimitExceeded` is translated to a clear error
  envelope with both numbers + remediation suggestion.

### Version pin

- `deriva-ml` is now `>=1.31.0` (was unpinned; audit fix).

## Wire-shape impact

- **Additive parameters** — existing callers see no change.
- **Behavior tightening on `list_feature_values`** — queries that
  previously OOMed silently now return
  `{"error": "result set exceeds max_results=50000; pass execution_rids=... to narrow the query, or raise max_results"}`.
  Documented in CLAUDE.md as a v3.1 release note. Migration: pass
  `execution_rids=` or raise `max_results=`.

## What this does NOT do

- No `compare_metrics` tool. The audit's F3 friction is closed at
  the primitive layer (`execution_rids=` exposes the batch filter);
  a follow-up `compare-model-runs` skill teaches the comparison
  workflow respecting both metric-storage patterns
  (features-as-scalars and metrics-as-JSONL-asset).
- No resource shape changes. Resources stay RID-asc for snapshot
  stability.
- No new tools, no new resources, no new Pydantic models.

## Test plan

- [x] All 287 prior tests still pass
- [x] 6 new sort tests (2 each on list_executions / list_datasets /
      list_workflows — forwards-on-True, preserves-RID-on-False)
- [x] 3 new feature_values tests (forwards execution_rids,
      forwards default max_results, translates exception to error envelope)
- [x] `find_workflow_executions` existing tests still pass (DRY refactor)
- [x] Resources unchanged: `ml/executions`, `ml/datasets`,
      `ml/workflows` still return RID-asc results
- [x] Lint + format clean
- [x] CLAUDE.md updated with v3.1 release notes
- [x] Final-review subagent: APPROVED FOR RELEASE

🤖 Generated with [Claude Code](https://claude.com/claude-code)