### PR TITLE
feat(dataset): rename deriva_ml_increment_dataset_version to deriva_ml_release (ADR-0003)

### DIFF
--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -1068,13 +1068,20 @@ class AddNestedExecutionResponse(BaseModel):
 
 
 class _DatasetVersionBumpMixin(BaseModel):
-    """Common fields for tools that bump a dataset's version.
+    """Common fields for tools that change a dataset's version.
 
     Three tools share this shape: ``add_dataset_members``,
-    ``delete_dataset_members``, and ``increment_dataset_version``.
-    They all return the dataset RID and the post-bump version
-    string. Subclasses add the ``status`` discriminator and any
-    tool-specific delta fields (e.g. ``added_count``).
+    ``delete_dataset_members``, and ``release``. They all return the
+    dataset RID and the post-call version string. Subclasses add the
+    ``status`` discriminator and any tool-specific delta fields
+    (e.g. ``added_count``).
+
+    Per ADR-0003 (deriva-ml 1.34+), ``add_dataset_members`` and
+    ``delete_dataset_members`` flip the dataset to a *dev* version
+    (a label of the form ``<last_release>.post1.devN``); the
+    returned ``new_version`` may therefore be a dev label, not a
+    released label. ``release`` is the only operation that produces
+    a released version.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -1085,6 +1092,11 @@ class _DatasetVersionBumpMixin(BaseModel):
 
 class AddDatasetMembersResponse(_DatasetVersionBumpMixin):
     """Response from ``deriva_ml_add_dataset_members``.
+
+    Per ADR-0003 (deriva-ml 1.34+), the returned ``new_version`` is
+    a dev label (``<last_release>.post1.devN``) — adding members
+    flips the dataset to dev, not to a released version. Call
+    ``deriva_ml_release`` afterward to mint a released version.
 
     v3.0: ``status`` was renamed from ``"success"`` to ``"added"`` to
     match the v3.0 status vocabulary (operation-specific verbs).
@@ -1097,6 +1109,11 @@ class AddDatasetMembersResponse(_DatasetVersionBumpMixin):
 class DeleteDatasetMembersResponse(_DatasetVersionBumpMixin):
     """Response from ``deriva_ml_delete_dataset_members``.
 
+    Per ADR-0003 (deriva-ml 1.34+), the returned ``new_version`` is
+    a dev label (``<last_release>.post1.devN``) — deleting members
+    flips the dataset to dev, not to a released version. Call
+    ``deriva_ml_release`` afterward to mint a released version.
+
     v3.0: ``status`` was renamed from ``"success"`` to ``"removed"``.
     """
 
@@ -1104,15 +1121,20 @@ class DeleteDatasetMembersResponse(_DatasetVersionBumpMixin):
     removed_count: int
 
 
-class IncrementDatasetVersionResponse(_DatasetVersionBumpMixin):
-    """Response from ``deriva_ml_increment_dataset_version``.
+class ReleaseDatasetResponse(_DatasetVersionBumpMixin):
+    """Response from ``deriva_ml_release``.
 
-    v3.0: ``status`` was renamed from ``"success"`` to ``"incremented"``.
+    Per ADR-0003 (deriva-ml 1.34+), ``release`` promotes a dev
+    period to a released version. The returned ``new_version`` is
+    a released label (e.g. ``"0.5.0"``); ``previous_version`` is
+    the dev label (e.g. ``"0.4.0.post1.dev3"``) that was promoted.
+    The ``bump`` field records which release segment was advanced
+    (``major`` / ``minor`` / ``patch``).
     """
 
-    status: Literal["incremented"]
+    status: Literal["released"]
     previous_version: str
-    component: str
+    bump: str
 
 
 class CreateDatasetResponse(DatasetSummary):

--- a/src/deriva_ml_mcp/prompts.py
+++ b/src/deriva_ml_mcp/prompts.py
@@ -125,11 +125,15 @@ stored as one or more Deriva tables underneath, but TREAT THEM AS
 DERIVA-ML DOMAIN OBJECTS, NOT AS RAW TABLES.
 
   Dataset    A versioned collection of catalog rows that an execution
-             consumed or produced. Datasets have a type
+             consumed or produced. Datasets carry a type
              (``Dataset_Type`` vocabulary), an element-type spec, a
-             version history, and can be downloaded as bags. Use
-             ``deriva_ml_create_dataset``, ``deriva_ml_add_dataset_members``,
-             ``deriva_ml_increment_dataset_version``,
+             version history, and can be downloaded as bags. Versions
+             are two-state per ADR-0003: every member-mutation flips
+             the dataset to a *dev* version
+             (``<last_release>.post1.devN``); ``deriva_ml_release`` is
+             the only operation that produces a released version.
+             Use ``deriva_ml_create_dataset``,
+             ``deriva_ml_add_dataset_members``, ``deriva_ml_release``,
              ``deriva_ml_cache_dataset``.
 
   Workflow   A versioned reference to the code (URL + git commit hash)
@@ -231,9 +235,11 @@ or Asset rows -- bypasses real machinery:
     producing Execution; raw inserts can create dangling references).
   - Provenance tracking (each mutation links back to the active
     Execution; raw inserts have no Execution context).
-  - Version management (``deriva_ml_increment_dataset_version`` creates
-    a new snapshot; raw inserts skip the version bump and leave consumers
-    pointed at stale data).
+  - Version management (``deriva_ml_add_dataset_members`` and
+    siblings flip the dataset to a dev version;
+    ``deriva_ml_release`` promotes that dev period to a released
+    snapshot. Raw inserts skip the version flip entirely and leave
+    consumers pointed at stale data).
   - RAG re-indexing (the ``deriva_ml_*`` tools fire surgical re-index
     hooks so freshly mutated rows are searchable on the next
     ``rag_search``; raw inserts do not).

--- a/src/deriva_ml_mcp/tools/dataset/mutate.py
+++ b/src/deriva_ml_mcp/tools/dataset/mutate.py
@@ -4,7 +4,7 @@ This submodule houses the 7 simple-mutation dataset tools:
 ``deriva_ml_create_dataset``, ``deriva_ml_delete_dataset``,
 ``deriva_ml_add_dataset_members``, ``deriva_ml_delete_dataset_members``,
 ``deriva_ml_update_dataset``, ``deriva_ml_add_dataset_element_type``,
-and ``deriva_ml_increment_dataset_version``.
+and ``deriva_ml_release``.
 
 These are the "one operation, one catalog mutation" tools -- each is
 short, body fits in a screen, no multi-step orchestration. The three
@@ -56,7 +56,7 @@ from deriva_ml_mcp._response_models import (
     CreateDatasetResponse,
     DeleteDatasetMembersResponse,
     DeleteDatasetResponse,
-    IncrementDatasetVersionResponse,
+    ReleaseDatasetResponse,
     UpdateDatasetResponse,
 )
 from deriva_ml_mcp.tools.dataset.read import _summarize_dataset
@@ -258,21 +258,29 @@ def register(ctx: PluginContext) -> None:
         -- faster, no resolution needed). Exactly one of the two must be
         non-empty.
 
-        Adding members automatically increments the dataset's minor
-        version. Member tables must already be registered as dataset
-        element types (see ``deriva_ml_add_dataset_element_type``).
+        Per ADR-0003 (deriva-ml 1.34+), adding members flips the
+        dataset to a *dev* version (``<last_release>.post1.devN``),
+        not a released version. To mint a stable, citable released
+        label, call ``deriva_ml_release`` after the mutation. The
+        returned ``new_version`` will be a dev label.
+
+        Member tables must already be registered as dataset element
+        types (see ``deriva_ml_add_dataset_element_type``).
 
         Args:
             dataset_rid: The RID of the dataset to add members to.
             member_rids: Mixed-table list of RIDs to add.
             members_by_table: Map of table name to list of RIDs.
-            description: Free-text description recorded with the version
-                bump.
+            description: Free-text description recorded with the dev
+                row's ``Description`` column. **Replaces** any prior
+                dev-period description rather than appending.
             execution_rid: Optional execution to attribute the change to.
 
         Returns:
             JSON string ``{"status": "added", "added_count",
-            "dataset_rid", "new_version"}``.
+            "dataset_rid", "new_version"}``. ``new_version`` is a
+            dev label; call ``deriva_ml_release`` to promote to a
+            released label.
 
         Raises:
             ValueError: If neither or both of ``member_rids``/
@@ -284,7 +292,7 @@ def register(ctx: PluginContext) -> None:
 
         Example:
             ``{"status": "added", "added_count": 3, "dataset_rid":
-            "1-AAAA", "new_version": "1.2.0"}``.
+            "1-AAAA", "new_version": "0.4.0.post1.dev1"}``.
         """
         has_list = bool(member_rids)
         has_dict = bool(members_by_table)
@@ -364,19 +372,27 @@ def register(ctx: PluginContext) -> None:
         """Remove records from a dataset.
 
         The records themselves are NOT deleted -- only the association
-        rows linking them to the dataset are removed. Removing members
-        increments the dataset's minor version.
+        rows linking them to the dataset are removed.
+
+        Per ADR-0003 (deriva-ml 1.34+), removing members flips the
+        dataset to a *dev* version (``<last_release>.post1.devN``),
+        not a released version. To mint a stable, citable released
+        label, call ``deriva_ml_release`` after the mutation. The
+        returned ``new_version`` will be a dev label.
 
         Args:
             dataset_rid: The RID of the dataset to remove members from.
             member_rids: List of member RIDs to remove.
-            description: Free-text description recorded with the version
-                bump.
+            description: Free-text description recorded with the dev
+                row's ``Description`` column. **Replaces** any prior
+                dev-period description rather than appending.
             execution_rid: Optional execution to attribute the change to.
 
         Returns:
             JSON string ``{"status": "removed", "removed_count",
-            "dataset_rid", "new_version"}``.
+            "dataset_rid", "new_version"}``. ``new_version`` is a
+            dev label; call ``deriva_ml_release`` to promote to a
+            released label.
 
         Raises:
             RuntimeError: Wrapped, propagated from
@@ -385,7 +401,7 @@ def register(ctx: PluginContext) -> None:
 
         Example:
             ``{"status": "removed", "removed_count": 2, "dataset_rid":
-            "1-AAAA", "new_version": "1.3.0"}``.
+            "1-AAAA", "new_version": "0.4.0.post1.dev2"}``.
         """
         removed_count = len(member_rids)
         try:
@@ -675,42 +691,64 @@ def register(ctx: PluginContext) -> None:
             )
 
     @ctx.tool(mutates=True)
-    async def deriva_ml_increment_dataset_version(
+    async def deriva_ml_release(
         hostname: str,
         catalog_id: str,
         dataset_rid: str,
-        component: Literal["major", "minor", "patch"] = "minor",
+        bump: Literal["major", "minor", "patch"] = "minor",
         description: str = "",
         execution_rid: str | None = None,
     ) -> str:
-        """Bump a dataset's semver version after upstream changes.
+        """Promote a dataset's dev period to a released version.
 
-        Use this to record a new version after metadata/data updates that
-        the regular member/type APIs don't already version (e.g. after an
-        out-of-band catalog edit). Bumping a higher-order component resets
-        lower-order components to zero.
+        Per ADR-0003 (deriva-ml 1.34+), ``release`` is the only operation
+        that produces a released ``Dataset_Version`` row. Member-mutation
+        operations (``deriva_ml_add_dataset_members``,
+        ``deriva_ml_delete_dataset_members``) flip the dataset to a dev
+        version (``<last_release>.post1.devN``); call this tool afterward
+        to mint a stable, citable released version.
+
+        Promotes the existing dev row in place: rewrites ``Version`` to
+        the released label, stamps ``Snapshot`` with the catalog snapshot
+        at release time, replaces ``Description`` with release notes, and
+        sets the row's ``Execution`` link to the supplied execution RID
+        (or ``NULL`` if none). Bumping a higher-order release segment
+        resets lower-order segments to zero.
 
         Args:
-            dataset_rid: The RID of the dataset to bump.
-            component: Which semver component to increment.
-            description: Free-text description recorded with the bump.
-            execution_rid: Optional execution to attribute the bump to.
+            dataset_rid: The RID of the dataset to release.
+            bump: Which release segment to advance from the last released
+                version (``"minor"`` is the common case;
+                ``"major"`` for schema-breaking changes;
+                ``"patch"`` for small clean-ups).
+            description: Release notes. **Replaces** the dev row's
+                accumulated description, not appended.
+            execution_rid: Optional execution RID to attribute the
+                release to. Stored on the released row's ``Execution``
+                link.
 
         Returns:
-            JSON string ``{"status": "incremented", "dataset_rid",
-            "previous_version", "new_version", "component"}``.
+            JSON string ``{"status": "released", "dataset_rid",
+            "previous_version", "new_version", "bump"}``.
+            ``previous_version`` is the dev label that was promoted
+            (e.g. ``"0.4.0.post1.dev3"``); ``new_version`` is the
+            released label (e.g. ``"0.5.0"``).
 
         Raises:
             RuntimeError: Wrapped, propagated from
-                ``deriva_ml.dataset.dataset.Dataset.increment_dataset_version``.
+                ``deriva_ml.dataset.dataset.Dataset.release``. Most
+                common: the dataset has no dev period to promote (call
+                ``deriva_ml_add_dataset_members`` first, or call the
+                ``deriva_ml.Dataset.mark_dev`` Python API to declare a
+                dev period for a no-op release).
 
         Example:
-            ``{"status": "incremented", "dataset_rid": "1-AAAA",
-            "previous_version": "1.2.0", "new_version": "1.3.0",
-            "component": "minor"}``.
+            ``{"status": "released", "dataset_rid": "1-AAAA",
+            "previous_version": "0.4.0.post1.dev3",
+            "new_version": "0.5.0", "bump": "minor"}``.
         """
         try:
-            version_part = VersionPart(component)
+            version_part = VersionPart(bump)
             with deriva_call():
                 # Run the synchronous deriva-ml calls in a thread pool so
                 # the event loop stays responsive. See deriva-mcp-core
@@ -720,19 +758,29 @@ def register(ctx: PluginContext) -> None:
                 previous_version = (
                     str(ds.current_version) if ds.current_version is not None else None
                 )
+
+                # The deriva-ml Dataset.release(execution=...) takes an
+                # Execution object, not a RID. Resolve to the typed
+                # object only when an execution_rid was supplied.
+                execution_obj = None
+                if execution_rid is not None:
+                    execution_obj = await asyncio.to_thread(
+                        ml.lookup_execution, execution_rid
+                    )
+
                 new_version = await asyncio.to_thread(
-                    ds.increment_dataset_version,
-                    component=version_part,
+                    ds.release,
+                    bump=version_part,
                     description=description,
-                    execution_rid=execution_rid,
+                    execution=execution_obj,
                 )
                 new_version_str = str(new_version)
             _pkg.audit_event(
-                "deriva_ml_increment_dataset_version",
+                "deriva_ml_release",
                 hostname=hostname,
                 catalog_id=catalog_id,
                 dataset_rid=dataset_rid,
-                component=component,
+                bump=bump,
                 previous_version=previous_version,
                 new_version=new_version_str,
             )
@@ -743,22 +791,22 @@ def register(ctx: PluginContext) -> None:
                 await _reindex_dataset(hostname, catalog_id, dataset_rid)
             except Exception:  # noqa: BLE001 -- best-effort cache refresh
                 logger.exception(
-                    "re-index failed for dataset %s after increment_dataset_version",
+                    "re-index failed for dataset %s after release",
                     dataset_rid,
                 )
-            return IncrementDatasetVersionResponse(
-                status="incremented",
+            return ReleaseDatasetResponse(
+                status="released",
                 dataset_rid=dataset_rid,
                 previous_version=previous_version,
                 new_version=new_version_str,
-                component=component,
+                bump=bump,
             ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
-                operation="increment_dataset_version",
+                operation="release",
                 hostname=hostname,
                 catalog_id=catalog_id,
                 dataset_rid=dataset_rid,
-                component=component,
+                bump=bump,
             )

--- a/tests/test_dataset_mutate.py
+++ b/tests/test_dataset_mutate.py
@@ -3,7 +3,7 @@
 Covers ``deriva_ml_create_dataset``, ``deriva_ml_delete_dataset``,
 ``deriva_ml_add_dataset_members``, ``deriva_ml_delete_dataset_members``,
 ``deriva_ml_update_dataset``, ``deriva_ml_add_dataset_element_type``,
-``deriva_ml_increment_dataset_version``, plus the v1.3 surgical
+``deriva_ml_release``, plus the v1.3 surgical
 RAG re-index wiring on the create / delete paths.
 
 The split mirrors the source-side ``tools/dataset/{read,mutate,complex}.py``
@@ -596,84 +596,99 @@ async def test_add_dataset_element_type_error(dataset_ctx, capturing_mcp, mock_m
 
 
 # ---------------------------------------------------------------------------
-# increment_dataset_version
+# release (replaces the old increment_dataset_version per ADR-0003)
 # ---------------------------------------------------------------------------
 
 
-async def test_increment_dataset_version_success(dataset_ctx, capturing_mcp, mock_ml):
-    ds = _make_dataset_mock("1-AAAA", current_version="1.2.0")
+async def test_release_success(dataset_ctx, capturing_mcp, mock_ml):
+    """Successful release: dev label -> released label, execution resolved to object."""
+    ds = _make_dataset_mock("1-AAAA", current_version="0.4.0.post1.dev3")
     new_ver = MagicMock()
-    new_ver.__str__ = lambda self: "1.3.0"
-    ds.increment_dataset_version.return_value = new_ver
+    new_ver.__str__ = lambda self: "0.5.0"
+    ds.release.return_value = new_ver
     mock_ml.lookup_dataset.return_value = ds
+
+    # The MCP tool resolves execution_rid -> Execution object via
+    # ml.lookup_execution before calling Dataset.release(execution=...).
+    exec_obj = MagicMock()
+    exec_obj.execution_rid = "EXEC-3"
+    mock_ml.lookup_execution.return_value = exec_obj
+
     with _patch_audit() as mock_audit:
         out = json.loads(
-            await capturing_mcp.tools["deriva_ml_increment_dataset_version"](
+            await capturing_mcp.tools["deriva_ml_release"](
                 hostname="h",
                 catalog_id="1",
                 dataset_rid="1-AAAA",
-                component="minor",
-                description="rebuilt members",
+                bump="minor",
+                description="Add training images for v0.5.0",
                 execution_rid="EXEC-3",
             )
         )
-    assert out["status"] == "incremented"
+    assert out["status"] == "released"
     assert out["dataset_rid"] == "1-AAAA"
-    assert out["previous_version"] == "1.2.0"
-    assert out["new_version"] == "1.3.0"
-    assert out["component"] == "minor"
+    assert out["previous_version"] == "0.4.0.post1.dev3"
+    assert out["new_version"] == "0.5.0"
+    assert out["bump"] == "minor"
 
-    # Check that VersionPart.minor was passed (not the raw string).
+    # Check that VersionPart.minor was passed and the typed Execution
+    # object was forwarded (not the bare RID).
     from deriva_ml.dataset.aux_classes import VersionPart
 
-    forwarded = ds.increment_dataset_version.call_args.kwargs
-    assert forwarded["component"] == VersionPart.minor
-    assert forwarded["description"] == "rebuilt members"
-    assert forwarded["execution_rid"] == "EXEC-3"
+    forwarded = ds.release.call_args.kwargs
+    assert forwarded["bump"] == VersionPart.minor
+    assert forwarded["description"] == "Add training images for v0.5.0"
+    assert forwarded["execution"] is exec_obj
 
-    success = _success_calls(mock_audit, "deriva_ml_increment_dataset_version")
+    success = _success_calls(mock_audit, "deriva_ml_release")
     assert success
-    assert success[0].kwargs["component"] == "minor"
-    assert success[0].kwargs["previous_version"] == "1.2.0"
-    assert success[0].kwargs["new_version"] == "1.3.0"
+    assert success[0].kwargs["bump"] == "minor"
+    assert success[0].kwargs["previous_version"] == "0.4.0.post1.dev3"
+    assert success[0].kwargs["new_version"] == "0.5.0"
 
 
-async def test_increment_dataset_version_major(dataset_ctx, capturing_mcp, mock_ml):
-    """component='major' is forwarded as VersionPart.major."""
-    ds = _make_dataset_mock("1-AAAA", current_version="1.2.3")
+async def test_release_major(dataset_ctx, capturing_mcp, mock_ml):
+    """bump='major' is forwarded as VersionPart.major."""
+    ds = _make_dataset_mock("1-AAAA", current_version="1.2.3.post1.dev1")
     new_ver = MagicMock()
     new_ver.__str__ = lambda self: "2.0.0"
-    ds.increment_dataset_version.return_value = new_ver
+    ds.release.return_value = new_ver
     mock_ml.lookup_dataset.return_value = ds
     with patch("deriva_ml_mcp.tools.dataset.audit_event"):
         out = json.loads(
-            await capturing_mcp.tools["deriva_ml_increment_dataset_version"](
-                hostname="h", catalog_id="1", dataset_rid="1-AAAA", component="major"
+            await capturing_mcp.tools["deriva_ml_release"](
+                hostname="h", catalog_id="1", dataset_rid="1-AAAA", bump="major"
             )
         )
     assert out["new_version"] == "2.0.0"
     from deriva_ml.dataset.aux_classes import VersionPart
 
-    assert ds.increment_dataset_version.call_args.kwargs["component"] == VersionPart.major
+    forwarded = ds.release.call_args.kwargs
+    assert forwarded["bump"] == VersionPart.major
+    # No execution_rid given -- the typed execution argument should be None.
+    assert forwarded["execution"] is None
 
 
-async def test_increment_dataset_version_error(dataset_ctx, capturing_mcp, mock_ml):
+async def test_release_error_no_dev_period(dataset_ctx, capturing_mcp, mock_ml):
+    """Releasing a dataset with no dev period surfaces the deriva-ml error."""
     ds = _make_dataset_mock("1-AAAA")
-    ds.increment_dataset_version.side_effect = RuntimeError("version conflict")
+    ds.release.side_effect = RuntimeError(
+        "Dataset 1-AAAA has no dev period to release"
+    )
     mock_ml.lookup_dataset.return_value = ds
     with _patch_audit() as mock_audit:
         out = json.loads(
-            await capturing_mcp.tools["deriva_ml_increment_dataset_version"](
+            await capturing_mcp.tools["deriva_ml_release"](
                 hostname="h",
                 catalog_id="1",
                 dataset_rid="1-AAAA",
-                component="patch",
+                bump="patch",
             )
         )
-    assert out == {"error": "version conflict"}
-    failed = _success_calls(mock_audit, "deriva_ml_increment_dataset_version_failed")
+    assert "no dev period" in out["error"]
+    failed = _success_calls(mock_audit, "deriva_ml_release_failed")
     assert failed
-    assert failed[0].kwargs["component"] == "patch"
+    assert failed[0].kwargs["bump"] == "patch"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -41,7 +41,7 @@ _DATASET_TOOLS = frozenset(
         # widened to take both `dataset_types` and `description`.
         "deriva_ml_update_dataset",
         "deriva_ml_add_dataset_element_type",
-        "deriva_ml_increment_dataset_version",
+        "deriva_ml_release",
         # Complex / local-FS tools
         "deriva_ml_cache_dataset",
         "deriva_ml_denormalize_dataset",


### PR DESCRIPTION
## Summary

Per deriva-ml's [ADR-0003](https://github.com/informatics-isi-edu/deriva-ml/blob/main/docs/adr/0003-dataset-dev-versioning-model.md) (delivered in 1.34), the public method `Dataset.increment_dataset_version` was renamed to `Dataset.release` with a changed contract:

- argument `component` renamed to `bump`
- argument `execution_rid: RID | None` changed to `execution: Execution | None`
- semantics: `release` promotes a dev period to a released version. It errors if the dataset has no dev row to promote — \"every release must come from a real working state.\"

This PR mirrors that rename and the surrounding semantic shift on the MCP surface, and updates the prompt to teach the new two-state model.

## Tool changes

| Before | After |
|---|---|
| `deriva_ml_increment_dataset_version(... component, description, execution_rid)` | `deriva_ml_release(... bump, description, execution_rid)` |
| Response status `\"incremented\"` | Response status `\"released\"` |
| Response field `component` | Response field `bump` |
| `IncrementDatasetVersionResponse` Pydantic model | `ReleaseDatasetResponse` Pydantic model |

The `execution_rid` parameter stays a string at the wire boundary (MCP can't pass Python objects). The impl resolves the RID via `ml.lookup_execution(...)` before calling `Dataset.release(execution=...)`.

## Docstring + prompt updates

- **`deriva_ml_add_dataset_members` / `deriva_ml_delete_dataset_members`** — now describe dev-flip semantics. Returned `new_version` is a dev label (`<last_release>.post1.devN`); call `deriva_ml_release` to mint a released label.
- **`_DatasetVersionBumpMixin`** docstring — flags that `new_version` may be a dev label for the mutation tools.
- **`deriva_ml_concepts` prompt** — Dataset domain summary lists `deriva_ml_release` in place of the removed tool; \"Version management\" steering-principle bullet describes the two-state (dev / released) model.

## Tests

- **New** `test_release_success` — exercises dev-label → released-label path, verifies the Execution-object resolution from the wire RID.
- **New** `test_release_major` — confirms `VersionPart.major` forwarding and the no-execution-supplied path.
- **New** `test_release_error_no_dev_period` — covers the ADR-0003 error case (\"call `mark_dev` first to declare a dev period\").
- **Existing** `test_plugin.py::test_all_registered_tools_exact` updated to expect `deriva_ml_release` in the tool registry.

Full suite: **321 passed**, 22 deselected (integration), 0 failures.

## Migration

No backwards-compat shim is provided per workspace policy. Non-Claude-Code clients that invoked `deriva_ml_increment_dataset_version` must rename to `deriva_ml_release` and rename `component` → `bump`. The deriva-ml migration guide section [\"Migrating to 1.34: dev versioning\"](https://github.com/informatics-isi-edu/deriva-ml/blob/main/docs/user-guide/migration.md#migrating-to-134-dev-versioning) covers the same rename at the Python-API level.

## Follow-ups (not in this PR)

- **`cite_url` field** on `DatasetDetail`, `ExecutionAssetRef`, `ExecutionInputDatasetRef` — the original deriva-ml#79 follow-up. Now that the deriva-ml work has landed (with `is_devrelease` for routing), the cite_url work can proceed in a separate PR.
- **deriva-ml-skills updates** — seven skills (`dataset-lifecycle`, `write-hydra-config`, `create-feature`, `debug-bag-contents`, `troubleshoot-execution`, `model-development-workflow`, `deriva-ml-context`) reference `deriva_ml_increment_dataset_version`. Skill PR follows.

## Test plan

- [ ] `uv run python -m pytest` — full suite passes (321).
- [ ] Read the `deriva_ml_release` docstring; check that the dev-flip framing for `add/delete_dataset_members` reads correctly.
- [ ] Confirm `deriva_ml_concepts` prompt's two-state framing matches ADR-0003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)