### PR TITLE
feat(resources): add cite_url to bundle responses (closes #79 follow-up)

### DIFF
--- a/src/deriva_ml_mcp/_helpers.py
+++ b/src/deriva_ml_mcp/_helpers.py
@@ -325,3 +325,116 @@ def _row_rid_for(row_per: str | None) -> Callable[[dict[str, Any]], str]:
         return ""
 
     return extract
+
+
+# ---------------------------------------------------------------------------
+# Cite URLs (RFC-style /id/{cat}/{rid}[@snaptime] resolver links)
+# ---------------------------------------------------------------------------
+
+
+def _cite_url(ml: Any, rid: str) -> str | None:
+    """Return the live (no-snaptime) cite URL for ``rid``.
+
+    Used by per-row response models for non-dataset entities (assets,
+    executions, workflows, etc.). Always returns the live form; clients
+    that need a snaptime-pinned URL for a dataset version go through
+    ``_cite_dataset_version_url`` instead.
+
+    The URL form is ``https://{host}/id/{catalog}/{rid}``.
+
+    Args:
+        ml: A connected ``deriva_ml.DerivaML`` instance.
+        rid: The entity RID to cite.
+
+    Returns:
+        The cite URL string, or ``None`` if construction fails (e.g.
+        the rid does not resolve, or ``ml.cite`` raises). The
+        ``cite_url`` field is best-effort from a presentation
+        standpoint -- a missing URL is recoverable; a missing field
+        would break the whole bundle.
+
+    Note:
+        Uses ``ml.cite(rid, current=True)`` under the hood. The
+        ``current=True`` argument selects the no-snaptime form;
+        the default ``current=False`` would append the *latest*
+        catalog snaptime, which is the wrong form for a per-row
+        navigation link in a bundle resource.
+    """
+    try:
+        return ml.cite(rid, current=True)
+    except Exception:  # noqa: BLE001 -- presentation field, never raise
+        return None
+
+
+def _cite_dataset_version_url(
+    ml: Any, dataset_rid: str, version: str | None, *, ds: Any | None = None
+) -> str | None:
+    """Return the cite URL for a specific dataset version.
+
+    Routing per ADR-0003 / 0004:
+
+    - **Released version** (PEP 440 not-devrelease, e.g. ``"0.4.0"``)
+      → snaptime-pinned URL ``.../id/{cat}/{rid}@{snaptime}``.
+      The snaptime comes from the dataset's version-history row for
+      that release.
+    - **Current dev version** (PEP 440 devrelease matching the
+      dataset's current dev row, e.g. ``"0.4.0.post1.dev3"``) →
+      no-snaptime URL ``.../id/{cat}/{rid}``. Dev rows have no
+      ``Snapshot``; per ADR-0003 they resolve to the live state.
+    - **`None` / current_version** → resolves to whichever shape
+      ``current_version`` takes (released or dev), routed as above.
+
+    Args:
+        ml: A connected ``deriva_ml.DerivaML`` instance.
+        dataset_rid: The Dataset RID.
+        version: A PEP 440 version string, or None to use the
+            dataset's ``current_version``.
+        ds: Optional pre-fetched ``Dataset`` object for ``dataset_rid``.
+            Pass it when the caller has already looked up the dataset
+            to avoid a redundant ``ml.lookup_dataset`` call.
+
+    Returns:
+        The cite URL string, or ``None`` if construction fails. A
+        degraded-to-live URL is preferred over None when the live
+        form is constructible; ``None`` is returned only when even
+        ``ml.cite(rid, current=True)`` raises.
+
+    Note:
+        Defensive: if anything in the version-history walk raises,
+        falls back to the live URL. The cite_url field is best-effort
+        from a presentation standpoint -- a missing snaptime is
+        recoverable; a missing field would break the whole bundle.
+    """
+    try:
+        if ds is None:
+            ds = ml.lookup_dataset(dataset_rid)
+        if version is None:
+            version = str(ds.current_version)
+
+        # Dev versions have no snapshot. Detect via the PEP 440 typed
+        # property. Construct a DatasetVersion to query is_devrelease.
+        from deriva_ml.dataset.aux_classes import DatasetVersion
+
+        try:
+            parsed = DatasetVersion.parse(version)
+        except Exception:  # noqa: BLE001 -- malformed version strings degrade
+            parsed = None
+
+        if parsed is not None and parsed.is_devrelease:
+            return _cite_url(ml, dataset_rid)
+
+        # Released version: look up snapshot via dataset_history().
+        for entry in ds.dataset_history():
+            if str(entry.dataset_version) == version:
+                snapshot = getattr(entry, "snapshot", None)
+                if snapshot:
+                    return f"https://{ml.host_name}/id/{ml.catalog_id}/{dataset_rid}@{snapshot}"
+                # Released version with no recorded snapshot is a catalog
+                # inconsistency (released rows must carry one); fall
+                # through to the live URL rather than synthesising one.
+                break
+
+        # Version not found in history (or had no snapshot): degrade.
+        return _cite_url(ml, dataset_rid)
+    except Exception:  # noqa: BLE001 -- presentation field, never raise
+        return _cite_url(ml, dataset_rid)

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -229,13 +229,22 @@ class DatasetVersionEntry(BaseModel):
 
 
 class DatasetDetail(DatasetSummary):
-    """Full Dataset detail: summary + chaise URL + version history.
+    """Full Dataset detail: summary + cite URL + version history.
 
     Produced by ``_get_dataset_detail_impl``. Used by the
     ``deriva://catalog/{h}/{c}/ml/dataset/{rid}`` resource.
+
+    The ``cite_url`` field replaces the previous ``chaise_url`` field
+    (renamed in v3.4 with no compat shim). The new URL is the
+    ``/id/{cat}/{rid}[@snaptime]`` resolver form -- table-agnostic,
+    routable to whatever current Chaise UI is hosted, and (for
+    released dataset versions) snaptime-pinned. For dev versions
+    (``current_version.is_devrelease``) the URL has no ``@snaptime``
+    component, per ADR-0003. Returns ``None`` if URL construction
+    failed (degraded but never blocking).
     """
 
-    chaise_url: str
+    cite_url: str | None = None
     version_history: list[DatasetVersionEntry]
 
 
@@ -378,12 +387,26 @@ class ExecutionSummary(BaseModel):
 
 
 class ExecutionInputDatasetRef(BaseModel):
-    """One input dataset on an Execution detail's ``inputs.datasets`` list."""
+    """One input dataset on an Execution detail's ``inputs.datasets`` list.
+
+    Carries the dataset RID, the version that was consumed, and a cite
+    URL pinned to that version. The cite URL routing matches ADR-0003:
+
+    - For a released ``version`` (PEP 440 not-devrelease), the URL
+      includes the ``@snaptime`` for that release.
+    - For a dev ``version`` (PEP 440 devrelease, e.g.
+      ``"0.4.0.post1.dev3"``), the URL has no ``@snaptime`` -- it
+      resolves to the live catalog state, per ADR-0003's "dev rows
+      have no snapshot" rule.
+    - When ``version`` is ``None`` (rare; consumed-without-pinned-version),
+      the URL resolves to the live state.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     rid: str
     version: str | None
+    cite_url: str | None = None
 
 
 class ExecutionAssetRef(BaseModel):
@@ -407,6 +430,10 @@ class ExecutionAssetRef(BaseModel):
       Used by the detail payload's outputs categorization (Execution_Asset
       vs Execution_Metadata) and useful to downstream consumers that
       want to know "is this an Image vs a generic Execution_Asset?".
+    - ``cite_url`` -- the ``/id/{cat}/{rid}`` resolver URL for this
+      asset. Always the live (no-snaptime) form -- assets are not
+      versioned the way datasets are, so there is no historical
+      snapshot to pin to. ``None`` when the rid is missing.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -416,6 +443,7 @@ class ExecutionAssetRef(BaseModel):
     description: str | None = None
     asset_types: list[str] = Field(default_factory=list)
     asset_table: str | None = None
+    cite_url: str | None = None
 
 
 class ExecutionInputs(BaseModel):

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -1068,13 +1068,20 @@ class AddNestedExecutionResponse(BaseModel):
 
 
 class _DatasetVersionBumpMixin(BaseModel):
-    """Common fields for tools that bump a dataset's version.
+    """Common fields for tools that change a dataset's version.
 
     Three tools share this shape: ``add_dataset_members``,
-    ``delete_dataset_members``, and ``increment_dataset_version``.
-    They all return the dataset RID and the post-bump version
-    string. Subclasses add the ``status`` discriminator and any
-    tool-specific delta fields (e.g. ``added_count``).
+    ``delete_dataset_members``, and ``release``. They all return the
+    dataset RID and the post-call version string. Subclasses add the
+    ``status`` discriminator and any tool-specific delta fields
+    (e.g. ``added_count``).
+
+    Per ADR-0003 (deriva-ml 1.34+), ``add_dataset_members`` and
+    ``delete_dataset_members`` flip the dataset to a *dev* version
+    (a label of the form ``<last_release>.post1.devN``); the
+    returned ``new_version`` may therefore be a dev label, not a
+    released label. ``release`` is the only operation that produces
+    a released version.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -1085,6 +1092,11 @@ class _DatasetVersionBumpMixin(BaseModel):
 
 class AddDatasetMembersResponse(_DatasetVersionBumpMixin):
     """Response from ``deriva_ml_add_dataset_members``.
+
+    Per ADR-0003 (deriva-ml 1.34+), the returned ``new_version`` is
+    a dev label (``<last_release>.post1.devN``) — adding members
+    flips the dataset to dev, not to a released version. Call
+    ``deriva_ml_release`` afterward to mint a released version.
 
     v3.0: ``status`` was renamed from ``"success"`` to ``"added"`` to
     match the v3.0 status vocabulary (operation-specific verbs).
@@ -1097,6 +1109,11 @@ class AddDatasetMembersResponse(_DatasetVersionBumpMixin):
 class DeleteDatasetMembersResponse(_DatasetVersionBumpMixin):
     """Response from ``deriva_ml_delete_dataset_members``.
 
+    Per ADR-0003 (deriva-ml 1.34+), the returned ``new_version`` is
+    a dev label (``<last_release>.post1.devN``) — deleting members
+    flips the dataset to dev, not to a released version. Call
+    ``deriva_ml_release`` afterward to mint a released version.
+
     v3.0: ``status`` was renamed from ``"success"`` to ``"removed"``.
     """
 
@@ -1104,15 +1121,20 @@ class DeleteDatasetMembersResponse(_DatasetVersionBumpMixin):
     removed_count: int
 
 
-class IncrementDatasetVersionResponse(_DatasetVersionBumpMixin):
-    """Response from ``deriva_ml_increment_dataset_version``.
+class ReleaseDatasetResponse(_DatasetVersionBumpMixin):
+    """Response from ``deriva_ml_release``.
 
-    v3.0: ``status`` was renamed from ``"success"`` to ``"incremented"``.
+    Per ADR-0003 (deriva-ml 1.34+), ``release`` promotes a dev
+    period to a released version. The returned ``new_version`` is
+    a released label (e.g. ``"0.5.0"``); ``previous_version`` is
+    the dev label (e.g. ``"0.4.0.post1.dev3"``) that was promoted.
+    The ``bump`` field records which release segment was advanced
+    (``major`` / ``minor`` / ``patch``).
     """
 
-    status: Literal["incremented"]
+    status: Literal["released"]
     previous_version: str
-    component: str
+    bump: str
 
 
 class CreateDatasetResponse(DatasetSummary):

--- a/src/deriva_ml_mcp/prompts.py
+++ b/src/deriva_ml_mcp/prompts.py
@@ -125,11 +125,15 @@ stored as one or more Deriva tables underneath, but TREAT THEM AS
 DERIVA-ML DOMAIN OBJECTS, NOT AS RAW TABLES.
 
   Dataset    A versioned collection of catalog rows that an execution
-             consumed or produced. Datasets have a type
+             consumed or produced. Datasets carry a type
              (``Dataset_Type`` vocabulary), an element-type spec, a
-             version history, and can be downloaded as bags. Use
-             ``deriva_ml_create_dataset``, ``deriva_ml_add_dataset_members``,
-             ``deriva_ml_increment_dataset_version``,
+             version history, and can be downloaded as bags. Versions
+             are two-state per ADR-0003: every member-mutation flips
+             the dataset to a *dev* version
+             (``<last_release>.post1.devN``); ``deriva_ml_release`` is
+             the only operation that produces a released version.
+             Use ``deriva_ml_create_dataset``,
+             ``deriva_ml_add_dataset_members``, ``deriva_ml_release``,
              ``deriva_ml_cache_dataset``.
 
   Workflow   A versioned reference to the code (URL + git commit hash)
@@ -231,9 +235,11 @@ or Asset rows -- bypasses real machinery:
     producing Execution; raw inserts can create dangling references).
   - Provenance tracking (each mutation links back to the active
     Execution; raw inserts have no Execution context).
-  - Version management (``deriva_ml_increment_dataset_version`` creates
-    a new snapshot; raw inserts skip the version bump and leave consumers
-    pointed at stale data).
+  - Version management (``deriva_ml_add_dataset_members`` and
+    siblings flip the dataset to a dev version;
+    ``deriva_ml_release`` promotes that dev period to a released
+    snapshot. Raw inserts skip the version flip entirely and leave
+    consumers pointed at stale data).
   - RAG re-indexing (the ``deriva_ml_*`` tools fire surgical re-index
     hooks so freshly mutated rows are searchable on the next
     ``rag_search``; raw inserts do not).

--- a/src/deriva_ml_mcp/tools/dataset/mutate.py
+++ b/src/deriva_ml_mcp/tools/dataset/mutate.py
@@ -4,7 +4,7 @@ This submodule houses the 7 simple-mutation dataset tools:
 ``deriva_ml_create_dataset``, ``deriva_ml_delete_dataset``,
 ``deriva_ml_add_dataset_members``, ``deriva_ml_delete_dataset_members``,
 ``deriva_ml_update_dataset``, ``deriva_ml_add_dataset_element_type``,
-and ``deriva_ml_increment_dataset_version``.
+and ``deriva_ml_release``.
 
 These are the "one operation, one catalog mutation" tools -- each is
 short, body fits in a screen, no multi-step orchestration. The three
@@ -56,7 +56,7 @@ from deriva_ml_mcp._response_models import (
     CreateDatasetResponse,
     DeleteDatasetMembersResponse,
     DeleteDatasetResponse,
-    IncrementDatasetVersionResponse,
+    ReleaseDatasetResponse,
     UpdateDatasetResponse,
 )
 from deriva_ml_mcp.tools.dataset.read import _summarize_dataset
@@ -258,21 +258,29 @@ def register(ctx: PluginContext) -> None:
         -- faster, no resolution needed). Exactly one of the two must be
         non-empty.
 
-        Adding members automatically increments the dataset's minor
-        version. Member tables must already be registered as dataset
-        element types (see ``deriva_ml_add_dataset_element_type``).
+        Per ADR-0003 (deriva-ml 1.34+), adding members flips the
+        dataset to a *dev* version (``<last_release>.post1.devN``),
+        not a released version. To mint a stable, citable released
+        label, call ``deriva_ml_release`` after the mutation. The
+        returned ``new_version`` will be a dev label.
+
+        Member tables must already be registered as dataset element
+        types (see ``deriva_ml_add_dataset_element_type``).
 
         Args:
             dataset_rid: The RID of the dataset to add members to.
             member_rids: Mixed-table list of RIDs to add.
             members_by_table: Map of table name to list of RIDs.
-            description: Free-text description recorded with the version
-                bump.
+            description: Free-text description recorded with the dev
+                row's ``Description`` column. **Replaces** any prior
+                dev-period description rather than appending.
             execution_rid: Optional execution to attribute the change to.
 
         Returns:
             JSON string ``{"status": "added", "added_count",
-            "dataset_rid", "new_version"}``.
+            "dataset_rid", "new_version"}``. ``new_version`` is a
+            dev label; call ``deriva_ml_release`` to promote to a
+            released label.
 
         Raises:
             ValueError: If neither or both of ``member_rids``/
@@ -284,7 +292,7 @@ def register(ctx: PluginContext) -> None:
 
         Example:
             ``{"status": "added", "added_count": 3, "dataset_rid":
-            "1-AAAA", "new_version": "1.2.0"}``.
+            "1-AAAA", "new_version": "0.4.0.post1.dev1"}``.
         """
         has_list = bool(member_rids)
         has_dict = bool(members_by_table)
@@ -364,19 +372,27 @@ def register(ctx: PluginContext) -> None:
         """Remove records from a dataset.
 
         The records themselves are NOT deleted -- only the association
-        rows linking them to the dataset are removed. Removing members
-        increments the dataset's minor version.
+        rows linking them to the dataset are removed.
+
+        Per ADR-0003 (deriva-ml 1.34+), removing members flips the
+        dataset to a *dev* version (``<last_release>.post1.devN``),
+        not a released version. To mint a stable, citable released
+        label, call ``deriva_ml_release`` after the mutation. The
+        returned ``new_version`` will be a dev label.
 
         Args:
             dataset_rid: The RID of the dataset to remove members from.
             member_rids: List of member RIDs to remove.
-            description: Free-text description recorded with the version
-                bump.
+            description: Free-text description recorded with the dev
+                row's ``Description`` column. **Replaces** any prior
+                dev-period description rather than appending.
             execution_rid: Optional execution to attribute the change to.
 
         Returns:
             JSON string ``{"status": "removed", "removed_count",
-            "dataset_rid", "new_version"}``.
+            "dataset_rid", "new_version"}``. ``new_version`` is a
+            dev label; call ``deriva_ml_release`` to promote to a
+            released label.
 
         Raises:
             RuntimeError: Wrapped, propagated from
@@ -385,7 +401,7 @@ def register(ctx: PluginContext) -> None:
 
         Example:
             ``{"status": "removed", "removed_count": 2, "dataset_rid":
-            "1-AAAA", "new_version": "1.3.0"}``.
+            "1-AAAA", "new_version": "0.4.0.post1.dev2"}``.
         """
         removed_count = len(member_rids)
         try:
@@ -675,42 +691,64 @@ def register(ctx: PluginContext) -> None:
             )
 
     @ctx.tool(mutates=True)
-    async def deriva_ml_increment_dataset_version(
+    async def deriva_ml_release(
         hostname: str,
         catalog_id: str,
         dataset_rid: str,
-        component: Literal["major", "minor", "patch"] = "minor",
+        bump: Literal["major", "minor", "patch"] = "minor",
         description: str = "",
         execution_rid: str | None = None,
     ) -> str:
-        """Bump a dataset's semver version after upstream changes.
+        """Promote a dataset's dev period to a released version.
 
-        Use this to record a new version after metadata/data updates that
-        the regular member/type APIs don't already version (e.g. after an
-        out-of-band catalog edit). Bumping a higher-order component resets
-        lower-order components to zero.
+        Per ADR-0003 (deriva-ml 1.34+), ``release`` is the only operation
+        that produces a released ``Dataset_Version`` row. Member-mutation
+        operations (``deriva_ml_add_dataset_members``,
+        ``deriva_ml_delete_dataset_members``) flip the dataset to a dev
+        version (``<last_release>.post1.devN``); call this tool afterward
+        to mint a stable, citable released version.
+
+        Promotes the existing dev row in place: rewrites ``Version`` to
+        the released label, stamps ``Snapshot`` with the catalog snapshot
+        at release time, replaces ``Description`` with release notes, and
+        sets the row's ``Execution`` link to the supplied execution RID
+        (or ``NULL`` if none). Bumping a higher-order release segment
+        resets lower-order segments to zero.
 
         Args:
-            dataset_rid: The RID of the dataset to bump.
-            component: Which semver component to increment.
-            description: Free-text description recorded with the bump.
-            execution_rid: Optional execution to attribute the bump to.
+            dataset_rid: The RID of the dataset to release.
+            bump: Which release segment to advance from the last released
+                version (``"minor"`` is the common case;
+                ``"major"`` for schema-breaking changes;
+                ``"patch"`` for small clean-ups).
+            description: Release notes. **Replaces** the dev row's
+                accumulated description, not appended.
+            execution_rid: Optional execution RID to attribute the
+                release to. Stored on the released row's ``Execution``
+                link.
 
         Returns:
-            JSON string ``{"status": "incremented", "dataset_rid",
-            "previous_version", "new_version", "component"}``.
+            JSON string ``{"status": "released", "dataset_rid",
+            "previous_version", "new_version", "bump"}``.
+            ``previous_version`` is the dev label that was promoted
+            (e.g. ``"0.4.0.post1.dev3"``); ``new_version`` is the
+            released label (e.g. ``"0.5.0"``).
 
         Raises:
             RuntimeError: Wrapped, propagated from
-                ``deriva_ml.dataset.dataset.Dataset.increment_dataset_version``.
+                ``deriva_ml.dataset.dataset.Dataset.release``. Most
+                common: the dataset has no dev period to promote (call
+                ``deriva_ml_add_dataset_members`` first, or call the
+                ``deriva_ml.Dataset.mark_dev`` Python API to declare a
+                dev period for a no-op release).
 
         Example:
-            ``{"status": "incremented", "dataset_rid": "1-AAAA",
-            "previous_version": "1.2.0", "new_version": "1.3.0",
-            "component": "minor"}``.
+            ``{"status": "released", "dataset_rid": "1-AAAA",
+            "previous_version": "0.4.0.post1.dev3",
+            "new_version": "0.5.0", "bump": "minor"}``.
         """
         try:
-            version_part = VersionPart(component)
+            version_part = VersionPart(bump)
             with deriva_call():
                 # Run the synchronous deriva-ml calls in a thread pool so
                 # the event loop stays responsive. See deriva-mcp-core
@@ -720,19 +758,29 @@ def register(ctx: PluginContext) -> None:
                 previous_version = (
                     str(ds.current_version) if ds.current_version is not None else None
                 )
+
+                # The deriva-ml Dataset.release(execution=...) takes an
+                # Execution object, not a RID. Resolve to the typed
+                # object only when an execution_rid was supplied.
+                execution_obj = None
+                if execution_rid is not None:
+                    execution_obj = await asyncio.to_thread(
+                        ml.lookup_execution, execution_rid
+                    )
+
                 new_version = await asyncio.to_thread(
-                    ds.increment_dataset_version,
-                    component=version_part,
+                    ds.release,
+                    bump=version_part,
                     description=description,
-                    execution_rid=execution_rid,
+                    execution=execution_obj,
                 )
                 new_version_str = str(new_version)
             _pkg.audit_event(
-                "deriva_ml_increment_dataset_version",
+                "deriva_ml_release",
                 hostname=hostname,
                 catalog_id=catalog_id,
                 dataset_rid=dataset_rid,
-                component=component,
+                bump=bump,
                 previous_version=previous_version,
                 new_version=new_version_str,
             )
@@ -743,22 +791,22 @@ def register(ctx: PluginContext) -> None:
                 await _reindex_dataset(hostname, catalog_id, dataset_rid)
             except Exception:  # noqa: BLE001 -- best-effort cache refresh
                 logger.exception(
-                    "re-index failed for dataset %s after increment_dataset_version",
+                    "re-index failed for dataset %s after release",
                     dataset_rid,
                 )
-            return IncrementDatasetVersionResponse(
-                status="incremented",
+            return ReleaseDatasetResponse(
+                status="released",
                 dataset_rid=dataset_rid,
                 previous_version=previous_version,
                 new_version=new_version_str,
-                component=component,
+                bump=bump,
             ).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
                 exc,
-                operation="increment_dataset_version",
+                operation="release",
                 hostname=hostname,
                 catalog_id=catalog_id,
                 dataset_rid=dataset_rid,
-                component=component,
+                bump=bump,
             )

--- a/src/deriva_ml_mcp/tools/dataset/read.py
+++ b/src/deriva_ml_mcp/tools/dataset/read.py
@@ -38,6 +38,7 @@ from deriva_ml.dataset.aux_classes import DatasetSpec
 import deriva_ml_mcp.tools.dataset as _pkg  # noqa: E402  (intentional cycle)
 from deriva_ml_mcp._helpers import (
     _MAX_LIMIT,
+    _cite_dataset_version_url,
     _error_envelope,
     _paginate,
     _read_rid,
@@ -164,9 +165,12 @@ def _get_dataset_detail_impl(ml: Any, dataset_rid: str) -> DatasetDetail:
         )
         for h in ds.dataset_history()
     ]
+    cite = _cite_dataset_version_url(
+        ml, dataset_rid, str(ds.current_version), ds=ds
+    )
     return DatasetDetail(
         **summary.model_dump(),
-        chaise_url=ds.get_chaise_url(),
+        cite_url=cite if isinstance(cite, str) else None,
         version_history=version_history,
     )
 
@@ -352,7 +356,7 @@ def register(ctx: PluginContext) -> None:
         Example:
             ``{"rid": "1-AAAA", "description": "Training set",
             "dataset_types": ["Training"], "current_version": "1.0.0",
-            "chaise_url": "https://example.org/chaise/...",
+            "cite_url": "https://example.org/id/1/1-AAAA@350-XXXX-YYYY",
             "version_history": []}``.
         """
         try:
@@ -376,9 +380,12 @@ def register(ctx: PluginContext) -> None:
                     # shape.
                     ds = await asyncio.to_thread(ml.lookup_dataset, dataset_rid)
                     summary = _summarize_dataset(ds)
+                    cite = _cite_dataset_version_url(
+                        ml, dataset_rid, str(ds.current_version), ds=ds
+                    )
                     payload = DatasetDetail(
                         **summary.model_dump(),
-                        chaise_url=ds.get_chaise_url(),
+                        cite_url=cite if isinstance(cite, str) else None,
                         version_history=[],
                     )
             return payload.model_dump_json(by_alias=True)

--- a/src/deriva_ml_mcp/tools/execution/read.py
+++ b/src/deriva_ml_mcp/tools/execution/read.py
@@ -36,6 +36,8 @@ from deriva_ml.execution.execution import ExecutionStatus
 import deriva_ml_mcp.tools.execution as _pkg  # noqa: E402  (intentional cycle)
 from deriva_ml_mcp._helpers import (
     _MAX_LIMIT,
+    _cite_dataset_version_url,
+    _cite_url,
     _error_envelope,
     _paginate,
     _read_rid,
@@ -215,16 +217,26 @@ def _get_execution_detail_impl(ml: Any, execution_rid: str) -> ExecutionDetail:
     # Inputs: datasets + input assets.
     input_datasets: list[ExecutionInputDatasetRef] = []
     try:
-        for ds in record.list_input_datasets():
+        ds_iter = record.list_input_datasets()
+    except Exception:  # noqa: BLE001 -- record may not be bound on all paths
+        ds_iter = []
+    for ds in ds_iter:
+        try:
             current = getattr(ds, "current_version", None)
+            version_str = str(current) if current is not None else None
+            cite = _cite_dataset_version_url(ml, ds.dataset_rid, version_str)
             input_datasets.append(
                 ExecutionInputDatasetRef(
                     rid=ds.dataset_rid,
-                    version=str(current) if current is not None else None,
+                    version=version_str,
+                    # Pydantic rejects non-string cite values (e.g. when
+                    # ml.cite is mocked and returns a MagicMock); coerce
+                    # defensively rather than dropping the whole entry.
+                    cite_url=cite if isinstance(cite, str) else None,
                 )
             )
-    except Exception:  # noqa: BLE001 -- record may not be bound on all paths
-        input_datasets = []
+        except Exception:  # noqa: BLE001 -- per-row presentation field
+            continue
 
     # ``record.list_assets(asset_role=...)`` already walks every
     # ``*_Execution`` association table -- including
@@ -252,25 +264,43 @@ def _get_execution_detail_impl(ml: Any, execution_rid: str) -> ExecutionDetail:
         older-API asset (missing description / asset_types) still
         produces a well-formed ref rather than raising.
         """
+        rid = getattr(asset, "asset_rid", None)
+        cite = _cite_url(ml, rid) if rid else None
         return ExecutionAssetRef(
-            rid=getattr(asset, "asset_rid", None),
+            rid=rid,
             filename=getattr(asset, "filename", None),
             description=getattr(asset, "description", None),
             asset_types=list(getattr(asset, "asset_types", []) or []),
             asset_table=getattr(asset, "asset_table", None),
+            # Pydantic rejects non-string cite values (e.g. when
+            # ml.cite is mocked and returns a MagicMock); coerce
+            # defensively rather than dropping the whole entry.
+            cite_url=cite if isinstance(cite, str) else None,
         )
 
     try:
-        for asset in record.list_assets(asset_role="Input"):
-            input_assets.append(_ref(asset))
-        for asset in record.list_assets(asset_role="Output"):
-            ref = _ref(asset)
-            if ref.asset_table == "Execution_Metadata":
-                output_metadata.append(ref)
-            else:
-                output_assets.append(ref)
+        in_iter = list(record.list_assets(asset_role="Input"))
     except Exception:  # noqa: BLE001 -- assets are optional
-        pass
+        in_iter = []
+    try:
+        out_iter = list(record.list_assets(asset_role="Output"))
+    except Exception:  # noqa: BLE001 -- assets are optional
+        out_iter = []
+
+    for asset in in_iter:
+        try:
+            input_assets.append(_ref(asset))
+        except Exception:  # noqa: BLE001 -- per-row presentation field
+            continue
+    for asset in out_iter:
+        try:
+            ref = _ref(asset)
+        except Exception:  # noqa: BLE001 -- per-row presentation field
+            continue
+        if ref.asset_table == "Execution_Metadata":
+            output_metadata.append(ref)
+        else:
+            output_assets.append(ref)
 
     # Experiment: try lookup_experiment(execution_rid). The deriva-ml
     # API raises if the execution has no Experiment row; treat that as

--- a/tests/test_dataset_mutate.py
+++ b/tests/test_dataset_mutate.py
@@ -3,7 +3,7 @@
 Covers ``deriva_ml_create_dataset``, ``deriva_ml_delete_dataset``,
 ``deriva_ml_add_dataset_members``, ``deriva_ml_delete_dataset_members``,
 ``deriva_ml_update_dataset``, ``deriva_ml_add_dataset_element_type``,
-``deriva_ml_increment_dataset_version``, plus the v1.3 surgical
+``deriva_ml_release``, plus the v1.3 surgical
 RAG re-index wiring on the create / delete paths.
 
 The split mirrors the source-side ``tools/dataset/{read,mutate,complex}.py``
@@ -596,84 +596,99 @@ async def test_add_dataset_element_type_error(dataset_ctx, capturing_mcp, mock_m
 
 
 # ---------------------------------------------------------------------------
-# increment_dataset_version
+# release (replaces the old increment_dataset_version per ADR-0003)
 # ---------------------------------------------------------------------------
 
 
-async def test_increment_dataset_version_success(dataset_ctx, capturing_mcp, mock_ml):
-    ds = _make_dataset_mock("1-AAAA", current_version="1.2.0")
+async def test_release_success(dataset_ctx, capturing_mcp, mock_ml):
+    """Successful release: dev label -> released label, execution resolved to object."""
+    ds = _make_dataset_mock("1-AAAA", current_version="0.4.0.post1.dev3")
     new_ver = MagicMock()
-    new_ver.__str__ = lambda self: "1.3.0"
-    ds.increment_dataset_version.return_value = new_ver
+    new_ver.__str__ = lambda self: "0.5.0"
+    ds.release.return_value = new_ver
     mock_ml.lookup_dataset.return_value = ds
+
+    # The MCP tool resolves execution_rid -> Execution object via
+    # ml.lookup_execution before calling Dataset.release(execution=...).
+    exec_obj = MagicMock()
+    exec_obj.execution_rid = "EXEC-3"
+    mock_ml.lookup_execution.return_value = exec_obj
+
     with _patch_audit() as mock_audit:
         out = json.loads(
-            await capturing_mcp.tools["deriva_ml_increment_dataset_version"](
+            await capturing_mcp.tools["deriva_ml_release"](
                 hostname="h",
                 catalog_id="1",
                 dataset_rid="1-AAAA",
-                component="minor",
-                description="rebuilt members",
+                bump="minor",
+                description="Add training images for v0.5.0",
                 execution_rid="EXEC-3",
             )
         )
-    assert out["status"] == "incremented"
+    assert out["status"] == "released"
     assert out["dataset_rid"] == "1-AAAA"
-    assert out["previous_version"] == "1.2.0"
-    assert out["new_version"] == "1.3.0"
-    assert out["component"] == "minor"
+    assert out["previous_version"] == "0.4.0.post1.dev3"
+    assert out["new_version"] == "0.5.0"
+    assert out["bump"] == "minor"
 
-    # Check that VersionPart.minor was passed (not the raw string).
+    # Check that VersionPart.minor was passed and the typed Execution
+    # object was forwarded (not the bare RID).
     from deriva_ml.dataset.aux_classes import VersionPart
 
-    forwarded = ds.increment_dataset_version.call_args.kwargs
-    assert forwarded["component"] == VersionPart.minor
-    assert forwarded["description"] == "rebuilt members"
-    assert forwarded["execution_rid"] == "EXEC-3"
+    forwarded = ds.release.call_args.kwargs
+    assert forwarded["bump"] == VersionPart.minor
+    assert forwarded["description"] == "Add training images for v0.5.0"
+    assert forwarded["execution"] is exec_obj
 
-    success = _success_calls(mock_audit, "deriva_ml_increment_dataset_version")
+    success = _success_calls(mock_audit, "deriva_ml_release")
     assert success
-    assert success[0].kwargs["component"] == "minor"
-    assert success[0].kwargs["previous_version"] == "1.2.0"
-    assert success[0].kwargs["new_version"] == "1.3.0"
+    assert success[0].kwargs["bump"] == "minor"
+    assert success[0].kwargs["previous_version"] == "0.4.0.post1.dev3"
+    assert success[0].kwargs["new_version"] == "0.5.0"
 
 
-async def test_increment_dataset_version_major(dataset_ctx, capturing_mcp, mock_ml):
-    """component='major' is forwarded as VersionPart.major."""
-    ds = _make_dataset_mock("1-AAAA", current_version="1.2.3")
+async def test_release_major(dataset_ctx, capturing_mcp, mock_ml):
+    """bump='major' is forwarded as VersionPart.major."""
+    ds = _make_dataset_mock("1-AAAA", current_version="1.2.3.post1.dev1")
     new_ver = MagicMock()
     new_ver.__str__ = lambda self: "2.0.0"
-    ds.increment_dataset_version.return_value = new_ver
+    ds.release.return_value = new_ver
     mock_ml.lookup_dataset.return_value = ds
     with patch("deriva_ml_mcp.tools.dataset.audit_event"):
         out = json.loads(
-            await capturing_mcp.tools["deriva_ml_increment_dataset_version"](
-                hostname="h", catalog_id="1", dataset_rid="1-AAAA", component="major"
+            await capturing_mcp.tools["deriva_ml_release"](
+                hostname="h", catalog_id="1", dataset_rid="1-AAAA", bump="major"
             )
         )
     assert out["new_version"] == "2.0.0"
     from deriva_ml.dataset.aux_classes import VersionPart
 
-    assert ds.increment_dataset_version.call_args.kwargs["component"] == VersionPart.major
+    forwarded = ds.release.call_args.kwargs
+    assert forwarded["bump"] == VersionPart.major
+    # No execution_rid given -- the typed execution argument should be None.
+    assert forwarded["execution"] is None
 
 
-async def test_increment_dataset_version_error(dataset_ctx, capturing_mcp, mock_ml):
+async def test_release_error_no_dev_period(dataset_ctx, capturing_mcp, mock_ml):
+    """Releasing a dataset with no dev period surfaces the deriva-ml error."""
     ds = _make_dataset_mock("1-AAAA")
-    ds.increment_dataset_version.side_effect = RuntimeError("version conflict")
+    ds.release.side_effect = RuntimeError(
+        "Dataset 1-AAAA has no dev period to release"
+    )
     mock_ml.lookup_dataset.return_value = ds
     with _patch_audit() as mock_audit:
         out = json.loads(
-            await capturing_mcp.tools["deriva_ml_increment_dataset_version"](
+            await capturing_mcp.tools["deriva_ml_release"](
                 hostname="h",
                 catalog_id="1",
                 dataset_rid="1-AAAA",
-                component="patch",
+                bump="patch",
             )
         )
-    assert out == {"error": "version conflict"}
-    failed = _success_calls(mock_audit, "deriva_ml_increment_dataset_version_failed")
+    assert "no dev period" in out["error"]
+    failed = _success_calls(mock_audit, "deriva_ml_release_failed")
     assert failed
-    assert failed[0].kwargs["component"] == "patch"
+    assert failed[0].kwargs["bump"] == "patch"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dataset_read.py
+++ b/tests/test_dataset_read.py
@@ -158,7 +158,10 @@ async def test_get_dataset_success(dataset_ctx, capturing_mcp, mock_ml):
     assert out["description"] == "desc"
     assert out["dataset_types"] == ["Training"]
     assert out["current_version"] == "1.0.0"
-    assert out["chaise_url"] == "https://example.org/chaise"
+    # cite_url is built via _cite_dataset_version_url; under the mock
+    # fixture both lookup_dataset and ml.cite return MagicMocks, which
+    # the impl coerces to None rather than failing Pydantic validation.
+    assert out["cite_url"] is None
     assert "history" not in out
     mock_ml.lookup_dataset.assert_called_once_with("1-AAAA")
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -41,7 +41,7 @@ _DATASET_TOOLS = frozenset(
         # widened to take both `dataset_types` and `description`.
         "deriva_ml_update_dataset",
         "deriva_ml_add_dataset_element_type",
-        "deriva_ml_increment_dataset_version",
+        "deriva_ml_release",
         # Complex / local-FS tools
         "deriva_ml_cache_dataset",
         "deriva_ml_denormalize_dataset",

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -222,6 +222,12 @@ async def test_ml_dataset_detail_includes_version_history(resource_ctx, capturin
     history_entry.execution_rid = "EXEC-1"
     ds.dataset_history.return_value = [history_entry]
     mock_ml.lookup_dataset.return_value = ds
+    # _cite_dataset_version_url interpolates ml.host_name and
+    # ml.catalog_id into the snapshot URL; set them to real strings so
+    # the f-string produces a real URL rather than embedding MagicMock
+    # reprs.
+    mock_ml.host_name = "data.example.org"
+    mock_ml.catalog_id = "1"
 
     out = json.loads(
         await capturing_mcp.resources[_DATASET_DETAIL_URI](
@@ -229,7 +235,10 @@ async def test_ml_dataset_detail_includes_version_history(resource_ctx, capturin
         )
     )
     assert out["rid"] == "1-AAAA"
-    assert out["chaise_url"] == "https://example.org/chaise"
+    # current_version "1.0.0" is a released label (not is_devrelease),
+    # found in dataset_history with snapshot "snap1" -- the cite_url
+    # routes to the snaptime-pinned form.
+    assert out["cite_url"] == "https://data.example.org/id/1/1-AAAA@snap1"
     assert out["version_history"] == [
         {
             "version": "1.0.0",
@@ -485,11 +494,15 @@ async def test_ml_execution_detail_includes_inputs_outputs(resource_ctx, capturi
     )
     assert out["rid"] == "1-EXEC"
     assert out["status"] == "Stopped"
-    # Asset rows include description, asset_types, asset_table. The
-    # mocks here only set asset_table; description/asset_types come back
-    # as their defaults (None / []).
+    # Asset rows include description, asset_types, asset_table, cite_url.
+    # The mocks here only set asset_table; description/asset_types/cite_url
+    # come back as their defaults (None / [] / None — the cite_url helper's
+    # ml.cite call returns a MagicMock under this fixture, which the
+    # impl coerces to None rather than failing Pydantic validation).
     assert out["inputs"] == {
-        "datasets": [{"rid": "1-DS", "version": "1.0.0"}],
+        "datasets": [
+            {"rid": "1-DS", "version": "1.0.0", "cite_url": None},
+        ],
         "assets": [
             {
                 "rid": "1-IN",
@@ -497,6 +510,7 @@ async def test_ml_execution_detail_includes_inputs_outputs(resource_ctx, capturi
                 "description": None,
                 "asset_types": [],
                 "asset_table": "Execution_Asset",
+                "cite_url": None,
             }
         ],
     }
@@ -512,6 +526,7 @@ async def test_ml_execution_detail_includes_inputs_outputs(resource_ctx, capturi
                 "description": None,
                 "asset_types": [],
                 "asset_table": "Execution_Asset",
+                "cite_url": None,
             }
         ],
         "metadata": [],
@@ -576,11 +591,11 @@ async def test_ml_execution_detail_categorizes_metadata_outputs(
             hostname="h", catalog_id="1", execution_rid="1-EXEC"
         )
     )
-    # Mocks here set asset_table only; description / asset_types come
-    # back as their defaults (None / []).
+    # Mocks here set asset_table only; description / asset_types / cite_url
+    # come back as their defaults (None / [] / None).
     _bare = lambda rid, fn, table: {  # noqa: E731
         "rid": rid, "filename": fn, "description": None,
-        "asset_types": [], "asset_table": table,
+        "asset_types": [], "asset_table": table, "cite_url": None,
     }
     assert out["outputs"]["assets"] == [
         _bare("1-WEIGHT", "cifar10_cnn_weights.pt", "Execution_Asset"),
@@ -650,6 +665,7 @@ async def test_ml_execution_detail_includes_asset_descriptions_and_types(
             "description": "Trained CNN model weights",
             "asset_types": ["Model_File"],
             "asset_table": "Execution_Asset",
+            "cite_url": None,
         },
     ]
     assert out["outputs"]["metadata"] == [
@@ -659,6 +675,7 @@ async def test_ml_execution_detail_includes_asset_descriptions_and_types(
             "description": "Resolved Hydra configuration for this execution",
             "asset_types": ["Hydra_Config"],
             "asset_table": "Execution_Metadata",
+            "cite_url": None,
         },
     ]
 
@@ -705,6 +722,7 @@ async def test_ml_execution_detail_handles_missing_asset_attributes(
             "description": None,
             "asset_types": [],
             "asset_table": "Execution_Asset",
+            "cite_url": None,
         },
     ]
 


### PR DESCRIPTION
## Summary

Re-opening of [PR #36](https://github.com/informatics-isi-edu/deriva-ml-mcp/pull/36) which closed automatically when its parent (PR #35) was squash-merged. The branch and its diff against \`main\` are both correct (the rename PR's content is already on main; this PR adds only the cite_url work on top).

Closes the original [deriva-ml#79](https://github.com/informatics-isi-edu/deriva-ml/issues/79) follow-up on the deriva-ml-mcp side. The deriva-ml ADR-0003 / ADR-0004 work has landed in 1.34, which means PEP 440 dev versions are first-class and the cite-URL routing falls out of the \`is_devrelease\` typed property.

This PR adds \`cite_url\` to three per-row response model types so the bundle resource is sufficient for typical \"show me X with a clickable RID\" presentation without per-row follow-up fetches.

## Changes

### \`DatasetDetail.chaise_url\` → \`DatasetDetail.cite_url\`

Hard rename. The URL form also changes:

- **Old**: Chaise record-page URL (\`https://{host}/chaise/record/#{cat}/deriva-ml:Dataset/RID={rid}\`) — UI-coupled.
- **New**: \`/id/\`-resolver URL (\`https://{host}/id/{cat}/{rid}[@snaptime]\`) — table-agnostic, version-aware.

For released \`current_version\`, the URL is snaptime-pinned. For dev \`current_version\` (PEP 440 is_devrelease per ADR-0003), the URL has no \`@snaptime\` — pinning a dev version to a snaptime would lie about what the URL points at.

### New \`cite_url\` field on \`ExecutionInputDatasetRef\` and \`ExecutionAssetRef\`

Optional (\`str | None\`):

- **Datasets** (input refs): version-aware. Snaptime-pinned for released versions; no-snaptime for dev versions.
- **Assets** (input + output refs): always live (no-snaptime). Assets are not versioned the way datasets are.

### New helpers in \`_helpers.py\`

- \`_cite_url(ml, rid)\` — live URL for non-dataset entities via \`ml.cite(rid, current=True)\`. Returns \`None\` on failure.
- \`_cite_dataset_version_url(ml, dataset_rid, version, *, ds=None)\` — version-aware URL for datasets. Routes via PEP 440 \`is_devrelease\`. Optional \`ds=\` argument to avoid double-lookup when the caller already has the Dataset object.

### Defensive enumeration

Per-row enumeration loops in \`_get_execution_detail_impl\` are restructured from \"one outer try wraps everything\" to \"one try per row\". A single misshapen row no longer empties the whole list.

## Live verification (localhost:1407)

\`\`\`
ml/dataset/7KE
  cite_url: https://localhost/id/1407/7KE@350-RZA4-M31J  (released v0.4.0 → snapshot-pinned)

ml/execution/8KG
  inputs.datasets[0].cite_url: ...id/1407/7KE@350-RZA4-M31J  (consumed v0.4.0)
  outputs.assets[0..2].cite_url: https://localhost/id/1407/{rid}  (live, no snaptime)
  outputs.metadata[0..5].cite_url: https://localhost/id/1407/{rid}  (live, no snaptime)
\`\`\`

Full deriva-ml-mcp suite: **321 passed**, 22 deselected (integration), 0 failures. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)