### PR TITLE
feat(resources): add cite_url to bundle responses (closes #79 follow-up)

### DIFF
--- a/src/deriva_ml_mcp/_helpers.py
+++ b/src/deriva_ml_mcp/_helpers.py
@@ -325,3 +325,116 @@ def _row_rid_for(row_per: str | None) -> Callable[[dict[str, Any]], str]:
         return ""
 
     return extract
+
+
+# ---------------------------------------------------------------------------
+# Cite URLs (RFC-style /id/{cat}/{rid}[@snaptime] resolver links)
+# ---------------------------------------------------------------------------
+
+
+def _cite_url(ml: Any, rid: str) -> str | None:
+    """Return the live (no-snaptime) cite URL for ``rid``.
+
+    Used by per-row response models for non-dataset entities (assets,
+    executions, workflows, etc.). Always returns the live form; clients
+    that need a snaptime-pinned URL for a dataset version go through
+    ``_cite_dataset_version_url`` instead.
+
+    The URL form is ``https://{host}/id/{catalog}/{rid}``.
+
+    Args:
+        ml: A connected ``deriva_ml.DerivaML`` instance.
+        rid: The entity RID to cite.
+
+    Returns:
+        The cite URL string, or ``None`` if construction fails (e.g.
+        the rid does not resolve, or ``ml.cite`` raises). The
+        ``cite_url`` field is best-effort from a presentation
+        standpoint -- a missing URL is recoverable; a missing field
+        would break the whole bundle.
+
+    Note:
+        Uses ``ml.cite(rid, current=True)`` under the hood. The
+        ``current=True`` argument selects the no-snaptime form;
+        the default ``current=False`` would append the *latest*
+        catalog snaptime, which is the wrong form for a per-row
+        navigation link in a bundle resource.
+    """
+    try:
+        return ml.cite(rid, current=True)
+    except Exception:  # noqa: BLE001 -- presentation field, never raise
+        return None
+
+
+def _cite_dataset_version_url(
+    ml: Any, dataset_rid: str, version: str | None, *, ds: Any | None = None
+) -> str | None:
+    """Return the cite URL for a specific dataset version.
+
+    Routing per ADR-0003 / 0004:
+
+    - **Released version** (PEP 440 not-devrelease, e.g. ``"0.4.0"``)
+      → snaptime-pinned URL ``.../id/{cat}/{rid}@{snaptime}``.
+      The snaptime comes from the dataset's version-history row for
+      that release.
+    - **Current dev version** (PEP 440 devrelease matching the
+      dataset's current dev row, e.g. ``"0.4.0.post1.dev3"``) →
+      no-snaptime URL ``.../id/{cat}/{rid}``. Dev rows have no
+      ``Snapshot``; per ADR-0003 they resolve to the live state.
+    - **`None` / current_version** → resolves to whichever shape
+      ``current_version`` takes (released or dev), routed as above.
+
+    Args:
+        ml: A connected ``deriva_ml.DerivaML`` instance.
+        dataset_rid: The Dataset RID.
+        version: A PEP 440 version string, or None to use the
+            dataset's ``current_version``.
+        ds: Optional pre-fetched ``Dataset`` object for ``dataset_rid``.
+            Pass it when the caller has already looked up the dataset
+            to avoid a redundant ``ml.lookup_dataset`` call.
+
+    Returns:
+        The cite URL string, or ``None`` if construction fails. A
+        degraded-to-live URL is preferred over None when the live
+        form is constructible; ``None`` is returned only when even
+        ``ml.cite(rid, current=True)`` raises.
+
+    Note:
+        Defensive: if anything in the version-history walk raises,
+        falls back to the live URL. The cite_url field is best-effort
+        from a presentation standpoint -- a missing snaptime is
+        recoverable; a missing field would break the whole bundle.
+    """
+    try:
+        if ds is None:
+            ds = ml.lookup_dataset(dataset_rid)
+        if version is None:
+            version = str(ds.current_version)
+
+        # Dev versions have no snapshot. Detect via the PEP 440 typed
+        # property. Construct a DatasetVersion to query is_devrelease.
+        from deriva_ml.dataset.aux_classes import DatasetVersion
+
+        try:
+            parsed = DatasetVersion.parse(version)
+        except Exception:  # noqa: BLE001 -- malformed version strings degrade
+            parsed = None
+
+        if parsed is not None and parsed.is_devrelease:
+            return _cite_url(ml, dataset_rid)
+
+        # Released version: look up snapshot via dataset_history().
+        for entry in ds.dataset_history():
+            if str(entry.dataset_version) == version:
+                snapshot = getattr(entry, "snapshot", None)
+                if snapshot:
+                    return f"https://{ml.host_name}/id/{ml.catalog_id}/{dataset_rid}@{snapshot}"
+                # Released version with no recorded snapshot is a catalog
+                # inconsistency (released rows must carry one); fall
+                # through to the live URL rather than synthesising one.
+                break
+
+        # Version not found in history (or had no snapshot): degrade.
+        return _cite_url(ml, dataset_rid)
+    except Exception:  # noqa: BLE001 -- presentation field, never raise
+        return _cite_url(ml, dataset_rid)

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -229,13 +229,22 @@ class DatasetVersionEntry(BaseModel):
 
 
 class DatasetDetail(DatasetSummary):
-    """Full Dataset detail: summary + chaise URL + version history.
+    """Full Dataset detail: summary + cite URL + version history.
 
     Produced by ``_get_dataset_detail_impl``. Used by the
     ``deriva://catalog/{h}/{c}/ml/dataset/{rid}`` resource.
+
+    The ``cite_url`` field replaces the previous ``chaise_url`` field
+    (renamed in v3.4 with no compat shim). The new URL is the
+    ``/id/{cat}/{rid}[@snaptime]`` resolver form -- table-agnostic,
+    routable to whatever current Chaise UI is hosted, and (for
+    released dataset versions) snaptime-pinned. For dev versions
+    (``current_version.is_devrelease``) the URL has no ``@snaptime``
+    component, per ADR-0003. Returns ``None`` if URL construction
+    failed (degraded but never blocking).
     """
 
-    chaise_url: str
+    cite_url: str | None = None
     version_history: list[DatasetVersionEntry]
 
 
@@ -378,12 +387,26 @@ class ExecutionSummary(BaseModel):
 
 
 class ExecutionInputDatasetRef(BaseModel):
-    """One input dataset on an Execution detail's ``inputs.datasets`` list."""
+    """One input dataset on an Execution detail's ``inputs.datasets`` list.
+
+    Carries the dataset RID, the version that was consumed, and a cite
+    URL pinned to that version. The cite URL routing matches ADR-0003:
+
+    - For a released ``version`` (PEP 440 not-devrelease), the URL
+      includes the ``@snaptime`` for that release.
+    - For a dev ``version`` (PEP 440 devrelease, e.g.
+      ``"0.4.0.post1.dev3"``), the URL has no ``@snaptime`` -- it
+      resolves to the live catalog state, per ADR-0003's "dev rows
+      have no snapshot" rule.
+    - When ``version`` is ``None`` (rare; consumed-without-pinned-version),
+      the URL resolves to the live state.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     rid: str
     version: str | None
+    cite_url: str | None = None
 
 
 class ExecutionAssetRef(BaseModel):
@@ -407,6 +430,10 @@ class ExecutionAssetRef(BaseModel):
       Used by the detail payload's outputs categorization (Execution_Asset
       vs Execution_Metadata) and useful to downstream consumers that
       want to know "is this an Image vs a generic Execution_Asset?".
+    - ``cite_url`` -- the ``/id/{cat}/{rid}`` resolver URL for this
+      asset. Always the live (no-snaptime) form -- assets are not
+      versioned the way datasets are, so there is no historical
+      snapshot to pin to. ``None`` when the rid is missing.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -416,6 +443,7 @@ class ExecutionAssetRef(BaseModel):
     description: str | None = None
     asset_types: list[str] = Field(default_factory=list)
     asset_table: str | None = None
+    cite_url: str | None = None
 
 
 class ExecutionInputs(BaseModel):

--- a/src/deriva_ml_mcp/tools/dataset/read.py
+++ b/src/deriva_ml_mcp/tools/dataset/read.py
@@ -38,6 +38,7 @@ from deriva_ml.dataset.aux_classes import DatasetSpec
 import deriva_ml_mcp.tools.dataset as _pkg  # noqa: E402  (intentional cycle)
 from deriva_ml_mcp._helpers import (
     _MAX_LIMIT,
+    _cite_dataset_version_url,
     _error_envelope,
     _paginate,
     _read_rid,
@@ -164,9 +165,12 @@ def _get_dataset_detail_impl(ml: Any, dataset_rid: str) -> DatasetDetail:
         )
         for h in ds.dataset_history()
     ]
+    cite = _cite_dataset_version_url(
+        ml, dataset_rid, str(ds.current_version), ds=ds
+    )
     return DatasetDetail(
         **summary.model_dump(),
-        chaise_url=ds.get_chaise_url(),
+        cite_url=cite if isinstance(cite, str) else None,
         version_history=version_history,
     )
 
@@ -352,7 +356,7 @@ def register(ctx: PluginContext) -> None:
         Example:
             ``{"rid": "1-AAAA", "description": "Training set",
             "dataset_types": ["Training"], "current_version": "1.0.0",
-            "chaise_url": "https://example.org/chaise/...",
+            "cite_url": "https://example.org/id/1/1-AAAA@350-XXXX-YYYY",
             "version_history": []}``.
         """
         try:
@@ -376,9 +380,12 @@ def register(ctx: PluginContext) -> None:
                     # shape.
                     ds = await asyncio.to_thread(ml.lookup_dataset, dataset_rid)
                     summary = _summarize_dataset(ds)
+                    cite = _cite_dataset_version_url(
+                        ml, dataset_rid, str(ds.current_version), ds=ds
+                    )
                     payload = DatasetDetail(
                         **summary.model_dump(),
-                        chaise_url=ds.get_chaise_url(),
+                        cite_url=cite if isinstance(cite, str) else None,
                         version_history=[],
                     )
             return payload.model_dump_json(by_alias=True)

--- a/src/deriva_ml_mcp/tools/execution/read.py
+++ b/src/deriva_ml_mcp/tools/execution/read.py
@@ -36,6 +36,8 @@ from deriva_ml.execution.execution import ExecutionStatus
 import deriva_ml_mcp.tools.execution as _pkg  # noqa: E402  (intentional cycle)
 from deriva_ml_mcp._helpers import (
     _MAX_LIMIT,
+    _cite_dataset_version_url,
+    _cite_url,
     _error_envelope,
     _paginate,
     _read_rid,
@@ -215,16 +217,26 @@ def _get_execution_detail_impl(ml: Any, execution_rid: str) -> ExecutionDetail:
     # Inputs: datasets + input assets.
     input_datasets: list[ExecutionInputDatasetRef] = []
     try:
-        for ds in record.list_input_datasets():
+        ds_iter = record.list_input_datasets()
+    except Exception:  # noqa: BLE001 -- record may not be bound on all paths
+        ds_iter = []
+    for ds in ds_iter:
+        try:
             current = getattr(ds, "current_version", None)
+            version_str = str(current) if current is not None else None
+            cite = _cite_dataset_version_url(ml, ds.dataset_rid, version_str)
             input_datasets.append(
                 ExecutionInputDatasetRef(
                     rid=ds.dataset_rid,
-                    version=str(current) if current is not None else None,
+                    version=version_str,
+                    # Pydantic rejects non-string cite values (e.g. when
+                    # ml.cite is mocked and returns a MagicMock); coerce
+                    # defensively rather than dropping the whole entry.
+                    cite_url=cite if isinstance(cite, str) else None,
                 )
             )
-    except Exception:  # noqa: BLE001 -- record may not be bound on all paths
-        input_datasets = []
+        except Exception:  # noqa: BLE001 -- per-row presentation field
+            continue
 
     # ``record.list_assets(asset_role=...)`` already walks every
     # ``*_Execution`` association table -- including
@@ -252,25 +264,43 @@ def _get_execution_detail_impl(ml: Any, execution_rid: str) -> ExecutionDetail:
         older-API asset (missing description / asset_types) still
         produces a well-formed ref rather than raising.
         """
+        rid = getattr(asset, "asset_rid", None)
+        cite = _cite_url(ml, rid) if rid else None
         return ExecutionAssetRef(
-            rid=getattr(asset, "asset_rid", None),
+            rid=rid,
             filename=getattr(asset, "filename", None),
             description=getattr(asset, "description", None),
             asset_types=list(getattr(asset, "asset_types", []) or []),
             asset_table=getattr(asset, "asset_table", None),
+            # Pydantic rejects non-string cite values (e.g. when
+            # ml.cite is mocked and returns a MagicMock); coerce
+            # defensively rather than dropping the whole entry.
+            cite_url=cite if isinstance(cite, str) else None,
         )
 
     try:
-        for asset in record.list_assets(asset_role="Input"):
-            input_assets.append(_ref(asset))
-        for asset in record.list_assets(asset_role="Output"):
-            ref = _ref(asset)
-            if ref.asset_table == "Execution_Metadata":
-                output_metadata.append(ref)
-            else:
-                output_assets.append(ref)
+        in_iter = list(record.list_assets(asset_role="Input"))
     except Exception:  # noqa: BLE001 -- assets are optional
-        pass
+        in_iter = []
+    try:
+        out_iter = list(record.list_assets(asset_role="Output"))
+    except Exception:  # noqa: BLE001 -- assets are optional
+        out_iter = []
+
+    for asset in in_iter:
+        try:
+            input_assets.append(_ref(asset))
+        except Exception:  # noqa: BLE001 -- per-row presentation field
+            continue
+    for asset in out_iter:
+        try:
+            ref = _ref(asset)
+        except Exception:  # noqa: BLE001 -- per-row presentation field
+            continue
+        if ref.asset_table == "Execution_Metadata":
+            output_metadata.append(ref)
+        else:
+            output_assets.append(ref)
 
     # Experiment: try lookup_experiment(execution_rid). The deriva-ml
     # API raises if the execution has no Experiment row; treat that as

--- a/tests/test_dataset_read.py
+++ b/tests/test_dataset_read.py
@@ -158,7 +158,10 @@ async def test_get_dataset_success(dataset_ctx, capturing_mcp, mock_ml):
     assert out["description"] == "desc"
     assert out["dataset_types"] == ["Training"]
     assert out["current_version"] == "1.0.0"
-    assert out["chaise_url"] == "https://example.org/chaise"
+    # cite_url is built via _cite_dataset_version_url; under the mock
+    # fixture both lookup_dataset and ml.cite return MagicMocks, which
+    # the impl coerces to None rather than failing Pydantic validation.
+    assert out["cite_url"] is None
     assert "history" not in out
     mock_ml.lookup_dataset.assert_called_once_with("1-AAAA")
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -222,6 +222,12 @@ async def test_ml_dataset_detail_includes_version_history(resource_ctx, capturin
     history_entry.execution_rid = "EXEC-1"
     ds.dataset_history.return_value = [history_entry]
     mock_ml.lookup_dataset.return_value = ds
+    # _cite_dataset_version_url interpolates ml.host_name and
+    # ml.catalog_id into the snapshot URL; set them to real strings so
+    # the f-string produces a real URL rather than embedding MagicMock
+    # reprs.
+    mock_ml.host_name = "data.example.org"
+    mock_ml.catalog_id = "1"
 
     out = json.loads(
         await capturing_mcp.resources[_DATASET_DETAIL_URI](
@@ -229,7 +235,10 @@ async def test_ml_dataset_detail_includes_version_history(resource_ctx, capturin
         )
     )
     assert out["rid"] == "1-AAAA"
-    assert out["chaise_url"] == "https://example.org/chaise"
+    # current_version "1.0.0" is a released label (not is_devrelease),
+    # found in dataset_history with snapshot "snap1" -- the cite_url
+    # routes to the snaptime-pinned form.
+    assert out["cite_url"] == "https://data.example.org/id/1/1-AAAA@snap1"
     assert out["version_history"] == [
         {
             "version": "1.0.0",
@@ -485,11 +494,15 @@ async def test_ml_execution_detail_includes_inputs_outputs(resource_ctx, capturi
     )
     assert out["rid"] == "1-EXEC"
     assert out["status"] == "Stopped"
-    # Asset rows include description, asset_types, asset_table. The
-    # mocks here only set asset_table; description/asset_types come back
-    # as their defaults (None / []).
+    # Asset rows include description, asset_types, asset_table, cite_url.
+    # The mocks here only set asset_table; description/asset_types/cite_url
+    # come back as their defaults (None / [] / None — the cite_url helper's
+    # ml.cite call returns a MagicMock under this fixture, which the
+    # impl coerces to None rather than failing Pydantic validation).
     assert out["inputs"] == {
-        "datasets": [{"rid": "1-DS", "version": "1.0.0"}],
+        "datasets": [
+            {"rid": "1-DS", "version": "1.0.0", "cite_url": None},
+        ],
         "assets": [
             {
                 "rid": "1-IN",
@@ -497,6 +510,7 @@ async def test_ml_execution_detail_includes_inputs_outputs(resource_ctx, capturi
                 "description": None,
                 "asset_types": [],
                 "asset_table": "Execution_Asset",
+                "cite_url": None,
             }
         ],
     }
@@ -512,6 +526,7 @@ async def test_ml_execution_detail_includes_inputs_outputs(resource_ctx, capturi
                 "description": None,
                 "asset_types": [],
                 "asset_table": "Execution_Asset",
+                "cite_url": None,
             }
         ],
         "metadata": [],
@@ -576,11 +591,11 @@ async def test_ml_execution_detail_categorizes_metadata_outputs(
             hostname="h", catalog_id="1", execution_rid="1-EXEC"
         )
     )
-    # Mocks here set asset_table only; description / asset_types come
-    # back as their defaults (None / []).
+    # Mocks here set asset_table only; description / asset_types / cite_url
+    # come back as their defaults (None / [] / None).
     _bare = lambda rid, fn, table: {  # noqa: E731
         "rid": rid, "filename": fn, "description": None,
-        "asset_types": [], "asset_table": table,
+        "asset_types": [], "asset_table": table, "cite_url": None,
     }
     assert out["outputs"]["assets"] == [
         _bare("1-WEIGHT", "cifar10_cnn_weights.pt", "Execution_Asset"),
@@ -650,6 +665,7 @@ async def test_ml_execution_detail_includes_asset_descriptions_and_types(
             "description": "Trained CNN model weights",
             "asset_types": ["Model_File"],
             "asset_table": "Execution_Asset",
+            "cite_url": None,
         },
     ]
     assert out["outputs"]["metadata"] == [
@@ -659,6 +675,7 @@ async def test_ml_execution_detail_includes_asset_descriptions_and_types(
             "description": "Resolved Hydra configuration for this execution",
             "asset_types": ["Hydra_Config"],
             "asset_table": "Execution_Metadata",
+            "cite_url": None,
         },
     ]
 
@@ -705,6 +722,7 @@ async def test_ml_execution_detail_handles_missing_asset_attributes(
             "description": None,
             "asset_types": [],
             "asset_table": "Execution_Asset",
+            "cite_url": None,
         },
     ]
 


### PR DESCRIPTION
## Summary

Closes the original [deriva-ml#79](https://github.com/informatics-isi-edu/deriva-ml/issues/79) follow-up on the deriva-ml-mcp side. The deriva-ml ADR-0003 / ADR-0004 work has landed in 1.34, which means PEP 440 dev versions are first-class and the cite-URL routing falls out of the \`is_devrelease\` typed property.

This PR adds \`cite_url\` to three per-row response model types so the bundle resource is sufficient for typical \"show me X with a clickable RID\" presentation without per-row follow-up fetches.

**Stacked on [#35](https://github.com/informatics-isi-edu/deriva-ml-mcp/pull/35)** — the increment_dataset_version → release rename. Merge that one first.

## Changes

### \`DatasetDetail.chaise_url\` → \`DatasetDetail.cite_url\`

Hard rename, no compat shim per workspace policy. The URL form also changes:

- **Old**: Chaise record-page URL (\`https://{host}/chaise/record/#{cat}/deriva-ml:Dataset/RID={rid}\`) — UI-coupled.
- **New**: \`/id/\`-resolver URL (\`https://{host}/id/{cat}/{rid}[@snaptime]\`) — table-agnostic, version-aware.

For released \`current_version\`, the URL is snaptime-pinned. For dev \`current_version\` (PEP 440 is_devrelease per ADR-0003), the URL has no \`@snaptime\` — pinning a dev version to a snaptime would lie about what the URL points at.

### New \`cite_url\` field on \`ExecutionInputDatasetRef\` and \`ExecutionAssetRef\`

Optional (\`str | None\`), follows the same routing rule:

- **Datasets** (input refs): version-aware. Snaptime-pinned for released versions; no-snaptime for dev versions.
- **Assets** (input + output refs): always live (no-snaptime). Assets are not versioned the way datasets are.

### New helpers in \`_helpers.py\`

- \`_cite_url(ml, rid)\` — live URL for non-dataset entities via \`ml.cite(rid, current=True)\`. Returns \`None\` on failure.
- \`_cite_dataset_version_url(ml, dataset_rid, version, *, ds=None)\` — version-aware URL for datasets. Routes via PEP 440 \`is_devrelease\`. Optional \`ds=\` argument to avoid double-lookup when the caller already has the Dataset object.

### Defensive enumeration

Per-row enumeration loops in \`_get_execution_detail_impl\` are restructured from \"one outer try wraps everything\" to \"one try per row\". A single misshapen row no longer empties the whole list — the bundle's \`outputs.assets\` stays useful even when one asset's metadata is malformed.

## Live verification (localhost:1407)

\`\`\`
ml/dataset/7KE
  cite_url: https://localhost/id/1407/7KE@350-RZA4-M31J  (released v0.4.0 → snapshot-pinned)

ml/execution/8KG
  inputs.datasets[0].cite_url: ...id/1407/7KE@350-RZA4-M31J  (consumed v0.4.0)
  outputs.assets[0..2].cite_url: https://localhost/id/1407/{rid}  (live, no snaptime)
  outputs.metadata[0..5].cite_url: https://localhost/id/1407/{rid}  (live, no snaptime)
\`\`\`

## Tests

Updated assertions in \`test_resources.py\` and \`test_dataset_read.py\` for the new \`cite_url\` field. The two existing tests that asserted \`chaise_url == \"https://example.org/chaise\"\` now assert the new \`cite_url\` field — under the test fixture's MagicMock-based mock_ml, the helper degrades to \`None\` rather than raising.

A new assertion in \`test_ml_dataset_detail_includes_version_history\` sets \`mock_ml.host_name\` and \`mock_ml.catalog_id\` to real strings to exercise the snaptime-pinned URL construction end-to-end.

Full deriva-ml-mcp suite: **321 passed**, 22 deselected (integration), 0 failures. Lint clean.

## Migration

Non-Claude-Code clients reading \`out[\"chaise_url\"]\` from \`ml/dataset/{rid}\` must rename to \`out[\"cite_url\"]\` and accept the URL-form change (Chaise record page → \`/id/\` resolver). Clients that constructed display links manually from RIDs can now use the bundle's \`cite_url\` field directly.

## Test plan

- [ ] Read the new \`_cite_dataset_version_url\` docstring; confirm the dev/released routing reads correctly.
- [ ] Spot-check the live resource against a real catalog with both released and dev versions.
- [ ] Confirm the rename of \`chaise_url\` → \`cite_url\` is the only breaking change in the wire shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)