### PR TITLE
feat(execution): surface three execution-phase durations

### DIFF
--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -373,6 +373,13 @@ class ExecutionSummary(BaseModel):
     auto-serializes them as ISO 8601 in JSON output) or string
     representations from mocks. ``duration`` is similarly tolerant
     -- deriva-ml may return a ``timedelta`` or a string.
+
+    ``duration`` is the algorithm-phase measurement (catalog column
+    ``Execution_Duration``); ``download_duration`` and
+    ``upload_duration`` are the two companion phases added 2026-05-19.
+    All three are ``None`` for catalogs that predate the schema bump
+    (forward-only migration -- see
+    docs/bugs/2026-05-19-execution-phase-durations-design.md).
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -384,6 +391,8 @@ class ExecutionSummary(BaseModel):
     start_time: datetime | str | None
     stop_time: datetime | str | None
     duration: timedelta | str | None
+    download_duration: timedelta | str | None = None
+    upload_duration: timedelta | str | None = None
 
 
 class ExecutionInputDatasetRef(BaseModel):

--- a/src/deriva_ml_mcp/resources/rag.py
+++ b/src/deriva_ml_mcp/resources/rag.py
@@ -274,7 +274,9 @@ class _ExecutionSerializer(RowSerializer):
                 "Stop Time",
                 str(row["stop_time"]) if row.get("stop_time") is not None else None,
             ),
-            _kv_line("Duration", row.get("duration")),
+            _kv_line("Execution Duration", row.get("duration")),
+            _kv_line("Download Duration", row.get("download_duration")),
+            _kv_line("Upload Duration", row.get("upload_duration")),
         ]
         return _render_block(f"## Execution: {rid}", lines)
 

--- a/src/deriva_ml_mcp/tools/execution/mutate.py
+++ b/src/deriva_ml_mcp/tools/execution/mutate.py
@@ -531,7 +531,8 @@ def register(ctx: PluginContext) -> None:
                 total_failed=summary["total_failed"],
                 retry_failed=retry_failed,
             )
-            # v1.3 surgical re-index: status + stop_time + duration changed.
+            # v1.3 surgical re-index: status + stop_time + the three
+            # *_duration fields changed.
             try:
                 from deriva_ml_mcp.resources.rag import _reindex_execution
 

--- a/src/deriva_ml_mcp/tools/execution/read.py
+++ b/src/deriva_ml_mcp/tools/execution/read.py
@@ -105,6 +105,8 @@ def _summarize_execution(record: Any) -> ExecutionSummary:
         start_time=getattr(record, "start_time", None),
         stop_time=getattr(record, "stop_time", None),
         duration=getattr(record, "duration", None),
+        download_duration=getattr(record, "download_duration", None),
+        upload_duration=getattr(record, "upload_duration", None),
     )
 
 
@@ -559,7 +561,9 @@ def register(ctx: PluginContext) -> None:
                     status_enum = ExecutionStatus(status) if status else None
 
                     def _count_executions() -> int:
-                        return len(list(ml.find_executions(workflow=workflow_rid, status=status_enum)))
+                        return len(
+                            list(ml.find_executions(workflow=workflow_rid, status=status_enum))
+                        )
 
                     total = await asyncio.to_thread(_count_executions)
                     return PreflightCountResponse(
@@ -793,9 +797,7 @@ def register(ctx: PluginContext) -> None:
                 # See deriva-mcp-core plugin-authoring-guide.md
                 # §"Synchronous work in threads".
                 ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
-                payload = await asyncio.to_thread(
-                    _get_lineage_impl, ml, rid, depth, max_executions
-                )
+                payload = await asyncio.to_thread(_get_lineage_impl, ml, rid, depth, max_executions)
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -256,6 +256,8 @@ def test_execution_serializer_renders_full_row() -> None:
         "start_time": datetime(2026, 1, 1, 12, 0, 0),
         "stop_time": datetime(2026, 1, 1, 12, 30, 0),
         "duration": "0:30:00",
+        "download_duration": "0:00:05",
+        "upload_duration": "0:00:12",
     }
     md = _ExecutionSerializer().serialize("Execution", row)
 
@@ -266,7 +268,12 @@ def test_execution_serializer_renders_full_row() -> None:
     assert "**Description:** Run #1." in md
     assert "**Start Time:** 2026-01-01 12:00:00" in md
     assert "**Stop Time:** 2026-01-01 12:30:00" in md
-    assert "**Duration:** 0:30:00" in md
+    # Three duration phases each get their own line; the legacy
+    # "Duration" label was renamed to "Execution Duration" in PR 2
+    # (2026-05-19) for consistency with Download/Upload Duration.
+    assert "**Execution Duration:** 0:30:00" in md
+    assert "**Download Duration:** 0:00:05" in md
+    assert "**Upload Duration:** 0:00:12" in md
 
 
 def test_execution_serializer_omits_unset_timestamps() -> None:


### PR DESCRIPTION
## Summary

Companion to [informatics-isi-edu/deriva-ml#fix/execution-exit-writes-duration](https://github.com/informatics-isi-edu/deriva-ml/pull/new/fix/execution-exit-writes-duration). That PR added two new catalog columns — `Download_Duration` and `Upload_Duration` — and renamed the existing `Duration` → `Execution_Duration`. This PR surfaces all three through the MCP read surface so list/get tools and the RAG resource expose the new measurements.

- `ExecutionSummary` (`_response_models.py`): two new optional fields `download_duration` / `upload_duration`, defaulting to `None` for catalogs that predate the schema bump.
- `_summarize_execution` (`tools/execution/read.py`): pulls the two new fields off `ExecutionRecord` and passes them through.
- RAG serializer (`resources/rag.py`): emits three Markdown lines — `Execution Duration`, `Download Duration`, `Upload Duration` — instead of a single ambiguous `Duration` line. Each line is omitted when its value is `None`.

Tools and resources that surface `ExecutionSummary` automatically inherit the new fields:

- `deriva_ml_list_executions`, `deriva_ml_get_execution`
- `deriva_ml_find_workflow_executions`
- `deriva_ml_list_execution_children`, `deriva_ml_list_execution_parents`
- `deriva://catalog/{h}/{c}/ml/executions`
- `deriva://catalog/{h}/{c}/ml/execution/{rid}`

## Test plan

- [x] `tests/test_rag.py::test_execution_serializer_renders_full_row` updated for the new `Execution Duration` label and extended to assert all three lines render when all three measurements are set.
- [x] Full test suite: 325 passed, 22 deselected.

## Sequencing

Should land **after** the deriva-ml PR — the new `download_duration` / `upload_duration` attributes only exist on `ExecutionRecord` once that PR's schema bump is in place. Until then this PR is a no-op against old catalogs (the new fields stay `None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)