### PR TITLE
v3.1.1: deriva_ml_concepts prompt + entity-resolution workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,6 +332,47 @@ respects both metric-storage patterns: features-as-scalars (use
 `execution_rids=` on `list_feature_values`) and metrics-as-JSONL-
 asset files (download via `work-with-assets`, parse locally).
 
+## Cross-Repo Sync: `deriva_ml_concepts` prompt ↔ `deriva-ml-context` skill
+
+The `_CONCEPTS_GUIDE` constant in `src/deriva_ml_mcp/prompts.py`
+(rendered as the `deriva_ml_concepts` MCP prompt) and the
+`skills/deriva-ml-context/SKILL.md` file in the companion
+`deriva-ml-skills` Claude Code plugin share their conceptual content
+DELIBERATELY. Both must explain:
+
+- What DerivaML is (one paragraph)
+- The five core abstractions (Dataset, Workflow, Execution, Feature, Asset)
+- The provenance principle (every artifact links to its producing Execution)
+- The vocabulary-extension pattern (use core's `add_term` with `schema="deriva-ml"`)
+
+The duplication is intentional. The two surfaces serve different LLM
+clients with different invocation models:
+
+- **Claude Code clients** with the `deriva-ml-skills` plugin loaded
+  get the conceptual frame pushed into context proactively via the
+  always-on `deriva-ml-context` skill (the audit-named "load-bearing"
+  path).
+- **Non-Claude-Code clients** (Cursor, SDK-based agents, raw FastMCP
+  clients, etc.) pull the same frame in via the `deriva_ml_concepts`
+  prompt over the MCP wire.
+
+The skill is RICHER than the prompt — it adds tool-selection guidance,
+cross-references to other skills, the worked "when to reach back to
+the raw catalog surface" table, and other Claude-Code-specific
+value-add. The prompt is the conceptual FLOOR; the skill is floor +
+Claude-Code value-add.
+
+**When updating the abstractions** (rare — they're fundamental),
+update BOTH:
+
+1. `_CONCEPTS_GUIDE` in `src/deriva_ml_mcp/prompts.py` (this repo)
+2. `skills/deriva-ml-context/SKILL.md` in `../deriva-ml-skills`
+
+Both files carry an inline comment block at their top pointing at the
+other side. The matching comment lives in
+`../deriva-ml-skills/CLAUDE.md` under the same section heading so the
+constraint is visible from either repo.
+
 ## Coverage Report
 
 `docs/coverage.md` records what happened to every old `deriva-mcp` tool. Update it

--- a/src/deriva_ml_mcp/prompts.py
+++ b/src/deriva_ml_mcp/prompts.py
@@ -6,7 +6,7 @@ docstrings. FastMCP surfaces them through the MCP ``prompts/list`` and
 the start of a conversation -- they are the cold-start anchor for the
 plugin's 45 tools and 11 resources.
 
-The three prompts complement the four built-in core prompts shipped by
+The four prompts complement the four built-in core prompts shipped by
 ``deriva-mcp-core`` (``query_guide``, ``entity_guide``,
 ``annotation_guide``, ``catalog_guide``) -- they do not replace them.
 Core's prompts cover generic ERMrest / annotation / catalog primitives;
@@ -16,7 +16,12 @@ dedup contract.
 
 Prompts registered here:
 
-    deriva_ml_getting_started     -- read first; orients the LLM
+    deriva_ml_concepts            -- conceptual frame; what DerivaML is,
+                                     the five abstractions, the provenance
+                                     principle. Read first if cold-starting.
+    deriva_ml_getting_started     -- operational orientation; (hostname,
+                                     catalog_id) rule, pagination, error
+                                     envelope, tool domains, discovery
     deriva_ml_execution_lifecycle -- state machine + commit semantics
     deriva_ml_workflow_dedup      -- deriva_ml_create_workflow is idempotent
 
@@ -47,11 +52,217 @@ if TYPE_CHECKING:
 #
 # Each constant is the full text returned as a single user message.
 # Plain ASCII only -- no en-dashes, smart quotes, or other Unicode.
+#
+# SYNC NOTE -- KEEP `_CONCEPTS_GUIDE` IN LOCKSTEP WITH THE
+# `deriva-ml-context` SKILL.
+#
+# `_CONCEPTS_GUIDE` deliberately mirrors the conceptual sections (what
+# DerivaML is, the five abstractions, the provenance principle / steering
+# principle, the vocabulary-extension pattern) of the `deriva-ml-context`
+# always-on skill in the companion `deriva-ml-skills` Claude Code plugin
+# (`skills/deriva-ml-context/SKILL.md`).
+#
+# The duplication is intentional:
+#   - Claude Code clients with the `deriva-ml-skills` plugin loaded get
+#     the conceptual frame pushed into context proactively via the
+#     always-on skill (the audit calls this the "load-bearing" path).
+#   - Non-Claude-Code clients (Cursor, SDK-based agents, raw FastMCP
+#     clients, etc.) pull the same frame in via the `deriva_ml_concepts`
+#     prompt over the MCP wire.
+#
+# The skill is RICHER than this prompt -- it adds tool-selection
+# guidance, cross-references to other skills, and the worked
+# "when to reach back to the raw catalog surface" table. This prompt is
+# the conceptual FLOOR; the skill is floor + Claude-Code value-add.
+#
+# When the abstractions evolve (rare -- they're fundamental), update BOTH:
+#   1. `_CONCEPTS_GUIDE` below
+#   2. `../deriva-ml-skills/skills/deriva-ml-context/SKILL.md`
+#      (the skill side carries a matching comment block at the top).
+
+
+_CONCEPTS_GUIDE = """\
+DERIVA-ML CONCEPTS -- read this if you do not already have a mental model of \
+DerivaML's domain. The deriva_ml_getting_started prompt assumes this conceptual \
+frame; if you arrived here cold, read this first.
+
+WHAT IS DERIVA-ML
+-----------------
+DerivaML is a reproducible-ML layer built on top of Deriva catalogs. It
+records the full provenance of every ML run -- inputs, code versions,
+configurations, outputs, and intermediate artifacts -- as first-class
+catalog entities so that experiments can be reproduced, audited,
+compared across users, and resumed across sessions.
+
+The stack:
+
+  - ``deriva-ml`` is the Python library; provides the ``DerivaML`` class,
+    ``Workflow``, ``ExecutionConfiguration``, dataset / feature / asset
+    APIs, and the ``with ml.create_execution(config) as exe:`` context
+    manager pattern.
+  - ``deriva-ml-mcp`` is THIS plugin (loaded by ``deriva-mcp-core``);
+    exposes the ``deriva_ml_*`` MCP tools and the
+    ``deriva://catalog/{h}/{c}/ml/...`` resource family.
+  - ``deriva-ml-skills`` is a companion Claude Code skill plugin that
+    layers workflow guidance on top -- only relevant when the LLM is
+    running inside Claude Code with that plugin loaded.
+
+THE FIVE CORE ABSTRACTIONS
+--------------------------
+These are the surface DerivaML adds on top of plain Deriva. Each is
+stored as one or more Deriva tables underneath, but TREAT THEM AS
+DERIVA-ML DOMAIN OBJECTS, NOT AS RAW TABLES.
+
+  Dataset    A versioned collection of catalog rows that an execution
+             consumed or produced. Datasets have a type
+             (``Dataset_Type`` vocabulary), an element-type spec, a
+             version history, and can be downloaded as bags. Use
+             ``deriva_ml_create_dataset``, ``deriva_ml_add_dataset_members``,
+             ``deriva_ml_increment_dataset_version``,
+             ``deriva_ml_cache_dataset``.
+
+  Workflow   A versioned reference to the code (URL + git commit hash)
+             that knows how to do a thing. A Workflow is content-
+             addressed: same URL + same commit = same Workflow row.
+             Workflows are typed (``Workflow_Type`` vocabulary). Use
+             ``deriva_ml_create_workflow``,
+             ``deriva_ml_find_workflow_by_url``. See the
+             ``deriva_ml_workflow_dedup`` prompt for idempotency.
+
+  Execution  One run of a Workflow against specific input Datasets,
+             producing output Datasets / Features / Assets. Executions
+             have a status (``Execution_Status_Type``), inputs / outputs
+             links, and a state machine that the lifecycle tools advance
+             through. Use ``deriva_ml_create_execution``,
+             ``deriva_ml_start_execution``, ``deriva_ml_commit_execution``,
+             ``deriva_ml_abort_execution``, ``deriva_ml_update_execution``.
+             See the ``deriva_ml_execution_lifecycle`` prompt for the
+             full state machine.
+
+  Feature    A typed value attached to a row of some target table (e.g.
+             a per-image classification label produced by a run, or a
+             scalar metric like ``f1_score`` per execution). Features
+             link the value back to the producing Execution for
+             provenance. Use ``deriva_ml_create_feature``,
+             ``deriva_ml_add_feature_values``,
+             ``deriva_ml_list_feature_values``.
+
+  Asset      A file uploaded to hatrac and recorded in the catalog with
+             an ``Asset_Type`` and provenance link to its producing
+             Execution. The MCP surface covers asset metadata only;
+             file bytes are out of scope (the MCP server has no general
+             access to the user's local filesystem). Use
+             ``deriva_ml_list_asset_tables``, ``deriva_ml_lookup_asset``,
+             ``deriva_ml_update_asset``. For asset bytes, hand off to
+             local Python via the user's environment (``ml.download_asset``,
+             ``exe.asset_file_path()``).
+
+THE PROVENANCE PRINCIPLE
+------------------------
+Every artifact (Dataset, Feature value, output Asset) MUST be linked to
+the Execution that produced it. This is why:
+
+  - You create an Execution BEFORE writing outputs, not after.
+  - You ``deriva_ml_start_execution`` to advance the state machine
+    BEFORE writing outputs (the alternative is the auto-wrap path of
+    ``deriva_ml_add_feature_values``; see the lifecycle prompt).
+  - You ``deriva_ml_commit_execution`` AFTER writing outputs, so the
+    staged values become visible to downstream queries.
+  - ``deriva_ml_update_execution`` deliberately does NOT accept a
+    ``status=`` argument -- the state machine is enforced by the
+    lifecycle tools, NOT by free-form status edits. Manual status
+    flips would let an LLM put the catalog into a state where the
+    upload-outputs side effect of commit never ran.
+
+The provenance principle is what makes ML runs reproducible across
+users, sessions, and time. Bypassing it (e.g. via raw entity CRUD on
+the underlying Deriva tables) breaks reproducibility silently.
+
+DERIVA-ML ABSTRACTIONS TAKE PRECEDENCE
+--------------------------------------
+A loaded deriva-ml-mcp plugin sits on top of ``deriva-mcp-core``, which
+exposes generic catalog primitives (``insert_records``, ``update_record``,
+``get_record``, schema CRUD, etc). For the FIVE ABSTRACTIONS above, you
+must use the ``deriva_ml_*`` tools, NEVER the raw core tools. The
+``deriva_ml_*`` tools enforce:
+
+  - Business logic (e.g. ``deriva_ml_add_dataset_members`` validates RIDs
+    against the dataset's element-type spec; raw inserts will let you
+    add wrong-table rows that break the dataset on materialization).
+  - FK validation across the Dataset / Workflow / Execution graph (every
+    Execution links to a Workflow; every output Dataset links to its
+    producing Execution; raw inserts can create dangling references).
+  - Provenance tracking (each mutation links back to the active
+    Execution; raw inserts have no Execution context).
+  - Version management (``deriva_ml_increment_dataset_version`` creates
+    a new snapshot; raw inserts skip the version bump and leave consumers
+    pointed at stale data).
+  - RAG re-indexing (the ``deriva_ml_*`` tools fire surgical re-index
+    hooks so freshly mutated rows are searchable on the next
+    ``rag_search``; raw inserts do not).
+  - Audit emission (every ``deriva_ml_*`` mutation emits an audit event
+    with the operation name; raw inserts use the generic core audit
+    which lacks DerivaML-specific context).
+
+For catalog objects that are NOT one of the five abstractions (custom
+domain tables like ``Subject`` / ``Image``, generic vocabularies, schema
+introspection, display annotations), use the core tools.
+
+VOCABULARIES AND THE EXTENSION PATTERN
+--------------------------------------
+DerivaML ships four built-in controlled vocabularies:
+
+  Dataset_Type            -- tag a Dataset's purpose (e.g. ``Training``,
+                             ``Test``, ``Validation``)
+  Workflow_Type           -- tag a Workflow's role (e.g. ``Model_Training``,
+                             ``Inference``, ``Data_Curation``)
+  Asset_Type              -- tag an Asset's file kind (e.g. ``Metrics_File``,
+                             ``Model_Weights``, ``Image``)
+  Execution_Status_Type   -- managed automatically by the state machine;
+                             do NOT extend manually
+
+These are CONTROLLED enumerations: a Dataset's type must be a registered
+term, not free-form text. Pass term values that already exist; if the
+right term doesn't exist, EXTEND the vocabulary first using core's
+generic ``add_term`` tool with ``schema="deriva-ml"``:
+
+    add_term(hostname=..., catalog_id=..., schema="deriva-ml",
+             table="Dataset_Type", name="My_New_Type",
+             description="...")
+
+(Legacy dedicated wrappers like ``add_dataset_type`` were retired; the
+generic ``add_term`` from ``deriva-mcp-core`` handles all four
+DerivaML vocabularies.)
+
+For YOUR OWN domain vocabularies (``Sample_Type``, ``Tissue_Type``,
+``Image_Quality``, etc.), use the same generic ``add_term`` with your
+domain schema name instead of ``"deriva-ml"``.
+
+WHERE TO GO NEXT
+----------------
+Now that you have the conceptual frame, read these in this order:
+
+  1. ``deriva_ml_getting_started``  -- operational orientation:
+     stateless model, pagination, error envelope, the five tool
+     domains, discovery via resources / RAG, the mutation chain.
+
+  2. ``deriva_ml_execution_lifecycle``  -- before doing any execution
+     work. The state machine is non-obvious and the wrong call order
+     can leave executions stuck.
+
+  3. ``deriva_ml_workflow_dedup``  -- before calling
+     ``deriva_ml_create_workflow``. It is idempotent; do not preflight.
+"""
 
 
 _GETTING_STARTED_GUIDE = """\
 DERIVA-ML GETTING STARTED -- read this before using any deriva-ml-mcp tool \
 or resource.
+
+If you do not already have a mental model of DerivaML's domain (what a
+Dataset / Workflow / Execution / Feature / Asset is, why every artifact
+is linked to its producing Execution), read the ``deriva_ml_concepts``
+prompt FIRST. This prompt assumes that conceptual frame.
 
 This plugin exposes DerivaML's ML-workflow surface (datasets, features,
 workflows, executions) on top of any Deriva catalog. It is layered above
@@ -579,7 +790,7 @@ For one workflow's full detail (name, type, url, checksum, version, etc.):
 
 
 def register(ctx: PluginContext) -> None:
-    """Register the three deriva-ml MCP prompts with the plugin context.
+    """Register the four deriva-ml MCP prompts with the plugin context.
 
     Args:
         ctx: PluginContext supplied by deriva-mcp-core at startup.
@@ -594,10 +805,26 @@ def register(ctx: PluginContext) -> None:
     """
 
     @ctx.prompt(
+        "deriva_ml_concepts",
+        description=(
+            "Conceptual frame for any LLM client cold-starting on deriva-ml-mcp: "
+            "what DerivaML is, the five core abstractions (Dataset, Workflow, "
+            "Execution, Feature, Asset), the provenance principle, and the "
+            "vocabulary-extension pattern. Read this BEFORE deriva_ml_getting_started "
+            "if you do not already have a DerivaML mental model. Mirrors the "
+            "deriva-ml-context skill in the deriva-ml-skills Claude Code plugin "
+            "for non-Claude-Code clients (Cursor, SDK-based agents, etc.)."
+        ),
+    )
+    def deriva_ml_concepts() -> str:
+        return _CONCEPTS_GUIDE
+
+    @ctx.prompt(
         "deriva_ml_getting_started",
         description=(
             "Cold-start orientation for deriva-ml-mcp: the (hostname, catalog_id) rule, "
-            "the four ML domains, discovery via resources/RAG, the workflow->execution->outputs chain"
+            "the four ML domains, discovery via resources/RAG, the workflow->execution->outputs chain. "
+            "Assumes the conceptual frame from deriva_ml_concepts."
         ),
     )
     def deriva_ml_getting_started() -> str:

--- a/src/deriva_ml_mcp/prompts.py
+++ b/src/deriva_ml_mcp/prompts.py
@@ -238,6 +238,108 @@ For YOUR OWN domain vocabularies (``Sample_Type``, ``Tissue_Type``,
 ``Image_Quality``, etc.), use the same generic ``add_term`` with your
 domain schema name instead of ``"deriva-ml"``.
 
+THE ENTITY RESOLUTION WORKFLOW
+------------------------------
+This applies to ANY catalog entity referenced by name -- tables,
+columns, schemas, vocabulary terms, datasets, workflows, executions,
+features, assets, or anything else the catalog tracks. ML-domain or
+generic, the workflow is the same.
+
+When the user mentions an entity by name, OR when the user asks to
+create a new one, follow these steps:
+
+  1. EXACT MATCH FIRST. If the user-supplied string matches a known
+     canonical name exactly (case-sensitive), use it. Don't search,
+     don't ask. Catalog names are case-sensitive: ``"Training"`` is
+     the ``Dataset_Type`` term; ``"training"`` is not.
+
+  2. SEMANTIC SEARCH IF AMBIGUOUS, FUZZY, OR DESCRIPTIVE. If the
+     user's phrasing doesn't match a canonical name exactly -- it's
+     descriptive (``"the training data type"``), abbreviated
+     (``"DR"``), misspelled (``"Diagnossis"``), or just unfamiliar --
+     call ``rag_search`` with their phrase. Use the appropriate
+     ``doc_type``:
+
+       - ``catalog-schema`` for tables, columns, features,
+         vocabulary terms
+       - ``catalog-data`` for datasets, workflows, executions
+       - ``ml-docs`` / ``user-guide`` for documentation references
+
+  3. PRESENT A PICKER WHEN MULTIPLE OPTIONS APPEAR. If RAG returns
+     more than one plausible candidate, list 3-5 of them with their
+     canonical name + one-line description + RID (or
+     ``table.column`` for column hits) and ask the user to pick.
+     Don't choose blindly when reasonable people might disagree. If
+     RAG returns ONE clear top hit (significantly above runners-up),
+     use it but tell the user what you resolved it to in one
+     sentence (``"I'm using the Training Dataset_Type."``). If RAG
+     returns NO useful hits, ask a clarifying question. DO NOT
+     fabricate a name; DO NOT call ``create_*`` with a guessed
+     identifier.
+
+  4a. LOOKUP PATH ENDS HERE. With the canonical entity in hand, you
+      can call the relevant ``lookup_*`` / ``get_*`` / ``find_*``
+      tool, or pass the canonical name / RID to whatever operation
+      the user requested.
+
+  4b. CREATE PATH HAS ONE MORE STEP. If you arrived here because
+      the user asked to CREATE a new entity, before actually
+      calling ``create_*``, surface the candidates from step 3 to
+      the user explicitly:
+
+         "I found these similar existing entities: <list>. Would
+          modifying or reusing one of these work, or do you want
+          to create a new one?"
+
+      If the user picks an existing one, switch to the lookup path
+      (4a). If the user confirms a new one is needed, proceed to
+      step 5.
+
+  5. DESCRIPTION HANDLING ON CREATE. Every ``create_*`` /
+     ``add_*`` tool that accepts a ``description`` (or ``comment``)
+     argument SHOULD receive a non-empty one. Descriptions become
+     part of the catalog's RAG index and are visible to every
+     future user; an empty description means future LLMs and
+     humans cannot tell what the entity was for.
+
+     If the user did not supply a description, GENERATE A
+     SUGGESTION from the conversation context (what was the user
+     trying to accomplish? what role does this entity play in
+     their workflow?), THEN SHOW IT TO THE USER for
+     confirmation or edit:
+
+         "I'm going to create the <entity> with this description:
+          '<generated suggestion>'. OK to proceed, or would you
+          like to edit it?"
+
+     Pass the confirmed text (or the user's edit) to the tool.
+     Don't pass an empty string. Don't pass placeholder text like
+     ``"TODO"`` or ``"(no description)"``. Don't fabricate a
+     description without showing the user.
+
+     If you're operating autonomously with no human in the loop
+     (an unattended agent script), fall back to your best
+     generated suggestion and add a note in your response so a
+     future audit can see which descriptions were
+     auto-generated without confirmation.
+
+WHY THIS WORKFLOW MATTERS
+-------------------------
+The cost of getting it wrong:
+
+  - Fabricating a name leads to FK-violation errors at best, or
+    silent data corruption at worst (e.g. a typo'd ``"Trianing"``
+    Dataset_Type that creates a duplicate vocab term).
+  - Skipping the picker when there are multiple matches lets the
+    LLM commit the user to an entity they didn't intend.
+  - Empty descriptions destroy catalog discoverability -- a
+    catalog with 500 datasets all described as ``""`` is
+    indistinguishable from a catalog with 500 datasets nobody
+    can find.
+
+The cost of doing it right is one or two extra round-trips per
+operation. Always prefer the round-trips.
+
 WHERE TO GO NEXT
 ----------------
 Now that you have the conceptual frame, read these in this order:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -146,7 +146,7 @@ _ML_RESOURCE_URIS = frozenset(
     }
 )
 
-# Names of the three MCP prompts registered by ``prompts.py``. The
+# Names of the four MCP prompts registered by ``prompts.py``. The
 # plugin-level test below uses ``>=`` (superset) rather than equality
 # so a future fully-loaded core that registers additional prompts via
 # the same context wouldn't break this assertion -- the contract here
@@ -154,6 +154,7 @@ _ML_RESOURCE_URIS = frozenset(
 # Per-prompt name exactness is pinned in ``test_prompts.py``.
 _ML_PROMPT_NAMES = frozenset(
     {
+        "deriva_ml_concepts",
         "deriva_ml_getting_started",
         "deriva_ml_execution_lifecycle",
         "deriva_ml_workflow_dedup",
@@ -293,8 +294,8 @@ def test_register_wires_four_catalog_connect_hooks(ctx):
     assert len(ctx._catalog_connect_hooks) == 4
 
 
-def test_register_wires_three_prompts(ctx, capturing_mcp):
-    """``register(ctx)`` must wire all three ML prompts via ``prompts.register``.
+def test_register_wires_four_prompts(ctx, capturing_mcp):
+    """``register(ctx)`` must wire all four ML prompts via ``prompts.register``.
 
     Uses ``>=`` rather than ``==`` so a future fully-loaded core that
     happens to register prompts via the same ``ctx`` wouldn't break

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,4 +1,4 @@
-"""Unit tests for the three deriva-ml MCP prompts.
+"""Unit tests for the four deriva-ml MCP prompts.
 
 Prompts are pure data -- no DERIVA I/O, no catalog access. The tests
 exercise registration shape (count, names) and content invariants
@@ -12,6 +12,7 @@ from deriva_ml_mcp import prompts
 
 _EXPECTED_PROMPT_NAMES = frozenset(
     {
+        "deriva_ml_concepts",
         "deriva_ml_getting_started",
         "deriva_ml_execution_lifecycle",
         "deriva_ml_workflow_dedup",
@@ -24,14 +25,14 @@ def test_register_runs_without_error(ctx):
     prompts.register(ctx)
 
 
-def test_three_prompts_registered(ctx, capturing_mcp):
-    """Exactly three prompts land in the capturing MCP after register."""
+def test_four_prompts_registered(ctx, capturing_mcp):
+    """Exactly four prompts land in the capturing MCP after register."""
     prompts.register(ctx)
-    assert len(capturing_mcp.prompts) == 3
+    assert len(capturing_mcp.prompts) == 4
 
 
 def test_prompt_names_exact(ctx, capturing_mcp):
-    """The three prompts must be registered under the documented names.
+    """The four prompts must be registered under the documented names.
 
     Exact-equality (rather than ``issubset``) catches both directions:
     a missing prompt and an unexpected one. The plugin-level test in


### PR DESCRIPTION
## Summary

Adds the conceptual cold-start prompt that the audit identified as
missing: any non-Claude-Code MCP client (Cursor, SDK-based agents,
raw FastMCP) had no equivalent of the `deriva-ml-context` always-on
skill, so it operated on 45+ tools with no conceptual frame.

## Changes

### New prompt: `deriva_ml_concepts`

The conceptual floor for any LLM client. Covers:
- What DerivaML is (one paragraph)
- The five core abstractions (Dataset, Workflow, Execution, Feature, Asset)
- The provenance principle and why it forbids manual status edits
- The vocabulary-extension pattern (`add_term` with `schema="deriva-ml"`)
- **The unified entity-resolution workflow** (new — see below)

`deriva_ml_getting_started` gets a one-line lead pointing readers at
this prompt if they don't already have the conceptual frame.

### New section: "THE ENTITY RESOLUTION WORKFLOW"

A 6-step workflow that applies to ANY catalog entity reference
(lookup or create), ML-domain or generic:

1. Exact match first
2. RAG search if ambiguous/fuzzy/descriptive
3. Picker when multiple options
4. Lookup path ends with the chosen entity
5. Create path: surface candidates ("modify/reuse or new?")
6. Description handling: generate suggestion from context,
   SHOW to user for confirmation, then pass through

Phrased plugin-agnostically so the text is reusable verbatim if
`deriva-mcp-core` later canonicalizes the workflow at the upstream
layer (issue to follow). Includes a "WHY THIS WORKFLOW MATTERS"
justification for the three failure modes prevented.

### Cross-repo sync markers

The `_CONCEPTS_GUIDE` constant deliberately mirrors the conceptual
sections of the `deriva-ml-context` always-on skill in the
companion `deriva-ml-skills` Claude Code plugin. Markers added in:

- `_CONCEPTS_GUIDE` (inline comment block at the constant's top)
- `CLAUDE.md` (new "Cross-Repo Sync" section)

Matching markers land in the deriva-ml-skills v1.2.0 PR.

## Wire-shape impact

**Purely additive.** New prompt, no breaking changes. All existing
prompts (`deriva_ml_getting_started`, `deriva_ml_execution_lifecycle`,
`deriva_ml_workflow_dedup`) are unchanged in content; just one
sentence cross-reference added to `deriva_ml_getting_started`.

## Test plan

- [x] All 296 prior tests pass
- [x] Test count assertions updated (`three_prompts` → `four_prompts`)
- [x] Prompt-name set assertions updated to include `deriva_ml_concepts`
- [x] Doctest collection passes
- [x] Lint + format clean
- [x] CLAUDE.md cross-repo sync section present

## Follow-ups (separate issues / PRs)

- File against `deriva-mcp-core`: canonicalize the entity-resolution
  workflow in core's prompts (its `entity_guide` is the natural home
  since the workflow applies to any catalog entity, not just ML).
- File against `deriva-mcp-core`: port the Layer-3 dup-detection from
  the legacy `deriva-mcp` server back into core's `create_*` tools.
  The `semantic-awareness` skill currently documents this feature as
  "the new server does this automatically" — but the cut-over to
  `deriva-mcp-core` lost it. Either restore the feature or update the
  skill (separate skill-cleanup PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)