### PR TITLE
fix(tools): wrap sync deriva-ml calls in asyncio.to_thread across all modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,15 @@ Inherited from `deriva-mcp-core`'s plugin authoring guide
   Tool names, audit event names, and prompt names use the same convention so
   searches and log greps line up cleanly. Sibling-plugin collisions are
   prevented by construction.
+- **Every synchronous deriva-ml or deriva-py call inside an `async def` tool
+  MUST be wrapped in `await asyncio.to_thread(...)`.** No exceptions. The
+  plugin's tool functions are coroutines invoked by an asyncio-based MCP host;
+  any sync call that takes more than a few hundred milliseconds blocks the
+  event loop and starves the host's permission/heartbeat machinery. Symptom:
+  intermittent silent tool rejections in clients (the host's permission stream
+  closes mid-flight; pending tool calls reject with "user doesn't want to
+  proceed" even though no user action occurred). See
+  Development Gotchas → "Sync calls in async tools" for history.
 
 ## Tool / Resource Dual-Mode Policy
 
@@ -453,6 +462,54 @@ parallel review of a different branch) still won't leak into commits.
   `def register(ctx: PluginContext) -> None:` with the `PluginContext`
   import guarded by `if TYPE_CHECKING:`. Don't "fix" the unquoted form back
   to quoted strings.
+
+- **Sync calls in async tools — wrap with `asyncio.to_thread`.** This is a
+  load-bearing rule (also stated under Tool Implementation Rules), but the
+  history is worth recording so the same mistake isn't repeated.
+
+  Tool functions are `async def` because the MCP host (deriva-mcp-core) is
+  asyncio-based. The deriva-ml and deriva-py libraries are synchronous —
+  `ml.find_datasets()`, `ds.list_dataset_members()`, `ml.lookup_dataset()`,
+  etc. all block. Calling these directly inside an async coroutine blocks the
+  event loop for the duration of the catalog call (often seconds; sometimes
+  minutes for `cache_dataset` or large queries).
+
+  While the loop is blocked, the host cannot service its other coroutines —
+  including the **permission stream** that delivers user approve/deny
+  decisions for tool calls. If that stream's heartbeat or response window
+  expires while the loop is stalled, the host closes the stream and rejects
+  every pending tool call with "Tool permission stream closed before response
+  received" — surfaced to the model as "The user doesn't want to proceed
+  with this tool use." The rejection is silent (no UI prompt), looks
+  identical to user cancellation, and is intermittent (depends on whether
+  the loop block crosses the threshold).
+
+  **Pre-PR-#28 history:** the original implementation (Phases 2–5, v1.0)
+  shipped every tool calling deriva-ml directly inside the async def. The
+  symptom didn't surface during initial development because dev tests used
+  small catalogs where calls returned in milliseconds. It surfaced under
+  realistic catalog load — long-running tools (`cache_dataset`, large
+  `find_datasets`) blocked the loop long enough for hosts to drop pending
+  calls.
+
+  **PR #28 (`fix(complex): wrap sync deriva-ml calls in asyncio.to_thread`)**
+  fixed this in `tools/dataset/complex.py` for the three known-slow tools
+  (`cache_dataset`, `denormalize_dataset`, `split_dataset`). It did **not**
+  cover the other tool modules (`asset.py`, `feature.py`, `maintenance.py`,
+  `workflow.py`, `dataset/mutate.py`, `dataset/read.py`,
+  `execution/mutate.py`, `execution/read.py`). All of those still need
+  the `asyncio.to_thread` wrapping; until they do, the same symptom
+  recurs intermittently for any of their tools that hit non-trivial
+  catalog work.
+
+  **The lesson — for plugin design.** Async-defined tools that call sync
+  libraries are a footgun. The rule must be applied uniformly the first
+  time, not retrofitted module-by-module. When adding a new tool, the
+  template should already include `asyncio.to_thread`; when reviewing a
+  PR that adds a tool, the absence of `asyncio.to_thread` around any
+  sync deriva-ml/deriva-py call is a blocking review comment. PR #28's
+  scoping (one module out of nine) is the failure mode this rule guards
+  against.
 
 ## Spec & Plan
 

--- a/docs/superpowers/plans/2026-05-05-async-thread-wrap-all-tools.md
+++ b/docs/superpowers/plans/2026-05-05-async-thread-wrap-all-tools.md
@@ -1,0 +1,715 @@
+# Async Thread-Wrap All Tool Modules — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wrap every synchronous deriva-ml / deriva-py call inside an `async def` tool with `await asyncio.to_thread(...)`, across the seven tool modules PR #28 didn't cover.
+
+**Architecture:** Same pattern PR #28 established in `tools/dataset/complex.py`. Inside each `async def` tool's `with deriva_call():` block, change every direct sync call (`ml.<method>(...)`, `ds.<method>(...)`, `exe.<method>(...)`, `_pkg.get_ml(...)`, plus helpers that themselves call sync deriva-ml) to `await asyncio.to_thread(<callable>, *args, **kwargs)`. For generator-returning sync calls, drain into a list inside a nested `def _drain():` helper and thread the helper (precedent: `complex.py:325–338`). No new functions, no API changes, no tests rewritten — purely a behavioral fix that keeps the asyncio event loop responsive.
+
+**Tech Stack:** Python 3.11+, asyncio, deriva-ml, deriva-mcp-core plugin SDK, pytest, ruff, uv.
+
+**Spec context:** [`CLAUDE.md`](../../../CLAUDE.md) — see "Tool Implementation Rules → asyncio.to_thread" and "Development Gotchas → Sync calls in async tools" (added 2026-05-05). PR #28 is the precedent: `fix(complex): wrap sync deriva-ml calls in asyncio.to_thread`.
+
+---
+
+## Why this is one PR with N module-scoped commits
+
+The change is mechanical and uniform; one PR makes the lesson visible (everything that was missed is fixed together). Module-scoped commits keep the diff reviewable and let `git bisect` find regressions if any slip through. The order below moves from smallest to largest module so reviewers can build pattern intuition before hitting the 700+ line files.
+
+## Per-task pattern (applies to every code task below)
+
+Each tool-module task follows the same shape:
+
+1. **Identify all sync deriva-ml/deriva-py callsites inside `with deriva_call():` blocks of `async def` tools.** Use the grep recipe (Step A below).
+2. **Add `import asyncio` to the module's imports** if not already present.
+3. **Wrap each callsite** with `await asyncio.to_thread(...)`. Patterns:
+   - `result = ml.find_workflows()` → `result = await asyncio.to_thread(ml.find_workflows)`
+   - `result = ml.find_workflows(deleted=True)` → `result = await asyncio.to_thread(ml.find_workflows, deleted=True)`
+   - `ml = _pkg.get_ml(hostname, catalog_id)` → `ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)`
+   - `ds = ml.lookup_dataset(rid)` → `ds = await asyncio.to_thread(ml.lookup_dataset, rid)`
+   - **Generator returns** (e.g. `ds.get_denormalized_as_dict(...)` returns iterator): drain inside a nested `def _drain():` and thread that. See `tools/dataset/complex.py:325–338` for the canonical example.
+   - **Property reads** (`ds.dataset_rid`, `ds.description`, `ds.current_version`) — these are NOT sync I/O calls; leave them alone. Properties on already-resolved objects are zero-cost dict lookups.
+   - **Helper functions defined in the same module** (e.g. `_list_datasets_impl(ml, ...)`): if the helper itself contains sync deriva-ml calls (it usually does), wrap the helper invocation: `payload = await asyncio.to_thread(_list_datasets_impl, ml, ...)`. Don't recursively wrap inside the helper — the helper runs entirely inside the worker thread.
+4. **Run that module's tests** — both unit (`tests/test_<module>.py`) and integration (`tests/test_integration_<module>.py` if present).
+5. **Commit** with the message format below.
+
+### Step A — find sync callsites inside a module
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp
+awk '/with deriva_call\(\):/,/^        return|^        except|^    @/' \
+    src/deriva_ml_mcp/tools/<MODULE>.py \
+  | grep -nE '^\s+(ml|ds|exe|wf|exec_obj|_pkg|f|asset|feature)\.|=\s*(ml|ds|exe|wf|exec_obj|_pkg)\.'
+```
+
+(The awk slices each `deriva_call()` block; the grep flags the sync attribute calls inside.)
+
+### Step B — module-tests recipe
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/test_<module>.py -v
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/test_integration_<module>.py -v   # if present
+```
+
+Expected: all tests pass. The change is behavior-preserving (same calls, same returns, just routed through a thread).
+
+### Step C — commit message format
+
+```
+fix(<module>): wrap sync deriva-ml calls in asyncio.to_thread
+
+Mirrors PR #28's pattern for tools/<module>.py. Every sync deriva-ml /
+deriva-py call inside an async def tool's deriva_call() block now
+runs via await asyncio.to_thread(...), so the asyncio event loop
+stays responsive while catalog work runs.
+
+Resolves the missing coverage from PR #28 for this module.
+```
+
+---
+
+## Task 0: Branch + verify clean baseline
+
+**Files:** none (workspace setup).
+
+- [ ] **Step 1: Branch off main**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp
+git checkout main
+git pull --ff-only origin main
+git checkout -b fix/async-thread-wrap-tools
+```
+
+Expected: on a fresh branch off `main`, working tree clean.
+
+- [ ] **Step 2: Run the full test suite to capture a green baseline**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest -x 2>&1 | tail -10
+```
+
+Expected: all tests pass (or known-flaky tests skip). If anything fails on `main`, **STOP** — that's a pre-existing regression unrelated to this work; surface it before continuing. Note the count for comparison at the end.
+
+- [ ] **Step 3: Confirm `import asyncio` is already present in `dataset/complex.py` (the existing example)**
+
+```bash
+grep -n '^import asyncio' src/deriva_ml_mcp/tools/dataset/complex.py
+```
+
+Expected: line 1–10 of the file. If absent, the existing PR #28 work is broken — STOP.
+
+---
+
+## Task 1: `tools/asset.py`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/tools/asset.py` (~7 callsites, 525 LoC)
+- Test: `tests/test_asset.py`, `tests/test_integration_asset.py`
+
+- [ ] **Step 1: Read the module to understand its current shape**
+
+```bash
+grep -n 'async def\|with deriva_call\|asyncio' src/deriva_ml_mcp/tools/asset.py | head -30
+```
+
+Note: the `async def` tool definitions, the `with deriva_call():` blocks under each, and whether `import asyncio` already exists.
+
+- [ ] **Step 2: List the callsites that need wrapping (Step A from header)**
+
+```bash
+awk '/with deriva_call\(\):/,/^        return|^        except|^    @/' \
+    src/deriva_ml_mcp/tools/asset.py \
+  | grep -nE '^\s+(ml|ds|exe|wf|exec_obj|_pkg|f|asset|feature)\.|=\s*(ml|ds|exe|wf|exec_obj|_pkg)\.'
+```
+
+Expected: ~7 lines. Each is a candidate.
+
+- [ ] **Step 3: Add `import asyncio` if absent**
+
+If `grep -n '^import asyncio' src/deriva_ml_mcp/tools/asset.py` returns no match, add it at the top of the imports block (after `from __future__ import annotations` if present, alongside other stdlib imports). Use the Edit tool against the existing import block — don't blind-add at line 1.
+
+- [ ] **Step 4: Wrap each callsite using the patterns in the per-task header**
+
+Apply the wrapping rules to every line found in Step 2. For each one:
+- If the call is a single attribute call: `await asyncio.to_thread(target.method, *args, **kwargs)`.
+- If the call returns a generator/iterator: define a nested `def _drain(): return list(...)` and use `await asyncio.to_thread(_drain)`.
+- If the line is a property read (no parentheses, no I/O): leave it alone.
+- If the line calls a same-module helper that itself does sync work: wrap the helper invocation.
+
+Make these edits one Edit-tool call at a time, working top-down through the file. Don't try to batch all 7 into one Edit.
+
+- [ ] **Step 5: Lint check**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run ruff check src/deriva_ml_mcp/tools/asset.py
+```
+
+Expected: clean (or only pre-existing lint warnings unrelated to this change).
+
+- [ ] **Step 6: Run module tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/test_asset.py tests/test_integration_asset.py -v 2>&1 | tail -20
+```
+
+Expected: all tests pass. If any fail, the wrap missed something — review what changed in the failing test's call path.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/deriva_ml_mcp/tools/asset.py
+git commit -m "fix(asset): wrap sync deriva-ml calls in asyncio.to_thread
+
+Mirrors PR #28's pattern for tools/asset.py. Every sync deriva-ml /
+deriva-py call inside an async def tool's deriva_call() block now
+runs via await asyncio.to_thread(...), so the asyncio event loop
+stays responsive while catalog work runs.
+
+Resolves the missing coverage from PR #28 for this module."
+```
+
+---
+
+## Task 2: `tools/feature.py`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/tools/feature.py` (~11 callsites, 756 LoC)
+- Test: `tests/test_feature.py`, `tests/test_integration_feature.py`
+
+- [ ] **Step 1: List callsites**
+
+```bash
+awk '/with deriva_call\(\):/,/^        return|^        except|^    @/' \
+    src/deriva_ml_mcp/tools/feature.py \
+  | grep -nE '^\s+(ml|ds|exe|wf|exec_obj|_pkg|f|asset|feature)\.|=\s*(ml|ds|exe|wf|exec_obj|_pkg)\.'
+```
+
+Expected: ~11 lines.
+
+- [ ] **Step 2: Add `import asyncio` if absent**
+
+```bash
+grep -n '^import asyncio' src/deriva_ml_mcp/tools/feature.py
+```
+
+If no match, add via Edit to the imports block.
+
+- [ ] **Step 3: Wrap each callsite**
+
+Apply the pattern from the per-task header.
+
+**Watch out for `ml.feature_record_class(...)`**: it returns a Pydantic class (no I/O), so wrapping is unnecessary. The line `ImageClassification = ml.feature_record_class(...)` does not need `asyncio.to_thread` if the function only constructs and returns a class (look at the deriva-ml source if uncertain).
+
+**Watch out for `feature_record_class().__init__(...)`** and similar — instantiating a Pydantic model is not I/O.
+
+The actual catalog calls are typically `ml.find_features()`, `ml.lookup_feature(...)`, `ml.add_features([...])`, `ml.feature_values(...)`, `ml.delete_feature(...)`. Those need wrapping.
+
+- [ ] **Step 4: Lint check**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run ruff check src/deriva_ml_mcp/tools/feature.py
+```
+
+- [ ] **Step 5: Run module tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/test_feature.py tests/test_integration_feature.py -v 2>&1 | tail -20
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/deriva_ml_mcp/tools/feature.py
+git commit -m "fix(feature): wrap sync deriva-ml calls in asyncio.to_thread
+
+Mirrors PR #28's pattern for tools/feature.py. Every sync deriva-ml /
+deriva-py call inside an async def tool's deriva_call() block now
+runs via await asyncio.to_thread(...), so the asyncio event loop
+stays responsive while catalog work runs.
+
+Resolves the missing coverage from PR #28 for this module."
+```
+
+---
+
+## Task 3: `tools/workflow.py`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/tools/workflow.py` (~17 callsites, 597 LoC)
+- Test: `tests/test_workflow.py`, `tests/test_integration_workflow.py`
+
+- [ ] **Step 1: List callsites**
+
+```bash
+awk '/with deriva_call\(\):/,/^        return|^        except|^    @/' \
+    src/deriva_ml_mcp/tools/workflow.py \
+  | grep -nE '^\s+(ml|ds|exe|wf|exec_obj|_pkg|f|asset|feature)\.|=\s*(ml|ds|exe|wf|exec_obj|_pkg)\.'
+```
+
+Expected: ~17 lines.
+
+- [ ] **Step 2: Add `import asyncio` if absent**
+
+- [ ] **Step 3: Wrap each callsite**
+
+Watch out for: `ml.find_workflows()` (returns list, simple wrap), `ml.lookup_workflow(rid)` (simple wrap), `ml.lookup_workflow_by_url(url)` (simple wrap), `ml.find_workflow_executions(wf_rid)` (simple wrap), `ml.create_workflow(...)` (simple wrap, but this is the one that does the dirty-tree git check — ensure `DERIVA_ML_ALLOW_DIRTY=true` is set during testing). `wf.set_workflow_description(...)` (simple wrap). Property reads (`wf.workflow_rid`, `wf.name`, `wf.description`) need NO wrapping.
+
+- [ ] **Step 4: Lint check**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run ruff check src/deriva_ml_mcp/tools/workflow.py
+```
+
+- [ ] **Step 5: Run module tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/test_workflow.py tests/test_integration_workflow.py -v 2>&1 | tail -20
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/deriva_ml_mcp/tools/workflow.py
+git commit -m "fix(workflow): wrap sync deriva-ml calls in asyncio.to_thread
+
+Mirrors PR #28's pattern for tools/workflow.py. Every sync deriva-ml /
+deriva-py call inside an async def tool's deriva_call() block now
+runs via await asyncio.to_thread(...), so the asyncio event loop
+stays responsive while catalog work runs.
+
+Resolves the missing coverage from PR #28 for this module."
+```
+
+---
+
+## Task 4: `tools/execution/read.py`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/tools/execution/read.py` (~13 callsites, 694 LoC)
+- Test: `tests/test_execution.py`, `tests/test_integration_execution.py`
+
+- [ ] **Step 1: List callsites**
+
+```bash
+awk '/with deriva_call\(\):/,/^        return|^        except|^    @/' \
+    src/deriva_ml_mcp/tools/execution/read.py \
+  | grep -nE '^\s+(ml|ds|exe|wf|exec_obj|_pkg|f|asset|feature)\.|=\s*(ml|ds|exe|wf|exec_obj|_pkg)\.'
+```
+
+Expected: ~13 lines.
+
+- [ ] **Step 2: Add `import asyncio` if absent**
+
+- [ ] **Step 3: Wrap each callsite**
+
+Calls in this module: `ml.find_executions(...)` (list), `ml.lookup_execution(rid)`, `exe.find_workflow_executions(...)`, `_pkg.get_ml(...)`. Property reads (`exe.execution_rid`, `exe.status`) need NO wrapping.
+
+- [ ] **Step 4: Lint check**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run ruff check src/deriva_ml_mcp/tools/execution/read.py
+```
+
+- [ ] **Step 5: Run module tests**
+
+`test_execution.py` covers both read and mutate; running it before the next task gives you a checkpoint. Integration tests cover both too.
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/test_execution.py tests/test_integration_execution.py -v 2>&1 | tail -20
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/deriva_ml_mcp/tools/execution/read.py
+git commit -m "fix(execution.read): wrap sync deriva-ml calls in asyncio.to_thread
+
+Mirrors PR #28's pattern for tools/execution/read.py. Every sync
+deriva-ml / deriva-py call inside an async def tool's deriva_call()
+block now runs via await asyncio.to_thread(...), so the asyncio
+event loop stays responsive while catalog work runs.
+
+Resolves the missing coverage from PR #28 for this module."
+```
+
+---
+
+## Task 5: `tools/execution/mutate.py`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/tools/execution/mutate.py` (~23 callsites, 888 LoC)
+- Test: `tests/test_execution.py`, `tests/test_integration_execution.py`
+
+- [ ] **Step 1: List callsites**
+
+```bash
+awk '/with deriva_call\(\):/,/^        return|^        except|^    @/' \
+    src/deriva_ml_mcp/tools/execution/mutate.py \
+  | grep -nE '^\s+(ml|ds|exe|wf|exec_obj|_pkg|f|asset|feature)\.|=\s*(ml|ds|exe|wf|exec_obj|_pkg)\.'
+```
+
+Expected: ~23 lines.
+
+- [ ] **Step 2: Add `import asyncio` if absent**
+
+- [ ] **Step 3: Wrap each callsite**
+
+Calls: `ml.create_execution(config)` (the lifecycle entry point — slow, must be wrapped), `exe.commit_execution()`, `exe.abort_execution()`, `exe.update_execution(...)`, `ml.add_nested_execution(parent, child)`, `_pkg.get_ml(...)`. ExecutionConfiguration construction is pure-Python (no wrap).
+
+**Special case:** `ml.create_execution(config)` returns an Execution object. The CONSTRUCTION of the config is pure Python; the `create_execution` call is sync I/O. Wrap it as a single call:
+`exe = await asyncio.to_thread(ml.create_execution, config)`.
+
+- [ ] **Step 4: Lint check**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run ruff check src/deriva_ml_mcp/tools/execution/mutate.py
+```
+
+- [ ] **Step 5: Run module tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/test_execution.py tests/test_integration_execution.py -v 2>&1 | tail -20
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/deriva_ml_mcp/tools/execution/mutate.py
+git commit -m "fix(execution.mutate): wrap sync deriva-ml calls in asyncio.to_thread
+
+Mirrors PR #28's pattern for tools/execution/mutate.py. Every sync
+deriva-ml / deriva-py call inside an async def tool's deriva_call()
+block now runs via await asyncio.to_thread(...), so the asyncio
+event loop stays responsive while catalog work runs.
+
+Resolves the missing coverage from PR #28 for this module."
+```
+
+---
+
+## Task 6: `tools/dataset/read.py`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/tools/dataset/read.py` (~27 callsites, 940 LoC)
+- Test: `tests/test_dataset_read.py`
+
+- [ ] **Step 1: List callsites**
+
+```bash
+awk '/with deriva_call\(\):/,/^        return|^        except|^    @/' \
+    src/deriva_ml_mcp/tools/dataset/read.py \
+  | grep -nE '^\s+(ml|ds|exe|wf|exec_obj|_pkg|f|asset|feature)\.|=\s*(ml|ds|exe|wf|exec_obj|_pkg)\.'
+```
+
+Expected: ~27 lines.
+
+- [ ] **Step 2: Add `import asyncio` if absent**
+
+- [ ] **Step 3: Wrap each callsite**
+
+This module is large but the calls are all read-side: `ml.find_datasets(...)`, `ml.lookup_dataset(rid)`, `ds.list_dataset_members(...)`, `ds.list_dataset_parents(...)`, `ds.list_dataset_children(...)`, `ds.dataset_history()`, `ml.list_dataset_element_types()`, `ml.bag_info(spec)`, plus same-module helpers (`_list_datasets_impl`, `_summarize_dataset`).
+
+For helpers that already take a `ml` instance and do sync work internally, wrap the **helper invocation**, not the calls inside the helper:
+```python
+# Before:
+payload = _list_datasets_impl(ml, after_rid=after_rid, limit=capped, ...)
+# After:
+payload = await asyncio.to_thread(_list_datasets_impl, ml, after_rid=after_rid, limit=capped, ...)
+```
+
+This module is also where `_summarize_dataset` (`ds.list_dataset_members()` plus aggregation) lives — wrap the function invocation similarly.
+
+For `ds.dataset_history()` returning an iterable that's then list-comprehended (`for h in ds.dataset_history()`), drain via a `_drain()` helper:
+```python
+def _history_list():
+    return [
+        DatasetHistoryEntry(...)
+        for h in ds.dataset_history()
+    ]
+history = await asyncio.to_thread(_history_list)
+```
+
+- [ ] **Step 4: Lint check**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run ruff check src/deriva_ml_mcp/tools/dataset/read.py
+```
+
+- [ ] **Step 5: Run module tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/test_dataset_read.py -v 2>&1 | tail -20
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/deriva_ml_mcp/tools/dataset/read.py
+git commit -m "fix(dataset.read): wrap sync deriva-ml calls in asyncio.to_thread
+
+Mirrors PR #28's pattern for tools/dataset/read.py. Every sync
+deriva-ml / deriva-py call inside an async def tool's deriva_call()
+block now runs via await asyncio.to_thread(...), so the asyncio
+event loop stays responsive while catalog work runs. Same-module
+helpers that themselves contain sync calls are wrapped at the
+call site (the helper runs entirely in the worker thread).
+
+Resolves the missing coverage from PR #28 for this module."
+```
+
+---
+
+## Task 7: `tools/dataset/mutate.py`
+
+**Files:**
+- Modify: `src/deriva_ml_mcp/tools/dataset/mutate.py` (~28 callsites, 734 LoC)
+- Test: `tests/test_dataset_mutate.py`
+
+- [ ] **Step 1: List callsites**
+
+```bash
+awk '/with deriva_call\(\):/,/^        return|^        except|^    @/' \
+    src/deriva_ml_mcp/tools/dataset/mutate.py \
+  | grep -nE '^\s+(ml|ds|exe|wf|exec_obj|_pkg|f|asset|feature)\.|=\s*(ml|ds|exe|wf|exec_obj|_pkg)\.'
+```
+
+Expected: ~28 lines.
+
+- [ ] **Step 2: Add `import asyncio` if absent**
+
+- [ ] **Step 3: Wrap each callsite**
+
+Calls: `exe.create_dataset(...)`, `ds.add_dataset_members(...)`, `ds.add_dataset_type(...)`, `ds.delete_dataset_members(...)`, `ds.update_dataset(...)`, `ds.increment_version(...)`, `ml.create_execution(...)` (for the dataset-creation execution), `ml.delete_dataset(rid)`. All sync.
+
+**Watch out for:** `ml.create_execution(config)` followed by `exe = ml.create_execution(...)`. The execution context is a regular object after construction, so subsequent `exe.<method>()` calls should each be individually wrapped.
+
+- [ ] **Step 4: Lint check**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run ruff check src/deriva_ml_mcp/tools/dataset/mutate.py
+```
+
+- [ ] **Step 5: Run module tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/test_dataset_mutate.py -v 2>&1 | tail -20
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/deriva_ml_mcp/tools/dataset/mutate.py
+git commit -m "fix(dataset.mutate): wrap sync deriva-ml calls in asyncio.to_thread
+
+Mirrors PR #28's pattern for tools/dataset/mutate.py. Every sync
+deriva-ml / deriva-py call inside an async def tool's deriva_call()
+block now runs via await asyncio.to_thread(...), so the asyncio
+event loop stays responsive while catalog work runs.
+
+Resolves the missing coverage from PR #28 for this module."
+```
+
+---
+
+## Task 8: Verify nothing was missed
+
+The grep recipe should now return zero hits for unwrapped sync calls inside async tools. Audit-style verification.
+
+**Files:** none (audit only).
+
+- [ ] **Step 1: Confirm every module has `import asyncio`**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp
+for f in src/deriva_ml_mcp/tools/asset.py \
+         src/deriva_ml_mcp/tools/feature.py \
+         src/deriva_ml_mcp/tools/workflow.py \
+         src/deriva_ml_mcp/tools/dataset/read.py \
+         src/deriva_ml_mcp/tools/dataset/mutate.py \
+         src/deriva_ml_mcp/tools/execution/read.py \
+         src/deriva_ml_mcp/tools/execution/mutate.py ; do
+  grep -q '^import asyncio' "$f" || echo "MISSING import asyncio: $f"
+done
+```
+
+Expected: no output (every module has the import).
+
+- [ ] **Step 2: Confirm no unwrapped sync deriva-ml calls remain inside async def tools**
+
+```bash
+for f in src/deriva_ml_mcp/tools/asset.py \
+         src/deriva_ml_mcp/tools/feature.py \
+         src/deriva_ml_mcp/tools/workflow.py \
+         src/deriva_ml_mcp/tools/dataset/read.py \
+         src/deriva_ml_mcp/tools/dataset/mutate.py \
+         src/deriva_ml_mcp/tools/execution/read.py \
+         src/deriva_ml_mcp/tools/execution/mutate.py ; do
+  echo "=== $f ==="
+  awk '/with deriva_call\(\):/,/^        return|^        except|^    @/' "$f" \
+    | grep -nE '^\s+(ml|ds|exe|wf|exec_obj|_pkg|f|asset|feature)\.[a-z_]+\(|=\s*(ml|ds|exe|wf|exec_obj|_pkg)\.[a-z_]+\(' \
+    | grep -v 'asyncio.to_thread'
+done
+```
+
+Expected: each `===` heading is followed by no lines (all sync calls now go through `asyncio.to_thread`).
+
+If any line appears, that callsite was missed — go back to the relevant task and wrap it. (False positives are possible — property accesses ending in `()` if any exist; review each finding manually.)
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest 2>&1 | tail -10
+```
+
+Expected: same pass count as the baseline from Task 0 Step 2. Any new failures point at a wrap that broke a behavior — bisect via `git log --oneline main..HEAD` and `git checkout` each commit.
+
+- [ ] **Step 4: Run ruff across the full src tree**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run ruff check src tests
+```
+
+Expected: clean (or only pre-existing warnings unrelated to this change).
+
+---
+
+## Task 9: End-to-end smoke against a live catalog
+
+The unit tests pass with mocked deriva-ml. The actual symptom — silent rejection in MCP clients — is only visible against a live host. This task verifies the fix landed for real.
+
+**Files:** none (verification).
+
+**Pre-requisites:**
+- A reachable Deriva catalog (localhost or remote). The CIFAR-10 catalog from earlier (catalog 41) is sufficient if it still exists; otherwise use any catalog with at least one Dataset.
+- The MCP venv at `/Users/carl/.local/share/deriva-mcp-tool/.venv` consumes deriva-ml-mcp editable, so the changes are live without a reinstall.
+
+- [ ] **Step 1: Restart Claude Desktop / Claude Code**
+
+Restart the MCP host so the `deriva-mcp-core` subprocess respawns and loads the updated plugin. Editable installs DON'T require reinstall, but the running server process needs to re-import the plugin code.
+
+- [ ] **Step 2: Smoke-test the tools that previously rejected**
+
+In your client, request a sequence of `deriva_ml_*` tool calls that hit the previously-failing paths:
+
+```
+deriva_ml_list_datasets(hostname="localhost", catalog_id="41")
+deriva_ml_list_dataset_relations(hostname="localhost", catalog_id="41", dataset_rid="<a Split RID>")
+deriva_ml_list_dataset_members(hostname="localhost", catalog_id="41", dataset_rid="<a leaf RID>")
+deriva_ml_get_dataset(hostname="localhost", catalog_id="41", dataset_rid="<any RID>")
+deriva_ml_list_workflows(hostname="localhost", catalog_id="41")
+deriva_ml_list_executions(hostname="localhost", catalog_id="41")
+```
+
+Expected: all calls return data without rejection. Before this fix, `list_dataset_relations` (and others on first use) intermittently rejected silently.
+
+- [ ] **Step 3: Make a catalog-modifying call to exercise the mutate path**
+
+```
+deriva_ml_create_workflow(hostname="localhost", catalog_id="41",
+                          name="async-test", workflow_type="<existing type>",
+                          description="async wrap smoke test")
+```
+
+Expected: returns the created workflow's RID. No silent rejection.
+
+- [ ] **Step 4: If catalog 41 doesn't exist, build it**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-sandbox
+DERIVA_ML_ALLOW_DIRTY=true uv run python src/scripts/load_cifar10.py \
+    --hostname localhost \
+    --create-catalog cifar10 \
+    --num-images 5000
+```
+
+Then redo Steps 2 and 3 against the new catalog ID.
+
+---
+
+## Task 10: Push and open PR
+
+**Files:** none.
+
+- [ ] **Step 1: Verify branch state**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp
+git log --oneline main..HEAD
+```
+
+Expected: 7 commits, one per module-task (Tasks 1–7). Plus possibly Task 0/8/9 had no commits.
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin fix/async-thread-wrap-tools
+```
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --base main --title "fix(tools): wrap sync deriva-ml calls in asyncio.to_thread across all modules" --body "$(cat <<'EOF'
+## Summary
+
+Wraps every synchronous deriva-ml / deriva-py call inside an \`async def\` tool with \`await asyncio.to_thread(...)\`, across the seven tool modules PR #28 didn't cover.
+
+## Why
+
+PR #28 (\`fix(complex): wrap sync deriva-ml calls in asyncio.to_thread\`) fixed this for \`tools/dataset/complex.py\`, but the symptom — intermittent silent tool rejection in MCP clients ("user doesn't want to proceed" without any user action) — recurs for every tool in the unfixed modules. The asyncio event loop blocks during sync deriva calls, the host's permission stream times out, pending tool calls reject.
+
+Symptom diagnosed in deriva-ml-sandbox conversation 2026-05-05; mechanism is \`Tool permission stream closed before response received\` from Claude Desktop's main.log.
+
+## Modules covered
+
+- \`tools/asset.py\`
+- \`tools/feature.py\`
+- \`tools/workflow.py\`
+- \`tools/execution/read.py\`
+- \`tools/execution/mutate.py\`
+- \`tools/dataset/read.py\`
+- \`tools/dataset/mutate.py\`
+
+(\`tools/maintenance.py\` doesn't use \`deriva_call()\` blocks the same way and was excluded after audit.)
+
+## Test plan
+
+- [x] Per-module unit + integration tests pass after each commit
+- [x] Full \`uv run pytest\` baseline preserved (Task 0 vs Task 8)
+- [x] End-to-end smoke against a live catalog (Task 9)
+- [x] Lint clean (\`ruff check src tests\`)
+
+## Reference
+
+- Rule documented in \`CLAUDE.md\` → "Tool Implementation Rules" + "Development Gotchas → Sync calls in async tools" (commit 1a13947, 2026-05-05)
+- Plan: \`docs/superpowers/plans/2026-05-05-async-thread-wrap-all-tools.md\`
+- Precedent: PR #28 (\`fix(complex): wrap sync deriva-ml calls in asyncio.to_thread\`)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Every module identified by the audit has a task. Maintenance.py excluded with reason. The non-trivial cases (generators, helpers) are called out with the canonical pattern. ✓
+
+**Placeholder scan:** No "TBD" / "TODO" / "implement later." Each step has an exact command or an exact code transformation. ✓
+
+**Type consistency:** All task names match across the plan, PR-body bullet points match the actual modules touched, the per-task-header pattern is referenced consistently across tasks. The wrap pattern is shown once (per-task header) and not duplicated per task — readers of any single task get the link to the canonical pattern. ✓
+
+**Edge cases addressed:**
+- Generator returns: drain helper pattern (Task header + Task 6 worked example)
+- Same-module helpers: wrap at call site, not recursively
+- Property reads: explicitly NOT wrapped
+- Pydantic class construction (`feature_record_class`): NOT wrapped (no I/O)
+- Pure-Python config construction (`ExecutionConfiguration`): NOT wrapped
+
+**Risks the plan should surface:**
+- One regression I haven't fully thought through: behavior change from "blocks event loop, then completes" to "yields event loop, then completes." If any test relies on **synchronous ordering** between the tool's internal calls and other concurrent work, that could break. The existing PR #28 tests passed without this issue, so probably fine, but Task 8's full-suite run is the safety net.
+- Lint: ruff sometimes flags `asyncio.to_thread(callable, *args)` differently for keyword-only vs positional args. Each module's Step 4 lint check catches this per-commit.

--- a/src/deriva_ml_mcp/tools/asset.py
+++ b/src/deriva_ml_mcp/tools/asset.py
@@ -45,6 +45,7 @@ read+update-by-RID surfaces:
 
 from __future__ import annotations
 
+import asyncio
 import json
 from functools import partial
 from typing import TYPE_CHECKING, Any
@@ -263,8 +264,11 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
-                payload = _list_asset_tables_impl(ml)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                payload = await asyncio.to_thread(_list_asset_tables_impl, ml)
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
@@ -316,9 +320,19 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``ml.list_assets`` returns
+                # a generator that materializes over the wire, so the drain
+                # (list/sorted) must happen inside the worker thread, not
+                # on the event loop. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
                 if preflight_count:
-                    total = len(list(ml.list_assets(asset_table)))
+
+                    def _count_assets() -> int:
+                        return len(list(ml.list_assets(asset_table)))
+
+                    total = await asyncio.to_thread(_count_assets)
                     return PreflightCountResponse(
                         total_count=total,
                         action_required=(
@@ -327,10 +341,14 @@ def register(ctx: PluginContext) -> None:
                             "preflight_count=False."
                         ),
                     ).model_dump_json(by_alias=True)
-                assets = sorted(
-                    ml.list_assets(asset_table),
-                    key=lambda a: getattr(a, "asset_rid", "") or "",
-                )
+
+                def _list_and_sort_assets() -> list[Any]:
+                    return sorted(
+                        ml.list_assets(asset_table),
+                        key=lambda a: getattr(a, "asset_rid", "") or "",
+                    )
+
+                assets = await asyncio.to_thread(_list_and_sort_assets)
                 capped = min(max(limit, 0), _MAX_LIMIT)
                 page, truncated, next_after = _paginate(
                     assets,
@@ -389,8 +407,11 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
-                payload = _get_asset_detail_impl(ml, asset_rid)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                payload = await asyncio.to_thread(_get_asset_detail_impl, ml, asset_rid)
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
@@ -472,8 +493,11 @@ def register(ctx: PluginContext) -> None:
         updated_fields: list[str] = []
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
-                asset = ml.lookup_asset(asset_rid)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                asset = await asyncio.to_thread(ml.lookup_asset, asset_rid)
 
                 if asset_types is not None:
                     desired = set(asset_types)
@@ -481,15 +505,15 @@ def register(ctx: PluginContext) -> None:
                     to_add = sorted(desired - current)
                     to_remove = sorted(current - desired)
                     for term in to_add:
-                        asset.add_asset_type(term)
+                        await asyncio.to_thread(asset.add_asset_type, term)
                         added_done.append(term)
                     for term in to_remove:
-                        asset.remove_asset_type(term)
+                        await asyncio.to_thread(asset.remove_asset_type, term)
                         removed_done.append(term)
                     updated_fields.append("asset_types")
 
                 if description is not None:
-                    _write_asset_description(ml, asset, description)
+                    await asyncio.to_thread(_write_asset_description, ml, asset, description)
                     updated_fields.append("description")
 
             audit_event(

--- a/src/deriva_ml_mcp/tools/dataset/mutate.py
+++ b/src/deriva_ml_mcp/tools/dataset/mutate.py
@@ -26,6 +26,7 @@ captured every success-path emission in one shot.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import TYPE_CHECKING, Literal
@@ -116,8 +117,12 @@ def register(ctx: PluginContext) -> None:
         try:
             parsed_version = DatasetVersion.parse(version) if version else None
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                new_ds = _pkg.Dataset.create_dataset(
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                new_ds = await asyncio.to_thread(
+                    _pkg.Dataset.create_dataset,
                     ml,
                     execution_rid=execution_rid,
                     dataset_types=dataset_types,
@@ -195,9 +200,12 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                ds = ml.lookup_dataset(dataset_rid)
-                ml.delete_dataset(ds, recurse=recurse)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                ds = await asyncio.to_thread(ml.lookup_dataset, dataset_rid)
+                await asyncio.to_thread(ml.delete_dataset, ds, recurse=recurse)
             _pkg.audit_event(
                 "deriva_ml_delete_dataset",
                 hostname=hostname,
@@ -298,9 +306,13 @@ def register(ctx: PluginContext) -> None:
             added_count = sum(len(v) for v in members.values())
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                ds = ml.lookup_dataset(dataset_rid)
-                ds.add_dataset_members(
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                ds = await asyncio.to_thread(ml.lookup_dataset, dataset_rid)
+                await asyncio.to_thread(
+                    ds.add_dataset_members,
                     members=members,
                     description=description,
                     execution_rid=execution_rid,
@@ -378,9 +390,13 @@ def register(ctx: PluginContext) -> None:
         removed_count = len(member_rids)
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                ds = ml.lookup_dataset(dataset_rid)
-                ds.delete_dataset_members(
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                ds = await asyncio.to_thread(ml.lookup_dataset, dataset_rid)
+                await asyncio.to_thread(
+                    ds.delete_dataset_members,
                     members=member_rids,
                     description=description,
                     execution_rid=execution_rid,
@@ -502,8 +518,11 @@ def register(ctx: PluginContext) -> None:
         new_version: str | None = None
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                ds = ml.lookup_dataset(dataset_rid)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                ds = await asyncio.to_thread(ml.lookup_dataset, dataset_rid)
 
                 if dataset_types is not None:
                     desired = set(dataset_types)
@@ -511,10 +530,10 @@ def register(ctx: PluginContext) -> None:
                     adds_requested = sorted(desired - current)
                     removes_requested = sorted(current - desired)
                     if adds_requested:
-                        ds.add_dataset_types(adds_requested)
+                        await asyncio.to_thread(ds.add_dataset_types, adds_requested)
                         adds_done = list(adds_requested)
                     for term in removes_requested:
-                        ds.remove_dataset_type(term)
+                        await asyncio.to_thread(ds.remove_dataset_type, term)
                         removes_done.append(term)
                     updated_types = list(ds.dataset_types) if ds.dataset_types else []
                     updated_fields.append("dataset_types")
@@ -525,8 +544,12 @@ def register(ctx: PluginContext) -> None:
                     # delegate the catalog write to the shared
                     # _set_row_description helper, then mirror the value
                     # into the in-memory Dataset object only after the
-                    # write returns successfully.
-                    _set_row_description(ml, ml._dataset_table, dataset_rid, description)
+                    # write returns successfully. The helper call is the
+                    # sync catalog write -- thread it; the in-memory
+                    # mirror assignment afterwards is plain Python.
+                    await asyncio.to_thread(
+                        _set_row_description, ml, ml._dataset_table, dataset_rid, description
+                    )
                     ds.description = description
                     updated_fields.append("description")
 
@@ -624,8 +647,11 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                assoc_table = ml.add_dataset_element_type(table_name)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                assoc_table = await asyncio.to_thread(ml.add_dataset_element_type, table_name)
                 association_name = assoc_table.name
             _pkg.audit_event(
                 "deriva_ml_add_dataset_element_type",
@@ -686,12 +712,16 @@ def register(ctx: PluginContext) -> None:
         try:
             version_part = VersionPart(component)
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                ds = ml.lookup_dataset(dataset_rid)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                ds = await asyncio.to_thread(ml.lookup_dataset, dataset_rid)
                 previous_version = (
                     str(ds.current_version) if ds.current_version is not None else None
                 )
-                new_version = ds.increment_dataset_version(
+                new_version = await asyncio.to_thread(
+                    ds.increment_dataset_version,
                     component=version_part,
                     description=description,
                     execution_rid=execution_rid,

--- a/src/deriva_ml_mcp/tools/dataset/read.py
+++ b/src/deriva_ml_mcp/tools/dataset/read.py
@@ -20,6 +20,7 @@ through ``_error_envelope`` (reads only log on failure, no audit row).
 
 from __future__ import annotations
 
+import asyncio
 import json
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
@@ -272,9 +273,19 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``find_datasets`` and
+                # the ``_list_datasets_impl`` helper both do catalog
+                # round-trips. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in
+                # threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
                 if preflight_count:
-                    total = len(list(ml.find_datasets(deleted=include_deleted)))
+
+                    def _count() -> int:
+                        return len(list(ml.find_datasets(deleted=include_deleted)))
+
+                    total = await asyncio.to_thread(_count)
                     return PreflightCountResponse(
                         total_count=total,
                         action_required=(
@@ -284,7 +295,8 @@ def register(ctx: PluginContext) -> None:
                     ).model_dump_json(by_alias=True)
 
                 capped = min(max(limit, 0), _MAX_LIMIT)
-                payload = _list_datasets_impl(
+                payload = await asyncio.to_thread(
+                    _list_datasets_impl,
                     ml,
                     after_rid=after_rid,
                     limit=capped,
@@ -345,16 +357,24 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``lookup_dataset`` and
+                # ``_get_dataset_detail_impl`` (which drains
+                # ``ds.dataset_history()``) both do catalog round-trips.
+                # See deriva-mcp-core plugin-authoring-guide.md
+                # §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
                 if include_history:
-                    payload = _get_dataset_detail_impl(ml, dataset_rid)
+                    payload = await asyncio.to_thread(
+                        _get_dataset_detail_impl, ml, dataset_rid
+                    )
                 else:
                     # Skip the dataset_history() call entirely when not
                     # requested -- it can be expensive on long-lived
                     # datasets. Construct a DatasetDetail with an empty
                     # version_history list to preserve the unified wire
                     # shape.
-                    ds = ml.lookup_dataset(dataset_rid)
+                    ds = await asyncio.to_thread(ml.lookup_dataset, dataset_rid)
                     summary = _summarize_dataset(ds)
                     payload = DatasetDetail(
                         **summary.model_dump(),
@@ -430,9 +450,16 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                ds = ml.lookup_dataset(dataset_rid)
-                members = ds.list_dataset_members(recurse=recurse, version=version)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``list_dataset_members``
+                # walks the dataset's element tables and can fetch many
+                # rows. See deriva-mcp-core plugin-authoring-guide.md
+                # §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                ds = await asyncio.to_thread(ml.lookup_dataset, dataset_rid)
+                members = await asyncio.to_thread(
+                    ds.list_dataset_members, recurse=recurse, version=version
+                )
 
             if element_table is None:
                 summary = {tname: len(rows) for tname, rows in members.items()}
@@ -551,14 +578,20 @@ def register(ctx: PluginContext) -> None:
                 )
             kwargs: dict[str, Any] = {}
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                ds = ml.lookup_dataset(dataset_rid)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``list_dataset_parents``
+                # and ``list_dataset_children`` walk the dataset hierarchy
+                # over the wire. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in
+                # threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                ds = await asyncio.to_thread(ml.lookup_dataset, dataset_rid)
 
                 if direction in ("parents", "both"):
-                    parents = sorted(
-                        ds.list_dataset_parents(recurse=recurse, version=version),
-                        key=lambda d: d.dataset_rid,
+                    parents_raw = await asyncio.to_thread(
+                        ds.list_dataset_parents, recurse=recurse, version=version
                     )
+                    parents = sorted(parents_raw, key=lambda d: d.dataset_rid)
                     page, truncated, _ = _paginate(
                         parents,
                         after_rid=effective_after_rid,
@@ -569,10 +602,10 @@ def register(ctx: PluginContext) -> None:
                     kwargs["parents_truncated"] = truncated
 
                 if direction in ("children", "both"):
-                    children = sorted(
-                        ds.list_dataset_children(recurse=recurse, version=version),
-                        key=lambda d: d.dataset_rid,
+                    children_raw = await asyncio.to_thread(
+                        ds.list_dataset_children, recurse=recurse, version=version
                     )
+                    children = sorted(children_raw, key=lambda d: d.dataset_rid)
                     page, truncated, _ = _paginate(
                         children,
                         after_rid=effective_after_rid,
@@ -627,8 +660,17 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                tables = list(ml.list_dataset_element_types())
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``list_dataset_element_types``
+                # is a metadata round-trip. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in
+                # threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+
+                def _drain_element_types() -> list[Any]:
+                    return list(ml.list_dataset_element_types())
+
+                tables = await asyncio.to_thread(_drain_element_types)
             return json.dumps(
                 {
                     "element_types": [_table_to_dict(t) for t in tables],
@@ -686,8 +728,13 @@ def register(ctx: PluginContext) -> None:
                 exclude_tables=set(exclude_tables) if exclude_tables else None,
             )
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                info = ml.bag_info(spec)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``bag_info`` inspects
+                # the bag manifest and may touch the local cache. See
+                # deriva-mcp-core plugin-authoring-guide.md §"Synchronous
+                # work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                info = await asyncio.to_thread(ml.bag_info, spec)
             return json.dumps(info, default=str)
         except Exception as exc:
             # Read-only tool: log+return without an audit row (I-2 fix).
@@ -738,8 +785,16 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                payload = _get_dataset_spec_impl(ml, dataset_rid, version)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``_get_dataset_spec_impl``
+                # invokes ``ml.lookup_dataset`` which does a catalog
+                # round-trip. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in
+                # threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                payload = await asyncio.to_thread(
+                    _get_dataset_spec_impl, ml, dataset_rid, version
+                )
             return json.dumps(payload)
         except Exception as exc:
             # Read-only tool: log+return without an audit row (I-2 fix).
@@ -802,8 +857,13 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                payload = ml.validate_dataset_specs(specs)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``validate_dataset_specs``
+                # walks each spec and issues a metadata round-trip per
+                # RID. See deriva-mcp-core plugin-authoring-guide.md
+                # §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                payload = await asyncio.to_thread(ml.validate_dataset_specs, specs)
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
@@ -874,12 +934,20 @@ def register(ctx: PluginContext) -> None:
             from deriva_ml.execution.execution_configuration import ExecutionConfiguration
 
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``validate_execution_configuration``
+                # walks the full config (workflow, datasets, assets) and
+                # issues per-spec metadata round-trips. See
+                # deriva-mcp-core plugin-authoring-guide.md §"Synchronous
+                # work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
                 # MCP wire always delivers a dict; coerce to the
                 # Pydantic class. Pydantic's ValidationError on bad
                 # input bubbles up through the except below.
                 exec_config = ExecutionConfiguration(**config)
-                payload = ml.validate_execution_configuration(exec_config)
+                payload = await asyncio.to_thread(
+                    ml.validate_execution_configuration, exec_config
+                )
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(

--- a/src/deriva_ml_mcp/tools/execution/mutate.py
+++ b/src/deriva_ml_mcp/tools/execution/mutate.py
@@ -23,6 +23,7 @@ canonical patch site for ``test_execution.py``. Same rationale as
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import TYPE_CHECKING
@@ -207,7 +208,13 @@ def register(ctx: PluginContext) -> None:
         as_list = list(asset_rids or [])
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``ml.create_execution``
+                # is the lifecycle entry point and can be slow (catalog
+                # writes + ExecutionConfiguration build). See
+                # deriva-mcp-core plugin-authoring-guide.md §"Synchronous
+                # work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
                 # Pre-resolve workflow_rid to a Workflow object. Upstream
                 # `ml.create_execution(workflow=...)` accepts `Workflow | RID
                 # | str | None` BUT when given a string, it routes through
@@ -218,10 +225,11 @@ def register(ctx: PluginContext) -> None:
                 # catalog". Look up the Workflow object via the RID API
                 # explicitly so the MCP tool's parameter name and behavior
                 # agree.
-                workflow = ml.lookup_workflow(workflow_rid)
+                workflow = await asyncio.to_thread(ml.lookup_workflow, workflow_rid)
                 # Pass strings through; upstream coerces datasets via
                 # DatasetSpec.from_shorthand and assets via AssetSpec(rid=...).
-                execution = ml.create_execution(
+                execution = await asyncio.to_thread(
+                    ml.create_execution,
                     workflow=workflow,
                     datasets=ds_list or None,
                     assets=as_list or None,
@@ -339,8 +347,13 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                execution = ml.resume_execution(execution_rid)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``execution.status`` is
+                # a pure Pydantic property read on the already-fetched
+                # record and stays on the event loop. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                execution = await asyncio.to_thread(ml.resume_execution, execution_rid)
                 current = execution.status
 
                 if current == ExecutionStatus.Running:
@@ -362,7 +375,7 @@ def register(ctx: PluginContext) -> None:
                         }
                     )
 
-                execution.execution_start()
+                await asyncio.to_thread(execution.execution_start)
 
             _pkg.audit_event(
                 "deriva_ml_start_execution",
@@ -452,8 +465,15 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                execution = ml.resume_execution(execution_rid)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive — commit drains staged
+                # feature rows, runs ``upload_execution_outputs`` (which
+                # can do multi-minute network work), and updates catalog
+                # state. ``execution.status`` is a pure Pydantic property
+                # read and stays on the event loop. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                execution = await asyncio.to_thread(ml.resume_execution, execution_rid)
                 current = execution.status
 
                 if current not in _COMMIT_ALLOWED_STATES:
@@ -472,14 +492,17 @@ def register(ctx: PluginContext) -> None:
                 # already past that point (Stopped/Pending_Upload), just
                 # proceed straight to upload.
                 if current in {ExecutionStatus.Created, ExecutionStatus.Running}:
-                    execution.execution_stop()
+                    await asyncio.to_thread(execution.execution_stop)
 
                 # Snapshot pending feature-record count before draining
                 # so the response can report how many feature values
                 # actually landed (the asset-only return value of
-                # upload_execution_outputs doesn't expose this).
-                pending_features = execution._manifest_store.list_pending_feature_records(
-                    execution_rid
+                # upload_execution_outputs doesn't expose this). The
+                # manifest store is a local SQLite engine — sync I/O
+                # that still blocks the event loop, so wrap it.
+                pending_features = await asyncio.to_thread(
+                    execution._manifest_store.list_pending_feature_records,
+                    execution_rid,
                 )
                 feature_count = len(pending_features)
 
@@ -492,7 +515,7 @@ def register(ctx: PluginContext) -> None:
                 # data unflushed. Until upstream unifies the two paths,
                 # commit_execution must use upload_execution_outputs to
                 # get a real end-to-end commit.
-                uploaded = execution.upload_execution_outputs()
+                uploaded = await asyncio.to_thread(execution.upload_execution_outputs)
                 summary = _summarize_upload_dict(
                     uploaded,
                     execution_rid=execution_rid,
@@ -589,9 +612,22 @@ def register(ctx: PluginContext) -> None:
         updated_fields: list[str] = []
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                record = ml.lookup_execution(execution_rid)
-                record.description = description
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``record.description =
+                # ...`` writes back to the catalog via the
+                # ExecutionRecord ``description.setter`` hook (see
+                # deriva_ml/execution/execution_record.py:
+                # _update_description_in_catalog), so it is synchronous
+                # I/O and must run in the worker thread. See
+                # deriva-mcp-core plugin-authoring-guide.md §"Synchronous
+                # work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                record = await asyncio.to_thread(ml.lookup_execution, execution_rid)
+
+                def _apply_description() -> None:
+                    record.description = description
+
+                await asyncio.to_thread(_apply_description)
                 updated_fields.append("description")
             _pkg.audit_event(
                 "deriva_ml_update_execution",
@@ -673,8 +709,13 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                execution = ml.resume_execution(execution_rid)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``execution.status`` is
+                # a pure Pydantic property read on the already-fetched
+                # record and stays on the event loop. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                execution = await asyncio.to_thread(ml.resume_execution, execution_rid)
                 current = execution.status
 
                 if current == ExecutionStatus.Aborted:
@@ -688,7 +729,7 @@ def register(ctx: PluginContext) -> None:
                         reason=None,
                     ).model_dump_json(by_alias=True)
 
-                execution.abort()
+                await asyncio.to_thread(execution.abort)
 
             _pkg.audit_event(
                 "deriva_ml_abort_execution",
@@ -757,9 +798,16 @@ def register(ctx: PluginContext) -> None:
         types_list = list(dataset_types) if dataset_types else None
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                execution = ml.resume_execution(execution_rid)
-                dataset = execution.create_dataset(
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``dataset.rid`` is a
+                # pure Pydantic attribute read on the already-created
+                # dataset and stays on the event loop. See
+                # deriva-mcp-core plugin-authoring-guide.md §"Synchronous
+                # work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                execution = await asyncio.to_thread(ml.resume_execution, execution_rid)
+                dataset = await asyncio.to_thread(
+                    execution.create_dataset,
                     dataset_types=types_list,
                     description=description,
                 )
@@ -849,9 +897,16 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                parent = ml.resume_execution(parent_execution_rid)
-                parent.add_nested_execution(child_execution_rid, sequence=sequence)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                parent = await asyncio.to_thread(ml.resume_execution, parent_execution_rid)
+                await asyncio.to_thread(
+                    parent.add_nested_execution,
+                    child_execution_rid,
+                    sequence=sequence,
+                )
 
             _pkg.audit_event(
                 "deriva_ml_add_nested_execution",

--- a/src/deriva_ml_mcp/tools/execution/read.py
+++ b/src/deriva_ml_mcp/tools/execution/read.py
@@ -19,6 +19,7 @@ through ``_error_envelope`` (reads only log on failure, no audit row).
 
 from __future__ import annotations
 
+import asyncio
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
@@ -344,10 +345,20 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``ml.find_executions``
+                # returns a generator that materializes over the wire, so
+                # the drain (list) must happen inside the worker thread,
+                # not on the event loop. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
                 if preflight_count:
                     status_enum = ExecutionStatus(status) if status else None
-                    total = len(list(ml.find_executions(workflow=workflow_rid, status=status_enum)))
+
+                    def _count_executions() -> int:
+                        return len(list(ml.find_executions(workflow=workflow_rid, status=status_enum)))
+
+                    total = await asyncio.to_thread(_count_executions)
                     return PreflightCountResponse(
                         total_count=total,
                         action_required=(
@@ -356,7 +367,8 @@ def register(ctx: PluginContext) -> None:
                         ),
                     ).model_dump_json(by_alias=True)
                 capped = min(max(limit, 0), _MAX_LIMIT)
-                payload = _list_executions_impl(
+                payload = await asyncio.to_thread(
+                    _list_executions_impl,
                     ml,
                     workflow_rid=workflow_rid,
                     status=status,
@@ -401,8 +413,13 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                record = ml.lookup_execution(execution_rid)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``_summarize_execution``
+                # is a pure Pydantic build over already-fetched attrs and
+                # stays on the event loop. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                record = await asyncio.to_thread(ml.lookup_execution, execution_rid)
                 summary = _summarize_execution(record)
             return summary.model_dump_json(by_alias=True)
         except Exception as exc:
@@ -456,10 +473,20 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``ml.find_executions``
+                # returns a generator that materializes over the wire, so
+                # the drain (list) must happen inside the worker thread,
+                # not on the event loop. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
                 if preflight_count:
                     status_enum = ExecutionStatus(status) if status else None
-                    total = len(list(ml.find_executions(workflow=workflow_rid, status=status_enum)))
+
+                    def _count_executions() -> int:
+                        return len(list(ml.find_executions(workflow=workflow_rid, status=status_enum)))
+
+                    total = await asyncio.to_thread(_count_executions)
                     return PreflightCountResponse(
                         total_count=total,
                         action_required=(
@@ -469,7 +496,8 @@ def register(ctx: PluginContext) -> None:
                     ).model_dump_json(by_alias=True)
 
                 capped = min(max(limit, 0), _MAX_LIMIT)
-                payload = _list_executions_impl(
+                payload = await asyncio.to_thread(
+                    _list_executions_impl,
                     ml,
                     workflow_rid=workflow_rid,
                     status=status,
@@ -527,9 +555,19 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                record = ml.lookup_execution(execution_rid)
-                children = list(record.list_execution_children(recurse=recurse))
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``list_execution_children``
+                # returns a generator that materializes over the wire, so
+                # the drain must happen inside the worker thread. See
+                # deriva-mcp-core plugin-authoring-guide.md §"Synchronous
+                # work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                record = await asyncio.to_thread(ml.lookup_execution, execution_rid)
+
+                def _drain_children() -> list[Any]:
+                    return list(record.list_execution_children(recurse=recurse))
+
+                children = await asyncio.to_thread(_drain_children)
             return ExecutionChildrenResponse(
                 parent_rid=execution_rid,
                 recurse=recurse,
@@ -576,9 +614,19 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                record = ml.lookup_execution(execution_rid)
-                parents = list(record.list_execution_parents(recurse=recurse))
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``list_execution_parents``
+                # returns a generator that materializes over the wire, so
+                # the drain must happen inside the worker thread. See
+                # deriva-mcp-core plugin-authoring-guide.md §"Synchronous
+                # work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                record = await asyncio.to_thread(ml.lookup_execution, execution_rid)
+
+                def _drain_parents() -> list[Any]:
+                    return list(record.list_execution_parents(recurse=recurse))
+
+                parents = await asyncio.to_thread(_drain_parents)
             return ExecutionParentsResponse(
                 child_rid=execution_rid,
                 recurse=recurse,
@@ -658,8 +706,15 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = _pkg.get_ml(hostname, catalog_id)
-                payload = _get_lineage_impl(ml, rid, depth, max_executions)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``_get_lineage_impl``
+                # wraps ``ml.lookup_lineage`` which performs catalog I/O.
+                # See deriva-mcp-core plugin-authoring-guide.md
+                # §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                payload = await asyncio.to_thread(
+                    _get_lineage_impl, ml, rid, depth, max_executions
+                )
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(

--- a/src/deriva_ml_mcp/tools/feature.py
+++ b/src/deriva_ml_mcp/tools/feature.py
@@ -16,6 +16,7 @@ feature_table name from the previous page.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -175,9 +176,19 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``ml.find_features``
+                # returns a generator that materializes over the wire, so
+                # the drain (list/sorted) must happen inside the worker
+                # thread, not on the event loop. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
                 if preflight_count:
-                    total = len(list(ml.find_features(table=table)))
+
+                    def _count_features() -> int:
+                        return len(list(ml.find_features(table=table)))
+
+                    total = await asyncio.to_thread(_count_features)
                     return PreflightCountResponse(
                         total_count=total,
                         action_required=(
@@ -187,7 +198,8 @@ def register(ctx: PluginContext) -> None:
                     ).model_dump_json(by_alias=True)
 
                 capped = min(max(limit, 0), _MAX_LIMIT)
-                payload = _list_features_impl(
+                payload = await asyncio.to_thread(
+                    _list_features_impl,
                     ml,
                     table=table,
                     after_rid=after_rid,
@@ -237,8 +249,11 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
-                feature = ml.lookup_feature(table, feature_name)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                feature = await asyncio.to_thread(ml.lookup_feature, table, feature_name)
                 payload = {
                     "feature_name": feature.feature_name,
                     "target_table": feature.target_table.name,
@@ -393,35 +408,53 @@ def register(ctx: PluginContext) -> None:
 
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``feature_values``
+                # returns a generator that materializes over the wire, so
+                # the drain (list) must happen inside the worker thread,
+                # not on the event loop. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
                 # by_workflow needs a container; build it now that we have ml.
                 if selector_fn == "__by_workflow__":
-                    container = ml.lookup_dataset(dataset_rid) if dataset_rid else ml
+                    container = (
+                        await asyncio.to_thread(ml.lookup_dataset, dataset_rid)
+                        if dataset_rid
+                        else ml
+                    )
                     selector_fn = FeatureRecord.select_by_workflow(
                         selector_workflow, container=container
                     )
 
                 if dataset_rid is not None:
-                    ds = ml.lookup_dataset(dataset_rid)
-                    records = list(
-                        ds.feature_values(
-                            table,
-                            feature_name,
-                            selector=selector_fn,
-                            materialize_limit=max_results,
-                            execution_rids=execution_rids,
+                    ds = await asyncio.to_thread(ml.lookup_dataset, dataset_rid)
+
+                    def _drain_ds_feature_values() -> list[Any]:
+                        return list(
+                            ds.feature_values(
+                                table,
+                                feature_name,
+                                selector=selector_fn,
+                                materialize_limit=max_results,
+                                execution_rids=execution_rids,
+                            )
                         )
-                    )
+
+                    records = await asyncio.to_thread(_drain_ds_feature_values)
                 else:
-                    records = list(
-                        ml.feature_values(
-                            table,
-                            feature_name,
-                            selector=selector_fn,
-                            materialize_limit=max_results,
-                            execution_rids=execution_rids,
+
+                    def _drain_ml_feature_values() -> list[Any]:
+                        return list(
+                            ml.feature_values(
+                                table,
+                                feature_name,
+                                selector=selector_fn,
+                                materialize_limit=max_results,
+                                execution_rids=execution_rids,
+                            )
                         )
-                    )
+
+                    records = await asyncio.to_thread(_drain_ml_feature_values)
 
             if preflight_count:
                 total = len(records)
@@ -523,8 +556,12 @@ def register(ctx: PluginContext) -> None:
         assets_list = list(assets or [])
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
-                ml.create_feature(
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                await asyncio.to_thread(
+                    ml.create_feature,
                     target_table,
                     feature_name,
                     terms=terms_list,
@@ -536,7 +573,9 @@ def register(ctx: PluginContext) -> None:
                 # create_feature returns the FeatureRecord subclass, not
                 # the Feature schema. Re-look up the Feature for the
                 # response shape.
-                feature = ml.lookup_feature(target_table, feature_name)
+                feature = await asyncio.to_thread(
+                    ml.lookup_feature, target_table, feature_name
+                )
                 summary = _summarize_feature(feature)
             audit_event(
                 "deriva_ml_create_feature",
@@ -591,8 +630,11 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
-                was_deleted = ml.delete_feature(table, feature_name)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                was_deleted = await asyncio.to_thread(ml.delete_feature, table, feature_name)
             if was_deleted:
                 audit_event(
                     "deriva_ml_delete_feature",
@@ -698,8 +740,14 @@ def register(ctx: PluginContext) -> None:
         failed_index: int | None = None
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
-                feature = ml.lookup_feature(table, feature_name)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``feature_record_class``
+                # is pure-Python class construction (no I/O), so it stays
+                # on the event loop, as do the Pydantic record builds.
+                # See deriva-mcp-core plugin-authoring-guide.md §"Synchronous
+                # work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                feature = await asyncio.to_thread(ml.lookup_feature, table, feature_name)
                 feature_class = feature.feature_record_class()
 
                 records = []
@@ -708,16 +756,23 @@ def register(ctx: PluginContext) -> None:
                     records.append(feature_class(**entry))
                 failed_index = None
 
-                execution = ml.resume_execution(execution_rid)
+                execution = await asyncio.to_thread(ml.resume_execution, execution_rid)
                 # Hybrid dispatch (Q1). See docstring for the rationale.
                 current = execution.status
                 if current == ExecutionStatus.Created:
-                    with execution.execute():
-                        added = execution.add_features(records)
+                    # ``execution.execute()`` is a sync context manager
+                    # whose __enter__/__exit__ touch the catalog, and
+                    # ``add_features`` is sync I/O. Run the whole bracket
+                    # in a single worker thread.
+                    def _execute_and_add() -> int:
+                        with execution.execute():
+                            return execution.add_features(records)
+
+                    added = await asyncio.to_thread(_execute_and_add)
                 elif current == ExecutionStatus.Running:
                     # Already inside the long-running pipeline. The
                     # eventual commit_execution closes the lifecycle.
-                    added = execution.add_features(records)
+                    added = await asyncio.to_thread(execution.add_features, records)
                 else:
                     state_name = current.value if isinstance(current, ExecutionStatus) else current
                     raise ValueError(

--- a/src/deriva_ml_mcp/tools/workflow.py
+++ b/src/deriva_ml_mcp/tools/workflow.py
@@ -15,6 +15,7 @@ them in. We never run server-side git introspection on the MCP host.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from functools import partial
@@ -202,9 +203,19 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``ml.find_workflows``
+                # returns a generator that materializes over the wire, so
+                # the drain (list/sorted) must happen inside the worker
+                # thread, not on the event loop. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
                 if preflight_count:
-                    total = len(list(ml.find_workflows()))
+
+                    def _count_workflows() -> int:
+                        return len(list(ml.find_workflows()))
+
+                    total = await asyncio.to_thread(_count_workflows)
                     return PreflightCountResponse(
                         total_count=total,
                         action_required=(
@@ -214,7 +225,13 @@ def register(ctx: PluginContext) -> None:
                     ).model_dump_json(by_alias=True)
 
                 capped = min(max(limit, 0), _MAX_LIMIT)
-                payload = _list_workflows_impl(ml, after_rid=after_rid, limit=capped, sort=sort)
+                payload = await asyncio.to_thread(
+                    _list_workflows_impl,
+                    ml,
+                    after_rid=after_rid,
+                    limit=capped,
+                    sort=sort,
+                )
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             # Read-only tool: log+return without an audit row.
@@ -255,8 +272,11 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
-                summary = _get_workflow_impl(ml, workflow_rid)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                summary = await asyncio.to_thread(_get_workflow_impl, ml, workflow_rid)
             return summary.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
@@ -310,8 +330,11 @@ def register(ctx: PluginContext) -> None:
         """
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
-                wf = ml.lookup_workflow_by_url(url_or_checksum)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                wf = await asyncio.to_thread(ml.lookup_workflow_by_url, url_or_checksum)
                 summary = _summarize_workflow(wf)
             return summary.model_dump_json(by_alias=True)
         except Exception as exc:
@@ -416,7 +439,10 @@ def register(ctx: PluginContext) -> None:
         )
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
                 # Pre-check exists solely to set status="exists" for the
                 # audit + return value. _add_workflow already dedups
                 # internally on `checksum or url` and returns the existing
@@ -434,18 +460,23 @@ def register(ctx: PluginContext) -> None:
                 rid: str
                 status: str
                 try:
-                    existing = ml.lookup_workflow_by_url(lookup_key)
+                    existing = await asyncio.to_thread(ml.lookup_workflow_by_url, lookup_key)
                 except DerivaMLException:
                     existing = None
                 if existing is not None:
                     rid = existing.rid
                     status = "exists"
                 else:
-                    wf = ml.create_workflow(
+                    wf = await asyncio.to_thread(
+                        ml.create_workflow,
                         name=name,
                         workflow_type=workflow_type,
                         description=description,
                     )
+                    # url/checksum/version are pure Pydantic attribute
+                    # writes on a not-yet-catalog-bound Workflow (no
+                    # ``_ml_instance`` set), so they don't trigger I/O
+                    # and stay on the event loop.
                     wf.url = url
                     wf.checksum = checksum
                     wf.version = version
@@ -454,7 +485,7 @@ def register(ctx: PluginContext) -> None:
                     # workflow inserts in deriva_ml itself go through it.
                     # If deriva_ml 2.x renames it, our pre-flight smoke
                     # test will catch the mismatch via the import.
-                    rid = ml._add_workflow(wf)
+                    rid = await asyncio.to_thread(ml._add_workflow, wf)
                     status = "created"
             audit_event(
                 "deriva_ml_create_workflow",
@@ -554,13 +585,27 @@ def register(ctx: PluginContext) -> None:
         updated_fields: list[str] = []
         try:
             with deriva_call():
-                ml = get_ml(hostname, catalog_id)
-                wf = ml.lookup_workflow(workflow_rid)
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``wf.description`` and
+                # ``wf.workflow_type`` setattrs write back to the catalog
+                # via the Workflow ``__setattr__`` hook (see
+                # deriva_ml/execution/workflow.py), so they're synchronous
+                # I/O and must run in the worker thread. See
+                # deriva-mcp-core plugin-authoring-guide.md §"Synchronous
+                # work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                wf = await asyncio.to_thread(ml.lookup_workflow, workflow_rid)
+
+                def _apply_updates() -> None:
+                    if description is not None:
+                        wf.description = description
+                    if workflow_type is not None:
+                        wf.workflow_type = workflow_type
+
+                await asyncio.to_thread(_apply_updates)
                 if description is not None:
-                    wf.description = description
                     updated_fields.append("description")
                 if workflow_type is not None:
-                    wf.workflow_type = workflow_type
                     updated_fields.append("workflow_type")
             audit_event(
                 "deriva_ml_update_workflow",

--- a/tests/test_async_thread_wrap.py
+++ b/tests/test_async_thread_wrap.py
@@ -34,17 +34,13 @@ PLUGIN_ROOT = Path(__file__).resolve().parent.parent / "src" / "deriva_ml_mcp" /
 
 # Modules whose async tool functions are required to thread-wrap every
 # sync deriva-ml call inside ``with deriva_call():`` blocks.
-#
-# ``dataset/mutate.py`` is intentionally excluded: the wrap work for
-# that file is Task 7 of the ``fix/async-thread-wrap-tools`` series and
-# has not landed yet. Re-include it here as part of Task 7.
 TOOL_MODULES: list[Path] = [
     PLUGIN_ROOT / "asset.py",
     PLUGIN_ROOT / "feature.py",
     PLUGIN_ROOT / "workflow.py",
     PLUGIN_ROOT / "maintenance.py",
     PLUGIN_ROOT / "dataset" / "read.py",
-    # PLUGIN_ROOT / "dataset" / "mutate.py",  # excluded: pending Task 7 -- re-include when wrapped
+    PLUGIN_ROOT / "dataset" / "mutate.py",
     PLUGIN_ROOT / "dataset" / "complex.py",
     PLUGIN_ROOT / "execution" / "read.py",
     PLUGIN_ROOT / "execution" / "mutate.py",

--- a/tests/test_async_thread_wrap.py
+++ b/tests/test_async_thread_wrap.py
@@ -1,0 +1,464 @@
+"""Structural tests: every sync deriva-ml call inside an async tool's
+``with deriva_call():`` block must be wrapped in ``asyncio.to_thread``.
+
+Without this gate, the bug PR #28 (and the ``fix/async-thread-wrap-tools``
+work) addresses can be silently re-introduced. See ``CLAUDE.md`` →
+"Tool Implementation Rules → asyncio.to_thread" + "Development Gotchas
+→ Sync calls in async tools" for the rule and history.
+
+The check is AST-only -- no runtime catalog and no actual deriva-ml
+import is required. For every ``async def`` function defined in the
+listed tool modules, this test:
+
+1. Walks every ``with deriva_call():`` block inside the function.
+2. For every ``Call`` node whose receiver is a known deriva-ml object
+   (``ml``/``ds``/``exe``/``wf``/``record``/``feature``/``asset``/
+   ``dataset``/``execution``/``workflow``/``parent``/``child``), or
+   whose function is the imported ``get_ml`` constructor, asserts the
+   call is reachable only inside a nested function that is itself the
+   first argument to an ``asyncio.to_thread(...)`` call.
+
+The "wrapped" form ``await asyncio.to_thread(ml.find_features)`` passes
+the *Attribute* node ``ml.find_features`` (not a Call) into
+``to_thread``; that case generates no Call node and is therefore not
+flagged. The unwrapped form ``ml.find_features()`` does generate a Call
+node and IS flagged unless protected by a threaded nested helper.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent / "src" / "deriva_ml_mcp" / "tools"
+
+# Modules whose async tool functions are required to thread-wrap every
+# sync deriva-ml call inside ``with deriva_call():`` blocks.
+#
+# ``dataset/mutate.py`` is intentionally excluded: the wrap work for
+# that file is Task 7 of the ``fix/async-thread-wrap-tools`` series and
+# has not landed yet. Re-include it here as part of Task 7.
+TOOL_MODULES: list[Path] = [
+    PLUGIN_ROOT / "asset.py",
+    PLUGIN_ROOT / "feature.py",
+    PLUGIN_ROOT / "workflow.py",
+    PLUGIN_ROOT / "maintenance.py",
+    PLUGIN_ROOT / "dataset" / "read.py",
+    # PLUGIN_ROOT / "dataset" / "mutate.py",  # excluded: pending Task 7 -- re-include when wrapped
+    PLUGIN_ROOT / "dataset" / "complex.py",
+    PLUGIN_ROOT / "execution" / "read.py",
+    PLUGIN_ROOT / "execution" / "mutate.py",
+]
+
+# Names whose method calls indicate sync deriva-ml I/O. Any
+# ``<name>.<method>(...)`` Call where ``<name>`` is in this set is
+# considered a sync deriva-ml callsite that must be thread-wrapped.
+DERIVA_OBJECT_NAMES: frozenset[str] = frozenset(
+    {
+        "ml",
+        "ds",
+        "exe",
+        "wf",
+        "record",
+        "feature",
+        "asset",
+        "dataset",
+        "execution",
+        "workflow",
+        "parent",
+        "child",
+    }
+)
+
+# Bare-function names (imported directly from deriva-ml plumbing) that
+# are themselves sync deriva-ml callsites.
+DERIVA_FUNC_NAMES: frozenset[str] = frozenset({"get_ml"})
+
+# Method names on deriva-ml objects that are documented pure-Python
+# (no catalog I/O) and are deliberately allowed to remain unwrapped
+# inside ``with deriva_call():`` blocks. Each entry must correspond to
+# an in-tree comment justifying the exemption.
+#
+# - ``feature_record_class`` (Feature) -- class-factory, no I/O.
+#   See ``tools/feature.py`` ``deriva_ml_add_feature_values`` comment.
+# - ``get_chaise_url`` (Dataset/Asset/Execution) -- f-string URL
+#   construction over ``host_name``/``catalog_id``/``rid``; no
+#   network calls. See ``deriva_ml/dataset/dataset.py:get_chaise_url``.
+PURE_PYTHON_METHODS: frozenset[str] = frozenset(
+    {
+        "feature_record_class",
+        "get_chaise_url",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_deriva_io_call(node: ast.Call) -> bool:
+    """Return True iff ``node`` is a sync deriva-ml call by allowlist.
+
+    Args:
+        node: An ``ast.Call`` node.
+
+    Returns:
+        True if the call's function is ``<name>.<method>`` with
+        ``<name>`` in ``DERIVA_OBJECT_NAMES``, or a bare name in
+        ``DERIVA_FUNC_NAMES``. False otherwise.
+    """
+    func = node.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        if func.value.id not in DERIVA_OBJECT_NAMES:
+            return False
+        # Documented pure-Python methods are exempt -- they don't do
+        # catalog I/O so wrapping them in a thread is unnecessary.
+        return func.attr not in PURE_PYTHON_METHODS
+    if isinstance(func, ast.Name):
+        return func.id in DERIVA_FUNC_NAMES
+    return False
+
+
+def _is_with_deriva_call(node: ast.With | ast.AsyncWith) -> bool:
+    """Return True iff ``node`` is a ``with deriva_call():`` (or async-with) block.
+
+    Matches both ``with deriva_call():`` and
+    ``with deriva_call() as x:`` shapes; the attribute-access form
+    (``mod.deriva_call()``) is also matched defensively.
+
+    Args:
+        node: A ``with``/``async with`` AST node.
+
+    Returns:
+        True if any of the context managers is a Call to
+        ``deriva_call`` (Name) or ``<x>.deriva_call`` (Attribute).
+    """
+    for item in node.items:
+        ctx = item.context_expr
+        if not isinstance(ctx, ast.Call):
+            continue
+        called = ctx.func
+        if isinstance(called, ast.Name) and called.id == "deriva_call":
+            return True
+        if isinstance(called, ast.Attribute) and called.attr == "deriva_call":
+            return True
+    return False
+
+
+def _collect_threaded_nested_funcs(async_func: ast.AsyncFunctionDef) -> set[int]:
+    """Return ids of nested function defs passed as the 1st arg to ``asyncio.to_thread``.
+
+    A nested ``def`` or ``async def`` whose name appears as the first
+    positional argument to ``asyncio.to_thread(<name>, ...)`` runs
+    entirely inside the worker thread, so any sync deriva-ml calls
+    inside its body are allowed unwrapped (the whole body executes off
+    the event loop). This helper finds every such nested definition by
+    matching name -> definition.
+
+    Args:
+        async_func: The outer ``async def`` whose body to scan.
+
+    Returns:
+        A set of ``id(node)`` values for FunctionDef / AsyncFunctionDef
+        nodes that are reachable as ``asyncio.to_thread(<their_name>, ...)``
+        somewhere in the outer function's body.
+    """
+    # 1. Map nested function names -> their AST nodes.
+    nested_by_name: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+    for node in ast.walk(async_func):
+        if node is async_func:
+            continue
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            nested_by_name[node.name] = node
+
+    # 2. Find every ``asyncio.to_thread(<name>, ...)`` call and collect
+    #    the matching nested definitions.
+    threaded_ids: set[int] = set()
+    for node in ast.walk(async_func):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_asyncio_to_thread(node.func):
+            continue
+        if not node.args:
+            continue
+        first_arg = node.args[0]
+        if isinstance(first_arg, ast.Name) and first_arg.id in nested_by_name:
+            threaded_ids.add(id(nested_by_name[first_arg.id]))
+    return threaded_ids
+
+
+def _is_asyncio_to_thread(func_node: ast.AST) -> bool:
+    """Return True iff ``func_node`` is the attribute reference ``asyncio.to_thread``.
+
+    Args:
+        func_node: An expression that appears in ``Call.func`` position.
+
+    Returns:
+        True iff the expression is exactly ``asyncio.to_thread``.
+    """
+    return (
+        isinstance(func_node, ast.Attribute)
+        and isinstance(func_node.value, ast.Name)
+        and func_node.value.id == "asyncio"
+        and func_node.attr == "to_thread"
+    )
+
+
+def _walk_async_funcs(tree: ast.AST) -> list[ast.AsyncFunctionDef]:
+    """Return every ``async def`` defined anywhere in ``tree``.
+
+    Includes top-level definitions and ones nested inside other
+    functions (e.g. tools registered inside a ``register(ctx)`` call).
+    Nested ``async def``s defined *inside* an outer ``async def`` will
+    be returned in their own right; that's fine -- the per-function
+    check is scoped to each ``async def``'s own body and the inner
+    one's ``with deriva_call():`` blocks (if any) get checked twice,
+    which is harmless and covers the case where a tool is genuinely
+    nested.
+
+    Args:
+        tree: A parsed AST module.
+
+    Returns:
+        List of every ``ast.AsyncFunctionDef`` in document order.
+    """
+    return [node for node in ast.walk(tree) if isinstance(node, ast.AsyncFunctionDef)]
+
+
+def _calls_in_subtree(root: ast.AST) -> list[ast.Call]:
+    """Return every ``ast.Call`` reachable from ``root``.
+
+    Args:
+        root: Any AST node.
+
+    Returns:
+        All Call descendants in document order.
+    """
+    return [node for node in ast.walk(root) if isinstance(node, ast.Call)]
+
+
+def _node_within(node: ast.AST, ancestor: ast.AST) -> bool:
+    """Return True iff ``node`` is the same as, or a descendant of, ``ancestor``.
+
+    Implemented by walking ``ancestor`` once and checking object
+    identity; the AST is not enormous and this runs once per (call,
+    nested-helper) pair.
+
+    Args:
+        node: Candidate descendant.
+        ancestor: Candidate ancestor.
+
+    Returns:
+        True iff ``node`` is reachable from ``ancestor`` via ``ast.walk``.
+    """
+    return any(child is node for child in ast.walk(ancestor))
+
+
+# ---------------------------------------------------------------------------
+# Core check
+# ---------------------------------------------------------------------------
+
+
+def _violations_in_module(path: Path) -> list[str]:
+    """Return a list of violation strings for one tool module.
+
+    Each violation string is a one-line summary identifying the file,
+    enclosing async function, line number, and the offending source
+    fragment. The list is empty when the module is clean.
+
+    Args:
+        path: Absolute path to the tool module.
+
+    Returns:
+        Sorted list of violation strings (empty when clean).
+    """
+    source = path.read_text()
+    tree = ast.parse(source, filename=str(path))
+    violations: list[str] = []
+
+    for async_func in _walk_async_funcs(tree):
+        # Nested defs whose body runs in the worker thread -- calls
+        # inside these are exempt from the wrap rule.
+        threaded_ids = _collect_threaded_nested_funcs(async_func)
+        threaded_nodes: list[ast.AST] = []
+        for node in ast.walk(async_func):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and id(node) in threaded_ids
+            ):
+                threaded_nodes.append(node)
+
+        # Find every ``with deriva_call():`` block in this async func,
+        # including ``async with`` for completeness.
+        with_blocks: list[ast.With | ast.AsyncWith] = []
+        for node in ast.walk(async_func):
+            if isinstance(node, (ast.With, ast.AsyncWith)) and _is_with_deriva_call(node):
+                with_blocks.append(node)
+
+        for with_block in with_blocks:
+            for call in _calls_in_subtree(with_block):
+                # Skip the ``deriva_call()`` context-manager call itself
+                # (it appears in ``with_block.items[*].context_expr``).
+                if any(call is item.context_expr for item in with_block.items):
+                    continue
+                # Skip ``asyncio.to_thread(...)`` calls themselves.
+                if _is_asyncio_to_thread(call.func):
+                    continue
+                # Only deriva-IO calls are subject to the rule.
+                if not _is_deriva_io_call(call):
+                    continue
+                # Allow calls inside a nested helper that's threaded.
+                if any(_node_within(call, helper) for helper in threaded_nodes):
+                    continue
+
+                snippet = ast.unparse(call)
+                violations.append(
+                    f"{path}:{call.lineno}: in `async def {async_func.name}`: "
+                    f"unwrapped sync deriva-ml call `{snippet}` inside "
+                    f"`with deriva_call():` (must be `await asyncio.to_thread(...)`)"
+                )
+
+    return sorted(violations)
+
+
+# ---------------------------------------------------------------------------
+# The test
+# ---------------------------------------------------------------------------
+
+
+def test_async_tools_thread_wrap_sync_deriva_calls() -> None:
+    """Every sync deriva-ml call in an async tool must be thread-wrapped.
+
+    Iterates ``TOOL_MODULES``, parses each, and asserts no module
+    contains an unwrapped sync deriva-ml call inside an async tool's
+    ``with deriva_call():`` block. A failure means a contributor (or
+    a future refactor) has reintroduced the regression class that
+    PR #28 / ``fix/async-thread-wrap-tools`` is fixing.
+    """
+    all_violations: list[str] = []
+    for module_path in TOOL_MODULES:
+        assert module_path.is_file(), f"tool module not found: {module_path}"
+        all_violations.extend(_violations_in_module(module_path))
+
+    if all_violations:
+        msg = "\n".join(["Unwrapped sync deriva-ml calls found:", *all_violations])
+        raise AssertionError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Self-test: prove the checker actually catches violations.
+#
+# This guards against the checker silently degrading -- e.g. a refactor
+# that broadens an exemption such that the rule no longer fires. It
+# parses an in-memory module containing an unwrapped ``ml.find_datasets()``
+# inside ``with deriva_call():`` and asserts ``_violations_in_module``
+# (via the per-tree helper) reports it.
+# ---------------------------------------------------------------------------
+
+
+_BAD_SOURCE = '''
+"""Synthetic broken module to verify the checker detects regressions."""
+from __future__ import annotations
+
+import asyncio  # noqa: F401 -- referenced by the wrap pattern in good code
+from deriva_mcp_core import deriva_call
+
+
+async def deriva_ml_intentionally_broken(hostname: str, catalog_id: str) -> str:
+    with deriva_call():
+        ml.find_datasets()  # unwrapped sync call -- MUST be flagged
+    return "x"
+'''
+
+_GOOD_SOURCE = '''
+"""Synthetic correct module: every sync call thread-wrapped."""
+from __future__ import annotations
+
+import asyncio
+from deriva_mcp_core import deriva_call
+
+
+async def deriva_ml_correctly_wrapped(hostname: str, catalog_id: str) -> str:
+    with deriva_call():
+        ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+        result = await asyncio.to_thread(ml.find_datasets)
+    return str(result)
+
+
+async def deriva_ml_nested_helper(hostname: str, catalog_id: str) -> str:
+    with deriva_call():
+        ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+
+        def _drain() -> list:
+            # Inside a threaded nested helper -- exempt.
+            return list(ml.find_datasets())
+
+        rows = await asyncio.to_thread(_drain)
+    return str(rows)
+'''
+
+
+def _violations_in_source(source: str) -> list[str]:
+    """Run the checker over an in-memory source string. Test-only helper.
+
+    Args:
+        source: Python source text.
+
+    Returns:
+        Violation strings, same shape as ``_violations_in_module``.
+    """
+    tree = ast.parse(source)
+    violations: list[str] = []
+
+    for async_func in _walk_async_funcs(tree):
+        threaded_ids = _collect_threaded_nested_funcs(async_func)
+        threaded_nodes: list[ast.AST] = []
+        for node in ast.walk(async_func):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and id(node) in threaded_ids
+            ):
+                threaded_nodes.append(node)
+
+        with_blocks: list[ast.With | ast.AsyncWith] = []
+        for node in ast.walk(async_func):
+            if isinstance(node, (ast.With, ast.AsyncWith)) and _is_with_deriva_call(node):
+                with_blocks.append(node)
+
+        for with_block in with_blocks:
+            for call in _calls_in_subtree(with_block):
+                if any(call is item.context_expr for item in with_block.items):
+                    continue
+                if _is_asyncio_to_thread(call.func):
+                    continue
+                if not _is_deriva_io_call(call):
+                    continue
+                if any(_node_within(call, helper) for helper in threaded_nodes):
+                    continue
+                violations.append(f"line {call.lineno}: {ast.unparse(call)}")
+
+    return violations
+
+
+def test_self_check_flags_unwrapped_call() -> None:
+    """Sanity: the checker DOES flag a deliberately unwrapped sync call.
+
+    Without this guard, a refactor could neutralize the main test
+    (e.g. by accidentally exempting all calls) and the suite would
+    still appear green.
+    """
+    violations = _violations_in_source(_BAD_SOURCE)
+    assert any("ml.find_datasets()" in v for v in violations), (
+        f"checker failed to flag the synthetic violation; got: {violations!r}"
+    )
+
+
+def test_self_check_passes_on_correctly_wrapped_code() -> None:
+    """Sanity: the checker does NOT flag the canonical wrapped patterns.
+
+    Confirms the two valid shapes -- direct ``await asyncio.to_thread(...)``
+    and threaded-nested-helper -- are accepted.
+    """
+    violations = _violations_in_source(_GOOD_SOURCE)
+    assert violations == [], f"checker false-positived on good code: {violations!r}"


### PR DESCRIPTION
## Summary

Wraps every synchronous deriva-ml / deriva-py call inside an `async def` tool with `await asyncio.to_thread(...)`, across the seven tool modules PR #28 didn't cover. Adds a permanent AST-level structural test that prevents regression.

## Why

PR #28 (`fix(complex): wrap sync deriva-ml calls in asyncio.to_thread`) fixed this for `tools/dataset/complex.py`, but the symptom — intermittent silent tool rejections in MCP clients ("user doesn't want to proceed" without any user action) — recurs for every tool in the unfixed modules. The asyncio event loop blocks during sync deriva calls; the host's permission stream times out; pending tool calls reject.

Mechanism diagnosed during a deriva-ml-sandbox conversation 2026-05-05; the failure mode shows up in Claude Desktop's `main.log` as `Tool permission stream closed before response received`. Root cause: synchronous `deriva-ml` / `deriva-py` calls inside `async def` tools block the asyncio event loop.

## Modules covered

| Commit | Module | Callsites wrapped |
|---|---|---|
| `4123c06` | `tools/asset.py` | 12 |
| `95155a4` | `tools/feature.py` | 11 |
| `4ab3420` | `tools/workflow.py` | 14 |
| `4cde409` | `tools/execution/read.py` | 16 |
| `8249d3e` | `tools/execution/mutate.py` | 18 |
| `6607988` | `tools/dataset/read.py` | 23 |
| `c02e737` | `tools/dataset/mutate.py` | 18 |

(`tools/maintenance.py` was audited but didn't need changes — its `with deriva_call():` blocks `await` already-async coroutines, no sync wrapping required.)

## Permanent regression guard

`tests/test_async_thread_wrap.py` (commit `d3cf84a`) walks every tool module's AST, finds calls to deriva-ml objects (`ml`, `ds`, `exe`, `wf`, `record`, `feature`, `asset`, `dataset`, `execution`, `workflow`, `parent`, `child`) and the `get_ml` constructor inside `with deriva_call():` blocks of async tools, and asserts each one is the argument to `await asyncio.to_thread(...)` — either directly or via a nested helper that's itself threaded.

Includes a self-test (synthetic AST input with both correctly-wrapped and unwrapped sources) so the checker itself can't silently degrade.

## Documentation

- `CLAUDE.md` (commit `17101fb`) adds a load-bearing rule under "Tool Implementation Rules" requiring `asyncio.to_thread` for every sync deriva call in async tools, plus a longer history under "Development Gotchas → Sync calls in async tools" capturing the lesson PR #28 missed.
- `docs/superpowers/plans/2026-05-05-async-thread-wrap-all-tools.md` (commit `3d8a7b5`) is the implementation plan that drove this PR — kept for archive value.

## Subtle cases the per-module work surfaced

Each tool module had its own quirks worth flagging in this PR:

- **`tools/workflow.py`**: Distinguishes I/O-triggering Pydantic property writes (`wf.description = ...`, `wf.workflow_type = ...` on a `lookup_workflow`-resolved Workflow) from pure-Python writes on freshly-constructed Workflow instances. The former are wrapped in `_apply_updates` helper; the latter stay on the event loop. Verified against `Workflow.__setattr__` (`deriva-ml/src/deriva_ml/execution/workflow.py:165-204`).

- **`tools/execution/mutate.py`**: Same pattern for `record.description = description` (verified against `ExecutionRecord.description.setter` at `execution_record.py:219-233`). Wrapped via `_apply_description` helper.

- **`tools/feature.py`**: Wraps the entire `with execution.execute(): execution.add_features(...)` block as a unit via `_execute_and_add` helper because Execution's `__enter__`/`__exit__` does catalog I/O.

- **Generator-returning sync calls** (e.g. `ml.find_features()`, `ml.list_assets()`, `ds.feature_values(...)`): drained inside nested `def _drain():` helpers that get threaded — preserves "all I/O happens in the worker thread" while letting the caller use the materialized list on the event loop. Pattern from `tools/dataset/complex.py:325-338`.

- **`PURE_PYTHON_METHODS`** allowlist in the AST test: `feature_record_class` (Pydantic class factory) and `get_chaise_url` (f-string URL construction) — both verified pure-Python in deriva-ml source.

## Test plan

- [x] Per-module unit + integration tests pass after each commit
- [x] Full `uv run pytest`: 311 passed (vs. 308 baseline; +3 from new AST tests)
- [x] AST structural test: 3/3 passing
- [x] `ruff check src tests`: clean
- [x] End-to-end smoke against live catalog 41 (CIFAR-10 with 5000 images): the previously-flaky `deriva_ml_list_dataset_relations` call now succeeds without rejection. Also verified `list_dataset_members`, `list_workflows`, `list_executions` — all clean.

## Reference

- Precedent: PR #28 (`fix(complex): wrap sync deriva-ml calls in asyncio.to_thread`)
- Plan: `docs/superpowers/plans/2026-05-05-async-thread-wrap-all-tools.md`
- Rule: `CLAUDE.md` → "Tool Implementation Rules" + "Development Gotchas → Sync calls in async tools"

🤖 Generated with [Claude Code](https://claude.com/claude-code)