### PR TITLE
feat(dataset): surface split_dataset row_per / via / ignore_unrelated_anchors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,10 @@ dependencies = [
     "deriva-mcp-core",
     # v3.3.0 raised from >=1.31.0 to >=1.33.0 to require lookup_lineage
     # (v1.32.0) and validate_dataset_specs / validate_execution_configuration
-    # (v1.33.0).
-    "deriva-ml>=1.33.0",
+    # (v1.33.0). v3.3.5 raises to >=1.36.6 to require the new
+    # split_dataset(row_per=, via=, ignore_unrelated_anchors=) kwargs
+    # added in deriva-ml #174/#176.
+    "deriva-ml>=1.36.6",
     # Pin deriva-py to the `deriva-ml` branch in the built wheel metadata --
     # not just in [tool.uv] (which is local-only and does not ship). Installers
     # other than uv (pip, plain build envs) would otherwise resolve whatever

--- a/src/deriva_ml_mcp/tools/dataset/complex.py
+++ b/src/deriva_ml_mcp/tools/dataset/complex.py
@@ -420,6 +420,9 @@ def register(ctx: PluginContext) -> None:
         split_description: str = "",
         workflow_type: str = "Dataset_Split",
         dry_run: bool = False,
+        row_per: str | None = None,
+        via: list[str] | None = None,
+        ignore_unrelated_anchors: bool | None = None,
     ) -> str:
         """Split a dataset into train/test/(validation) child datasets in the catalog.
 
@@ -463,6 +466,26 @@ def register(ctx: PluginContext) -> None:
             dry_run: If True, compute the split assignment without creating
                 any catalog datasets. Use to validate strategy choice and
                 partition sizes before committing.
+            row_per: Explicit leaf table for denormalization. Optional;
+                omit for the common case. When ``stratify_by_column`` is
+                set and ``row_per`` is None, the Python API auto-defaults
+                to ``element_table`` (one row per element). Set
+                explicitly to override -- e.g. when projecting through a
+                feature-association bridge and you want one row per
+                feature value rather than per element.
+            via: Tables forced into the join chain without contributing
+                columns (denormalizer ``via=`` parameter). Used to
+                disambiguate path ambiguity when multiple FK paths exist
+                between ``element_table`` and a column in
+                ``stratify_by_column``, without polluting the output
+                column list. Optional; omit for the common case.
+            ignore_unrelated_anchors: If True, silently drop dataset
+                anchors whose table has no FK path to any requested
+                table (denormalizer ``ignore_unrelated_anchors``).
+                Useful when the source dataset has heterogeneous member
+                tables and only a subset participates in the split.
+                Optional; omit for the common case (defaults to False
+                in the Python API).
 
         Returns:
             JSON string ``{"status": "split", "source", "split", "training",
@@ -493,6 +516,18 @@ def register(ctx: PluginContext) -> None:
                 # plugin-authoring-guide.md §"Synchronous work in
                 # threads".
                 ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                # Denormalization-control kwargs (deriva-ml #174/#176):
+                # only forward when the caller set them, so the Python
+                # API's own defaults (row_per=None auto-resolves to
+                # element_table when stratifying; ignore_unrelated_anchors
+                # defaults to False) remain in control for the common case.
+                extra_kwargs: dict = {}
+                if row_per is not None:
+                    extra_kwargs["row_per"] = row_per
+                if via is not None:
+                    extra_kwargs["via"] = via
+                if ignore_unrelated_anchors is not None:
+                    extra_kwargs["ignore_unrelated_anchors"] = ignore_unrelated_anchors
                 result = await asyncio.to_thread(
                     _pkg._split_dataset,
                     ml,
@@ -512,6 +547,7 @@ def register(ctx: PluginContext) -> None:
                     include_tables=include_tables,
                     workflow_type=workflow_type,
                     dry_run=dry_run,
+                    **extra_kwargs,
                 )
                 payload = result.model_dump()
 

--- a/tests/test_dataset_complex.py
+++ b/tests/test_dataset_complex.py
@@ -564,3 +564,63 @@ async def test_split_dataset_error_path(dataset_ctx, capturing_mcp, mock_ml):
     assert failed
     assert failed[0].kwargs["source_dataset_rid"] == "1-AAAA"
     assert failed[0].kwargs["dry_run"] is False
+
+
+async def test_split_dataset_denorm_kwargs_omitted_by_default(dataset_ctx, capturing_mcp, mock_ml):
+    """Default call MUST NOT forward row_per / via / ignore_unrelated_anchors.
+
+    The Python API owns the defaults (row_per auto-resolves to
+    element_table when stratifying; ignore_unrelated_anchors defaults to
+    False). The wrapper only forwards these kwargs when the caller set
+    them explicitly so that the Python API can keep evolving the
+    defaults without the MCP layer re-asserting None.
+    """
+    payload = _split_result_payload()
+    result_obj = MagicMock()
+    result_obj.model_dump.return_value = payload
+    with (
+        patch("deriva_ml_mcp.tools.dataset._split_dataset", return_value=result_obj) as mock_split,
+        _patch_audit(),
+    ):
+        await capturing_mcp.tools["deriva_ml_split_dataset"](
+            hostname="h",
+            catalog_id="1",
+            source_dataset_rid="1-AAAA",
+        )
+    kwargs = mock_split.call_args.kwargs
+    assert "row_per" not in kwargs
+    assert "via" not in kwargs
+    assert "ignore_unrelated_anchors" not in kwargs
+
+
+async def test_split_dataset_forwards_denorm_kwargs(dataset_ctx, capturing_mcp, mock_ml):
+    """row_per / via / ignore_unrelated_anchors flow through to split_dataset.
+
+    Regression test for the deriva-ml #174/#176 wrapper update: when
+    the caller sets any of the denormalization-control kwargs, the
+    MCP wrapper must forward them verbatim to
+    ``deriva_ml.dataset.split.split_dataset``.
+    """
+    payload = _split_result_payload()
+    payload["strategy"] = "stratified"
+    result_obj = MagicMock()
+    result_obj.model_dump.return_value = payload
+    with (
+        patch("deriva_ml_mcp.tools.dataset._split_dataset", return_value=result_obj) as mock_split,
+        _patch_audit(),
+    ):
+        await capturing_mcp.tools["deriva_ml_split_dataset"](
+            hostname="h",
+            catalog_id="1",
+            source_dataset_rid="1-AAAA",
+            stratify_by_column="Image_Classification.Image_Class",
+            include_tables=["Image", "Image_Classification"],
+            element_table="Image",
+            row_per="Image_Classification",
+            via=["Execution_Image_Image_Classification"],
+            ignore_unrelated_anchors=True,
+        )
+    kwargs = mock_split.call_args.kwargs
+    assert kwargs["row_per"] == "Image_Classification"
+    assert kwargs["via"] == ["Execution_Image_Image_Classification"]
+    assert kwargs["ignore_unrelated_anchors"] is True


### PR DESCRIPTION
## Summary

Follow-up to [deriva-ml #176](https://github.com/informatics-isi-edu/deriva-ml/pull/176) (closes [deriva-ml #174](https://github.com/informatics-isi-edu/deriva-ml/issues/174)) which added three denormalization-control kwargs to `deriva_ml.dataset.split.split_dataset`. This PR exposes them on the `deriva_ml_split_dataset` MCP tool so MCP callers can reach them without dropping down to the Python API.

The new kwargs are:

- `row_per` (`str | None`) -- explicit leaf table for denormalization; lets a caller override the auto-default of `element_table` when stratifying.
- `via` (`list[str] | None`) -- tables forced into the join chain without contributing columns. Disambiguates path ambiguity (denormalizer Rule 6) without polluting the output.
- `ignore_unrelated_anchors` (`bool | None`) -- silently drop dataset anchors whose table has no FK path to any requested table (denormalizer Rule 8).

## Pass-through semantics

The wrapper forwards each kwarg **only when the caller sets it explicitly**. This keeps the Python API in control of the defaults:

- `split_dataset` itself defaults `row_per=element_table` when `stratify_by_column` or a `selection_fn` is in play, so MCP callers stratifying by an element-table feature continue to get the right behavior with no signature change.
- `ignore_unrelated_anchors` defaults to `False` in the Python API.

This means the common case (stratify by an element-table feature, e.g. `Image_Classification.Image_Class`) keeps working without setting any of these kwargs.

## Dependency pin

`deriva-ml>=1.33.0` -> `deriva-ml>=1.36.6` so installs pull a wheel that actually contains the new kwargs. (#174/#176 landed past v1.36.5.)

## Test plan

- [x] `uv sync` succeeds with the new pin (editable local checkout already provides the new kwargs).
- [x] `uv run python -m pytest tests/` -- 331 passed, 0 failed.
- [x] `uv run ruff check src tests` -- all checks passed.
- [x] New tests cover both paths:
  - `test_split_dataset_denorm_kwargs_omitted_by_default` -- when caller does not set the new kwargs, the wrapper does NOT forward them to `split_dataset` (so the Python API's own defaults stay authoritative).
  - `test_split_dataset_forwards_denorm_kwargs` -- when the caller sets `row_per`, `via`, and `ignore_unrelated_anchors`, the wrapper forwards each verbatim.
- [ ] Integration: a live-catalog test that stratifies through a feature-association bridge using the new kwargs (covered indirectly by the deriva-ml side; this PR is wrapper-only).