### PR TITLE
fix(execution): surface experiment field for Hydra-driven runs

### DIFF
--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -509,18 +509,29 @@ class ExecutionExperiment(BaseModel):
     experiment run. The ``model_config`` field name conflicts with
     Pydantic's reserved attribute, so it's aliased to ``model_cfg``
     in Python while the wire JSON key remains ``"model_config"``.
+
+    The ``config_choices`` and ``model_config`` dicts are typed as
+    ``dict[str, Any]`` because real Hydra-zen configs include
+    non-primitive values — lists (e.g. ``_zen_exclude: ["description"]``),
+    nested dicts (e.g. nested optimizer config), and class-path
+    strings under reserved keys (``_target_``, ``_zen_target``). An
+    earlier typing of ``dict[str, str | int | float | bool | None]``
+    rejected those values at Pydantic validation time, the bare
+    ``except Exception`` in ``_get_execution_detail_impl`` silently
+    swallowed the failure, and ``experiment: null`` came back for
+    every real Hydra-driven execution. Broadening to ``Any`` is the
+    right contract: this is the cheap-accessor surface, not a
+    schema-validated one.
     """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, protected_namespaces=())
 
     name: str | None
-    config_choices: dict[str, str | int | float | bool | None] = Field(default_factory=dict)
+    config_choices: dict[str, Any] = Field(default_factory=dict)
     # Aliased: Python attribute is ``model_cfg``; wire key is ``"model_config"``
     # to preserve the v1.x wire shape. Pydantic's protected_namespaces=() above
     # is needed because ``model_*`` is a reserved prefix.
-    model_cfg: dict[str, str | int | float | bool | None] = Field(
-        default_factory=dict, alias="model_config"
-    )
+    model_cfg: dict[str, Any] = Field(default_factory=dict, alias="model_config")
 
 
 class ExecutionDetail(ExecutionSummary):

--- a/src/deriva_ml_mcp/tools/execution/read.py
+++ b/src/deriva_ml_mcp/tools/execution/read.py
@@ -321,21 +321,46 @@ def _get_execution_detail_impl(ml: Any, execution_rid: str) -> ExecutionDetail:
     # surface the cheap fields (name + config_choices + model_config)
     # but NOT the full hydra_config payload -- it can be 10-100 KB and
     # a caller wanting it should fetch the metadata asset directly.
+    #
+    # NOTE(2026-05-19): the previous bare ``except Exception`` silently
+    # swallowed BOTH "no Experiment row" (correct) and Pydantic
+    # ValidationError from ExecutionExperiment.model_validate (wrong).
+    # That hid a serializer bug for ~6 months: real Hydra-zen configs
+    # carry non-primitive values (lists, nested dicts) and the
+    # narrow typing rejected them, so EVERY Hydra-driven execution
+    # came back with experiment=null. The typing was broadened in the
+    # same commit; this catch now splits the two failure modes so a
+    # future ValidationError surfaces in logs instead of vanishing.
     experiment: ExecutionExperiment | None = None
     try:
         exp = ml.lookup_experiment(execution_rid)
-        experiment = ExecutionExperiment.model_validate(
-            {
-                "name": getattr(exp, "name", None),
-                "config_choices": getattr(exp, "config_choices", {}) or {},
-                # The wire key is "model_config" (alias) -- pass the dict
-                # under the wire-key form to take advantage of model_validate's
-                # alias-aware construction.
-                "model_config": getattr(exp, "model_config", {}) or {},
-            }
-        )
     except Exception:  # noqa: BLE001 -- absent experiment is the common case
-        experiment = None
+        exp = None
+    if exp is not None:
+        try:
+            experiment = ExecutionExperiment.model_validate(
+                {
+                    "name": getattr(exp, "name", None),
+                    "config_choices": getattr(exp, "config_choices", {}) or {},
+                    # The wire key is "model_config" (alias) -- pass the dict
+                    # under the wire-key form to take advantage of model_validate's
+                    # alias-aware construction.
+                    "model_config": getattr(exp, "model_config", {}) or {},
+                }
+            )
+        except Exception as exc:  # noqa: BLE001 -- log but don't break the response
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "ExecutionExperiment serialization failed for %s: %s. "
+                "Returning experiment=None; the underlying Experiment object "
+                "from deriva-ml exists but its fields failed validation. This "
+                "is likely a deriva-ml-mcp serializer regression -- the "
+                "lookup_experiment path itself succeeded.",
+                execution_rid,
+                exc,
+            )
+            experiment = None
 
     return ExecutionDetail(
         **summary.model_dump(),

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -403,9 +403,7 @@ async def test_ml_dataset_spec_error_path_is_silent(resource_ctx, capturing_mcp,
 # ---------------------------------------------------------------------------
 
 
-async def test_ml_dataset_bag_preview_uses_current_version(
-    resource_ctx, capturing_mcp, mock_ml
-):
+async def test_ml_dataset_bag_preview_uses_current_version(resource_ctx, capturing_mcp, mock_ml):
     """Resource form omits ``version`` -- always inspects current version
     with a warning recommending an explicit pin. The shared
     ``_bag_info_impl`` helper is what the tool uses too, so a drift in
@@ -442,9 +440,7 @@ async def test_ml_dataset_bag_preview_uses_current_version(
     assert spec_arg.exclude_tables is None
 
 
-async def test_ml_dataset_bag_preview_error_path_is_silent(
-    resource_ctx, capturing_mcp, mock_ml
-):
+async def test_ml_dataset_bag_preview_error_path_is_silent(resource_ctx, capturing_mcp, mock_ml):
     mock_ml.lookup_dataset.side_effect = RuntimeError("Dataset not found")
     with patch("deriva_ml_mcp._helpers.audit_event") as mock_audit:
         out = json.loads(
@@ -691,8 +687,12 @@ async def test_ml_execution_detail_categorizes_metadata_outputs(
     # Mocks here set asset_table only; description / asset_types / cite_url
     # come back as their defaults (None / [] / None).
     _bare = lambda rid, fn, table: {  # noqa: E731
-        "rid": rid, "filename": fn, "description": None,
-        "asset_types": [], "asset_table": table, "cite_url": None,
+        "rid": rid,
+        "filename": fn,
+        "description": None,
+        "asset_types": [],
+        "asset_table": table,
+        "cite_url": None,
     }
     assert out["outputs"]["assets"] == [
         _bare("1-WEIGHT", "cifar10_cnn_weights.pt", "Execution_Asset"),
@@ -853,6 +853,57 @@ async def test_ml_execution_detail_includes_experiment_when_present(
     # We deliberately do NOT surface the full hydra_config dict (can be 10-100 KB);
     # the resource exposes the cheap accessors only.
     assert "hydra_config" not in out["experiment"]
+
+
+async def test_ml_execution_detail_experiment_tolerates_non_primitive_values(
+    resource_ctx, capturing_mcp, mock_ml
+):
+    """Regression: ExecutionExperiment must accept list / dict values in
+    model_config and config_choices.
+
+    Surfaced 2026-05-19 in the e2e platform test session: a real Hydra-zen
+    config produces a model_config dict that includes keys like
+    ``_zen_exclude: list[str]`` (e.g. ``['description']``). The earlier
+    typing of ``model_cfg: dict[str, str | int | float | bool | None]``
+    rejected the list value at validation time, the bare ``except Exception``
+    at read.py:337-338 silently turned the failure into ``experiment=None``,
+    and the resource reported ``"experiment": null`` for every real
+    Hydra-driven execution. The typing has been broadened to accept any
+    JSON-serializable value (``Any``); this test pins that contract.
+    """
+    record = _make_execution_record_mock(rid="1-EXP", workflow_rid="1-WF")
+    record.list_input_datasets.return_value = []
+    record.list_assets.return_value = []
+    mock_ml.lookup_execution.return_value = record
+
+    experiment = MagicMock()
+    experiment.name = "cifar10_quick"
+    experiment.config_choices = {"model": "cnn_2layer", "optimizer": "adam"}
+    # Real hydra-zen model_config carries lists (and could carry nested dicts);
+    # the validator must tolerate all of it without dropping the field.
+    experiment.model_config = {
+        "lr": 0.001,
+        "batch_size": 32,
+        "_zen_exclude": ["description"],  # list of strings
+        "_target_": "models.cifar10_cnn.cifar10_cnn",
+        "nested": {"weight_decay": 0.0},  # nested dict
+    }
+    mock_ml.lookup_experiment.return_value = experiment
+
+    out = json.loads(
+        await capturing_mcp.resources[_EXECUTION_DETAIL_URI](
+            hostname="h", catalog_id="1", execution_rid="1-EXP"
+        )
+    )
+
+    # Pre-fix this silently came back as experiment=None.
+    assert out["experiment"] is not None, (
+        "experiment field was silently dropped (likely the ValidationError "
+        "was swallowed by the bare `except Exception` at read.py:337-338)"
+    )
+    assert out["experiment"]["name"] == "cifar10_quick"
+    assert out["experiment"]["model_config"]["_zen_exclude"] == ["description"]
+    assert out["experiment"]["model_config"]["nested"] == {"weight_decay": 0.0}
 
 
 async def test_ml_execution_detail_not_found(resource_ctx, capturing_mcp, mock_ml):


### PR DESCRIPTION
## Summary

The MCP execution-detail resource (\`deriva://catalog/{h}/{c}/ml/execution/{rid}\`) silently returned \`experiment: null\` for every Hydra-driven execution. Surfaced today in the 2026-05-19 e2e platform test session: training execution \`CDG\` on catalog 46 had a complete, valid Experiment record extractable via deriva-ml's \`lookup_experiment(rid)\` — \`name='cifar10_quick'\`, 7 \`config_choices\`, 18 \`model_config\` keys — but the resource reported nothing.

## Root cause

Two interlocking issues:

1. **Narrow typing.** \`ExecutionExperiment.model_cfg\` and \`.config_choices\` were typed as \`dict[str, str | int | float | bool | None]\` — primitives only. Real Hydra-zen configs include non-primitive values: lists (\`_zen_exclude: ["description"]\`), nested dicts, and class-path strings under \`_*\` keys. Pydantic's \`model_validate\` rejected any non-primitive value with \`ValidationError\`.

2. **Silent exception swallowing.** \`_get_execution_detail_impl\` at \`read.py:337-338\` wrapped both \`lookup_experiment()\` AND \`ExecutionExperiment.model_validate()\` in a single \`except Exception\`. The intent was to silently handle the common \"execution is not an experiment\" case (deriva-ml raises in that case). The unintended side effect was that the ValidationError from issue 1 *also* got swallowed, so every Hydra-driven execution returned \`experiment: null\` and nobody noticed for ~6 months.

## Fix

Two changes:

1. **Broaden typing** to \`dict[str, Any]\` for both \`model_cfg\` and \`config_choices\`. The \`ExecutionExperiment\` docstring documents why: this is the cheap-accessor surface for Hydra-zen configs, not a schema-validated one.

2. **Split the exception handler.** \`lookup_experiment()\` raising is still silent (real \"not an experiment\" case). A \`ValidationError\` during \`ExecutionExperiment.model_validate()\` now logs a warning and surfaces \`experiment=None\` — future serializer regressions will be visible in logs.

## Regression test

\`test_ml_execution_detail_experiment_tolerates_non_primitive_values\` builds an Experiment mock with \`_zen_exclude: ["description"]\` (a list) plus a nested dict, then asserts the resource returns the experiment field with both non-primitive values intact. Fails on un-fixed code:

\`\`\`
AssertionError: experiment field was silently dropped (likely the
ValidationError was swallowed by the bare \`except Exception\` at
read.py:337-338)
\`\`\`

## Test plan

- [x] New regression test fails on un-fixed code, passes after the fix.
- [x] Full test suite: 326 passed (325 prior + 1 new), 22 deselected, 0 broken.
- [x] Manual verification against e2e session catalog 46: \`lookup_experiment(\"CDG\")\` returns a valid Experiment with \`name='cifar10_quick'\` + 7 \`config_choices\` + 18 \`model_config\` keys (including the offending \`_zen_exclude: ['description']\`). The execution detail resource on the fix branch will now surface this content instead of returning \`experiment: null\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)