### PR TITLE
fix(resources): categorize Execution_Metadata outputs in execution detail

### DIFF
--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -413,17 +413,33 @@ class ExecutionInputs(BaseModel):
 class ExecutionOutputs(BaseModel):
     """Outputs grouping on an Execution detail.
 
-    Outputs are asset-only today -- DerivaML doesn't currently model
-    "this execution produced this dataset" as a first-class output
-    relationship (datasets are produced by features that link back to
-    their producing execution; the relationship is reachable but not
-    direct). Kept as a single-key dict for forward compatibility with
-    a possible future ``outputs.datasets`` field.
+    Outputs are split into two buckets:
+
+    - ``assets`` -- "real" ``Execution_Asset`` outputs the run produced
+      (model weights, prediction CSVs, training logs, plots).
+    - ``metadata`` -- ``Execution_Metadata`` outputs (configuration.json,
+      hydra-*.yaml, uv.lock, environment snapshots). These are
+      provenance-of-the-run rather than products-of-the-run, and most
+      reader use cases want them separated from the real outputs.
+
+    Categorization is by the asset row's ``asset_table`` attribute,
+    which deriva-ml's ``ExecutionRecord.list_assets`` already exposes
+    (no upstream change needed -- the underlying enumerator walks both
+    ``Execution_Asset_Execution`` and ``Execution_Metadata_Execution``
+    association tables).
+
+    DerivaML doesn't currently model "this execution produced this
+    dataset" as a first-class output relationship (datasets are
+    produced by features that link back to their producing execution;
+    the relationship is reachable but not direct), so an
+    ``outputs.datasets`` field is intentionally absent. The dict stays
+    extensible for that future.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     assets: list[ExecutionAssetRef] = Field(default_factory=list)
+    metadata: list[ExecutionAssetRef] = Field(default_factory=list)
 
 
 class ExecutionExperiment(BaseModel):
@@ -460,10 +476,12 @@ class ExecutionDetail(ExecutionSummary):
     rather than aborting the whole detail payload. Same best-effort
     semantics for ``inputs.assets`` and ``outputs.assets``.
 
-    The ``metadata`` key from the v1.x design (Deriva_Config /
-    Execution_Config / Hydra_Config / Runtime_Env) is intentionally
-    OMITTED until upstream provides a generic enumerator -- see the
-    TODO comment in ``_get_execution_detail_impl``.
+    Outputs are split between ``outputs.assets`` (real
+    ``Execution_Asset`` files like model weights and prediction CSVs)
+    and ``outputs.metadata`` (``Execution_Metadata`` files like
+    ``configuration.json``, ``hydra-*.yaml``, ``uv.lock``, and the
+    environment snapshot). See ``ExecutionOutputs`` for the
+    categorization rationale.
 
     v2.0 wire shape: identical to v1.x (this PR Pydantic-izes the
     contract; there's no field rename or restructure on this model).

--- a/src/deriva_ml_mcp/resources/ml.py
+++ b/src/deriva_ml_mcp/resources/ml.py
@@ -482,15 +482,19 @@ def register(ctx: PluginContext) -> None:
         """Detail payload for one execution.
 
         Absorbs the old ``execution/{rid}/inputs``, ``/outputs``,
-        ``/metadata`` and ``experiment/{rid}`` URIs. The payload bundles
-        the execution summary plus ``inputs`` and ``outputs``. An
-        ``experiment`` key is added when the execution is a Hydra-driven
-        experiment (carries name + config_choices + model_config; the
-        full hydra_config dict is NOT surfaced -- it can be 10-100 KB,
-        and callers wanting it should fetch the metadata asset directly).
-        The ``metadata`` key is omitted entirely until deriva-ml provides
-        a generic enumerator for ``Execution_Metadata`` files (TODO in
-        ``_get_execution_detail_impl``).
+        ``/metadata`` and ``experiment/{rid}`` URIs into a single
+        bundle: the execution summary plus ``inputs`` and ``outputs``.
+
+        Outputs are split into ``outputs.assets`` (real
+        ``Execution_Asset`` files like model weights and prediction
+        CSVs) and ``outputs.metadata`` (``Execution_Metadata`` files
+        like ``configuration.json``, ``hydra-*.yaml``, ``uv.lock``, and
+        the environment snapshot). Both lists are always present even
+        when empty. An ``experiment`` key is added when the execution
+        is a Hydra-driven experiment (carries name + config_choices +
+        model_config; the full hydra_config dict is NOT surfaced -- it
+        can be 10-100 KB, and callers wanting it should fetch the
+        metadata asset directly).
         """
         try:
             with deriva_call():

--- a/src/deriva_ml_mcp/tools/execution/read.py
+++ b/src/deriva_ml_mcp/tools/execution/read.py
@@ -226,8 +226,24 @@ def _get_execution_detail_impl(ml: Any, execution_rid: str) -> ExecutionDetail:
     except Exception:  # noqa: BLE001 -- record may not be bound on all paths
         input_datasets = []
 
+    # ``record.list_assets(asset_role=...)`` already walks every
+    # ``*_Execution`` association table -- including
+    # ``Execution_Asset_Execution`` AND ``Execution_Metadata_Execution``
+    # -- so a single call returns both kinds of outputs mixed together.
+    # We categorize them by the asset row's ``asset_table`` attribute:
+    # ``"Execution_Metadata"`` rows go into ``outputs.metadata`` (Hydra
+    # configs, env snapshots, uv.lock, etc.); everything else goes into
+    # ``outputs.assets`` (the run's real products: model weights,
+    # prediction CSVs, training logs, plots).
+    #
+    # Inputs do not need this split today -- the caller-facing
+    # ``inputs.assets`` represents user-supplied input files and these
+    # are conventionally not ``Execution_Metadata`` rows. If that
+    # assumption ever breaks, mirror the categorization on the input
+    # branch.
     input_assets: list[ExecutionAssetRef] = []
     output_assets: list[ExecutionAssetRef] = []
+    output_metadata: list[ExecutionAssetRef] = []
     try:
         for asset in record.list_assets(asset_role="Input"):
             input_assets.append(
@@ -237,23 +253,16 @@ def _get_execution_detail_impl(ml: Any, execution_rid: str) -> ExecutionDetail:
                 )
             )
         for asset in record.list_assets(asset_role="Output"):
-            output_assets.append(
-                ExecutionAssetRef(
-                    rid=getattr(asset, "asset_rid", None),
-                    filename=getattr(asset, "filename", None),
-                )
+            ref = ExecutionAssetRef(
+                rid=getattr(asset, "asset_rid", None),
+                filename=getattr(asset, "filename", None),
             )
+            if getattr(asset, "asset_table", None) == "Execution_Metadata":
+                output_metadata.append(ref)
+            else:
+                output_assets.append(ref)
     except Exception:  # noqa: BLE001 -- assets are optional
         pass
-
-    # TODO(deriva-ml-execution-metadata-api): no generic API on
-    # ExecutionRecord to enumerate Execution_Metadata files by role
-    # (Deriva_Config / Execution_Config / Hydra_Config / Runtime_Env --
-    # they're stored as Asset rows joined through Execution_Metadata,
-    # not under list_assets's asset_role filter which only handles
-    # Input/Output). Until an upstream enumerator exists, no metadata
-    # field on ExecutionDetail -- the Experiment-bound hydra_config
-    # below covers the most common reader use case.
 
     # Experiment: try lookup_experiment(execution_rid). The deriva-ml
     # API raises if the execution has no Experiment row; treat that as
@@ -280,7 +289,7 @@ def _get_execution_detail_impl(ml: Any, execution_rid: str) -> ExecutionDetail:
     return ExecutionDetail(
         **summary.model_dump(),
         inputs=ExecutionInputs(datasets=input_datasets, assets=input_assets),
-        outputs=ExecutionOutputs(assets=output_assets),
+        outputs=ExecutionOutputs(assets=output_assets, metadata=output_metadata),
         experiment=experiment,
     )
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -447,13 +447,18 @@ async def test_ml_execution_detail_includes_inputs_outputs(resource_ctx, capturi
     input_ds.current_version = "1.0.0"
     record.list_input_datasets.return_value = [input_ds]
 
-    # Stub one input asset and one output asset.
+    # Stub one input asset and one output asset. The ``asset_table``
+    # attribute distinguishes regular ``Execution_Asset`` outputs from
+    # ``Execution_Metadata`` outputs (Hydra configs, env snapshots, etc.);
+    # categorization in ``_get_execution_detail_impl`` keys off it.
     input_asset = MagicMock()
     input_asset.asset_rid = "1-IN"
     input_asset.filename = "in.txt"
+    input_asset.asset_table = "Execution_Asset"
     output_asset = MagicMock()
     output_asset.asset_rid = "1-OUT"
     output_asset.filename = "out.txt"
+    output_asset.asset_table = "Execution_Asset"
 
     def _list_assets(asset_role: str | None = None):
         if asset_role == "Input":
@@ -478,17 +483,89 @@ async def test_ml_execution_detail_includes_inputs_outputs(resource_ctx, capturi
         "datasets": [{"rid": "1-DS", "version": "1.0.0"}],
         "assets": [{"rid": "1-IN", "filename": "in.txt"}],
     }
+    # Outputs split into two buckets: ``assets`` (real Execution_Asset
+    # outputs -- model weights, predictions, etc.) and ``metadata``
+    # (Execution_Metadata outputs -- Hydra configs, env snapshots,
+    # uv.lock, etc.). Both buckets are always present even when empty.
     assert out["outputs"] == {
         "assets": [{"rid": "1-OUT", "filename": "out.txt"}],
+        "metadata": [],
     }
-    # No metadata bucket (omit-when-no-upstream-API; see TODO in
-    # _get_execution_detail_impl).
-    assert "metadata" not in out
     # v2.0 wire change: experiment is always present, set to None when
     # the execution is not a Hydra-driven Experiment. v1.x omitted the
     # key entirely; the typed contract from PR 2 (#6) now surfaces it
     # explicitly so consumers can introspect without a KeyError.
     assert out["experiment"] is None
+
+
+async def test_ml_execution_detail_categorizes_metadata_outputs(
+    resource_ctx, capturing_mcp, mock_ml
+):
+    """Output assets split by ``asset_table`` into ``assets`` vs ``metadata``.
+
+    ``record.list_assets(asset_role="Output")`` returns BOTH ``Execution_Asset``
+    rows (model weights, prediction CSVs, training logs) and
+    ``Execution_Metadata`` rows (configuration.json, hydra-*.yaml, uv.lock,
+    environment snapshots) mixed together. The detail payload categorizes
+    them by their ``asset_table`` attribute so a consumer can answer "what
+    real outputs did this run produce?" without filtering metadata
+    out themselves.
+    """
+    record = _make_execution_record_mock(rid="1-EXEC", workflow_rid="1-WF")
+    record.list_input_datasets.return_value = []
+
+    # Three real outputs (Execution_Asset) and three metadata files
+    # (Execution_Metadata), shaped like a typical CIFAR-10 training run.
+    weights = MagicMock()
+    weights.asset_rid = "1-WEIGHT"
+    weights.filename = "cifar10_cnn_weights.pt"
+    weights.asset_table = "Execution_Asset"
+    log = MagicMock()
+    log.asset_rid = "1-LOG"
+    log.filename = "training_log.txt"
+    log.asset_table = "Execution_Asset"
+    preds = MagicMock()
+    preds.asset_rid = "1-CSV"
+    preds.filename = "prediction_probabilities.csv"
+    preds.asset_table = "Execution_Asset"
+
+    config = MagicMock()
+    config.asset_rid = "1-CFG"
+    config.filename = "configuration.json"
+    config.asset_table = "Execution_Metadata"
+    hydra = MagicMock()
+    hydra.asset_rid = "1-HYDRA"
+    hydra.filename = "hydra-1-config.yaml"
+    hydra.asset_table = "Execution_Metadata"
+    lockfile = MagicMock()
+    lockfile.asset_rid = "1-LOCK"
+    lockfile.filename = "uv.lock"
+    lockfile.asset_table = "Execution_Metadata"
+
+    def _list_assets(asset_role: str | None = None):
+        if asset_role == "Output":
+            return [weights, log, preds, config, hydra, lockfile]
+        return []
+
+    record.list_assets.side_effect = _list_assets
+    mock_ml.lookup_execution.return_value = record
+    mock_ml.lookup_experiment.side_effect = RuntimeError("Execution has no Experiment")
+
+    out = json.loads(
+        await capturing_mcp.resources[_EXECUTION_DETAIL_URI](
+            hostname="h", catalog_id="1", execution_rid="1-EXEC"
+        )
+    )
+    assert out["outputs"]["assets"] == [
+        {"rid": "1-WEIGHT", "filename": "cifar10_cnn_weights.pt"},
+        {"rid": "1-LOG", "filename": "training_log.txt"},
+        {"rid": "1-CSV", "filename": "prediction_probabilities.csv"},
+    ]
+    assert out["outputs"]["metadata"] == [
+        {"rid": "1-CFG", "filename": "configuration.json"},
+        {"rid": "1-HYDRA", "filename": "hydra-1-config.yaml"},
+        {"rid": "1-LOCK", "filename": "uv.lock"},
+    ]
 
 
 async def test_ml_execution_detail_includes_experiment_when_present(


### PR DESCRIPTION
## Summary

The \`deriva://catalog/{h}/{c}/ml/execution/{rid}\` resource was lumping \`Execution_Asset\` and \`Execution_Metadata\` outputs into a single \`outputs.assets\` list — so a consumer asking *\"what did this run produce?\"* got the real outputs (model weights, prediction CSVs, training logs) mixed with provenance files (\`configuration.json\`, \`hydra-*.yaml\`, \`uv.lock\`, environment snapshot) and had to filter them apart manually.

This PR splits outputs into two buckets:

- **\`outputs.assets\`** — real \`Execution_Asset\` outputs (model weights, predictions, plots, logs).
- **\`outputs.metadata\`** — \`Execution_Metadata\` outputs (configuration.json, hydra-*.yaml, uv.lock, env snapshots).

Both lists are always present, even when empty, so consumers can rely on the shape.

## Root cause

The TODO comment on \`_get_execution_detail_impl\` was wrong about the upstream API. It said *\"no generic enumerator on \`ExecutionRecord\` for \`Execution_Metadata\` files.\"* In fact, \`record.list_assets(asset_role=\"Output\")\` already walks **every** \`*_Execution\` association table — including \`Execution_Metadata_Execution\` — and the returned \`Asset\` objects carry an \`asset_table\` attribute distinguishing them.

No upstream change needed; the data was always there, just unclassified at the resource boundary.

## Live evidence

Against execution \`8KG\` on a localhost catalog 1407, the resource now returns:

\`\`\`json
\"outputs\": {
  \"assets\": [
    {\"rid\": \"8N4\", \"filename\": \"cifar10_cnn_weights.pt\"},
    {\"rid\": \"8N6\", \"filename\": \"training_log.txt\"},
    {\"rid\": \"8N8\", \"filename\": \"prediction_probabilities.csv\"}
  ],
  \"metadata\": [
    {\"rid\": \"8KM\", \"filename\": \"configuration.json\"},
    {\"rid\": \"8KP\", \"filename\": \"uv.lock\"},
    {\"rid\": \"8KR\", \"filename\": \"hydra-2026-05-08_15-49-07-config.yaml\"},
    {\"rid\": \"8KT\", \"filename\": \"hydra-2026-05-08_15-49-07-hydra.yaml\"},
    {\"rid\": \"8KW\", \"filename\": \"hydra-2026-05-08_15-49-07-overrides.yaml\"},
    {\"rid\": \"8KY\", \"filename\": \"environment_snapshot_20260508_154909.txt\"}
  ]
}
\`\`\`

Before the patch, those 9 entries were undifferentiated in \`outputs.assets\`. The same question previously took 7 round-trips of generic CRUD (\`get_table\` → \`list_foreign_keys\` → \`get_entities\` on association tables → \`query_attribute\` to resolve filenames).

## Verification

RED-GREEN tested:

- **RED**: existing \`test_ml_execution_detail_includes_inputs_outputs\` failed against the new shape (asserted no \`metadata\` key); new \`test_ml_execution_detail_categorizes_metadata_outputs\` failed showing all 6 mock entries lumped into \`outputs.assets\`.
- **GREEN**: both pass after the patch.
- **Full suite**: 319 passed, 22 deselected (integration), 0 failures.
- **Live**: direct call to \`_get_execution_detail_impl(ml, '8KG')\` against catalog 1407 returns the categorized shape shown above.

## Files changed

- \`src/deriva_ml_mcp/_response_models.py\` — add \`metadata: list[ExecutionAssetRef]\` to \`ExecutionOutputs\`; update docstrings.
- \`src/deriva_ml_mcp/tools/execution/read.py\` — categorize on \`asset.asset_table\`; remove the misleading TODO.
- \`src/deriva_ml_mcp/resources/ml.py\` — update resource docstring; strike \"metadata key omitted entirely\" note.
- \`tests/test_resources.py\` — update the existing detail test for the new shape; add the categorization test.

## Test plan

- [ ] \`uv run python -m pytest tests/test_resources.py -k execution_detail\` passes.
- [ ] \`uv run python -m pytest\` passes the full suite (319 tests).
- [ ] Spot-check the live resource against a real execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)