### PR TITLE
docs(prompts): drop reference to non-existent list_asset_tables verb

### DIFF
--- a/src/deriva_ml_mcp/prompts.py
+++ b/src/deriva_ml_mcp/prompts.py
@@ -526,11 +526,12 @@ for the wire name.
                   create / start / commit / update / abort /
                   create_execution_dataset / add_nested_execution.
 
-    asset      -- 4 tools. File-backed catalog rows (images, model
+    asset      -- 3 tools. File-backed catalog rows (images, model
                   weights, etc.) -- catalog-state operations only.
                   File I/O lives in deriva-skills's work-with-assets
-                  skill. Verbs: list_asset_tables / list_assets /
-                  lookup / update.
+                  skill. Verbs: list_assets / lookup / update.
+                  For "what asset tables exist in a schema?" use the
+                  ml/assets/{schema} resource (no dedicated tool).
 
 READ-SIDE QUESTIONS: FETCH THE RESOURCE FIRST
 ---------------------------------------------


### PR DESCRIPTION
## Summary

The \`deriva_ml_concepts\` prompt's \"asset\" domain summary claims **\"4 tools\"** with verbs \"list_asset_tables / list_assets / lookup / update\". The asset module (\`src/deriva_ml_mcp/tools/asset.py\`) in fact registers only **3 tools**: \`list_assets\`, \`lookup_asset\`, \`update_asset\`. The \`list_asset_tables\` verb refers to a tool that has never existed on this surface.

The closest real surface is the \`ml/assets/{schema}\` resource, which returns asset tables in one schema. There is no all-schemas asset-table tool; callers walk schemas via \`list_schemas\` (deriva-mcp-core) and read the resource per schema.

## Fix

Update the asset-domain summary to:

- \"3 tools\" (correct count)
- Drop \"list_asset_tables\" from the verb list
- Add a one-line pointer to \`ml/assets/{schema}\` for the \"what asset tables exist in a schema?\" use case

## Companion fix

The same bogus-tool reference appeared in six places across four files of \`deriva-ml-skills\`. The skill-side fix is filed as [deriva-ml-skills#13](https://github.com/informatics-isi-edu/deriva-ml-skills/pull/13). Both PRs were drafted from the same audit (enumerate every \`deriva_ml_*\` name referenced in skills/prompts and compare against the actual \`@ctx.tool\` decorators in this repo's source).

## Test plan

- [ ] Existing \`test_prompts.py\` and \`test_plugin.py\` tests still pass (no test pins the prompt content).
- [ ] Read the rewritten asset-domain summary. Does the \"3 tools\" count match the registered tool list, and does the \`ml/assets/{schema}\` pointer make sense as the right alternative for the \"what asset tables exist?\" question?

🤖 Generated with [Claude Code](https://claude.com/claude-code)