### PR TITLE
fix(asset): surface lookup_asset executions errors (#41 / B18)

### DIFF
--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -714,15 +714,28 @@ class AssetDetail(AssetSummary):
     Produced by ``_get_asset_detail_impl``. Used by the
     ``deriva://catalog/{h}/{c}/ml/asset/{rid}`` resource.
 
-    The ``executions`` list is best-effort: if
-    ``Asset.list_executions()`` raises (e.g. malformed catalog
-    metadata), it comes back empty rather than aborting the whole
-    detail payload.
+    Executions semantics. Two distinct empty-list cases are
+    distinguishable on the wire so callers can tell "no executions
+    are linked to this asset" apart from "the executions lookup
+    failed" -- the latter previously surfaced as an indistinguishable
+    silent ``[]`` (issue #41 / B18):
+
+    - ``executions == []`` and ``executions_error is None``: the asset
+      genuinely has no execution associations, or its asset table has
+      no Execution association at all (e.g. a domain asset table that
+      doesn't track executions). This is the "no data" answer.
+    - ``executions == []`` and ``executions_error`` is a string: the
+      executions lookup raised. The asset detail (filename, length,
+      url, types, ...) still comes through, but the executions
+      sub-field could not be populated. The string is
+      ``f"{exc.__class__.__name__}: {exc}"`` -- enough for a caller to
+      diagnose without re-running.
     """
 
     url: str | None
     description: str | None
     executions: list[AssetExecutionRef] = Field(default_factory=list)
+    executions_error: str | None = None
 
 
 class AssetListResponse(_PaginationFields):

--- a/src/deriva_ml_mcp/tools/asset.py
+++ b/src/deriva_ml_mcp/tools/asset.py
@@ -138,11 +138,31 @@ def _get_asset_detail_impl(ml: Any, asset_rid: str) -> AssetDetail:
     common case -- ``list_asset_executions`` returns plain
     ``ExecutionRecord``s), the role surfaces as ``None``.
 
-    If ``Asset.list_executions`` raises (e.g. malformed catalog
-    metadata), the executions list comes back empty rather than aborting
-    the whole detail payload -- mirrors the
-    ``_get_execution_detail_impl`` best-effort pattern in
-    ``tools/execution.py``.
+    Executions failure semantics (issue #41 / B18). The executions
+    sub-field is best-effort in the sense that a failure inside
+    ``Asset.list_executions()`` does not abort the whole detail
+    payload -- the asset metadata (filename, length, url, types, ...)
+    still comes through. But the failure is **surfaced**, not
+    swallowed: previously every exception turned into an
+    indistinguishable empty list, which masked transient ermrest
+    errors, auth glitches, and partial-list failures behind a
+    syntactically valid but semantically wrong "no executions" answer.
+    Now:
+
+    - If ``find_association`` raises because the asset table has no
+      ``Execution`` association at all (genuine "no execution
+      tracking" case), ``executions`` is ``[]`` and
+      ``executions_error`` is ``None`` -- same shape as the empty case.
+    - If any other exception is raised, ``executions`` is ``[]`` and
+      ``executions_error`` is ``"<ExcClass>: <message>"``. The caller
+      can distinguish "no associations" from "lookup failed" without
+      re-running.
+
+    The narrow "no association" detection keys on the
+    ``DerivaMLException`` message produced by
+    ``DerivaModel.find_association`` ("No association tables found
+    between ... and Execution.") -- the exception type alone is too
+    broad because the same class covers many distinct failures.
 
     Args:
         ml: A connected ``deriva_ml.DerivaML`` instance.
@@ -153,16 +173,28 @@ def _get_asset_detail_impl(ml: Any, asset_rid: str) -> AssetDetail:
     """
     asset = ml.lookup_asset(asset_rid)
     executions: list[AssetExecutionRef] = []
+    executions_error: str | None = None
     try:
-        for record in asset.list_executions():
+        records = list(asset.list_executions())
+    except Exception as exc:  # noqa: BLE001 -- classified below
+        # "No association tables found between <table> and Execution."
+        # is the legitimate "this asset table has no execution
+        # tracking" case raised by ``DerivaModel.find_association`` --
+        # surface that as a clean empty list. Anything else is a real
+        # error worth showing to the caller.
+        msg = str(exc)
+        if "No association tables found" in msg and "Execution" in msg:
+            executions_error = None
+        else:
+            executions_error = f"{exc.__class__.__name__}: {exc}"
+    else:
+        for record in records:
             executions.append(
                 AssetExecutionRef(
                     rid=getattr(record, "execution_rid", None),
                     asset_role=getattr(record, "asset_role", None),
                 )
             )
-    except Exception:  # noqa: BLE001 -- executions list is best-effort
-        executions = []
     return AssetDetail(
         rid=asset.asset_rid,
         filename=asset.filename,
@@ -173,6 +205,7 @@ def _get_asset_detail_impl(ml: Any, asset_rid: str) -> AssetDetail:
         asset_table=asset.asset_table,
         asset_types=list(asset.asset_types) if asset.asset_types else [],
         executions=executions,
+        executions_error=executions_error,
     )
 
 
@@ -319,13 +352,25 @@ def register(ctx: PluginContext) -> None:
         ``deriva://catalog/{h}/{c}/ml/asset/{rid}`` resource -- the two
         share an internal helper so the payloads cannot drift.
 
+        Executions semantics (issue #41). The ``executions`` list is
+        best-effort: an error inside the executions lookup does not
+        abort the rest of the detail. But the failure is now
+        surfaced via ``executions_error`` rather than swallowed:
+
+        - ``executions: []`` with ``executions_error: null`` means the
+          asset has no execution links (including the case where the
+          asset table has no Execution association at all).
+        - ``executions: []`` with ``executions_error: "<exc>"`` means
+          the lookup failed. Re-run, or inspect ``Execution_Asset_Execution``
+          directly to confirm.
+
         Args:
             asset_rid: The RID of the asset to look up.
 
         Returns:
             JSON string ``{"rid", "filename", "length", "md5", "url",
             "description", "asset_table", "asset_types", "executions":
-            [{"rid", "asset_role"}, ...]}``.
+            [{"rid", "asset_role"}, ...], "executions_error": str|null}``.
 
         Raises:
             RuntimeError: Wrapped as ``{"error": ...}``, propagated
@@ -337,7 +382,7 @@ def register(ctx: PluginContext) -> None:
             12345, "md5": "abc", "url": "/hatrac/...",
             "description": "MRI scan", "asset_table": "Image",
             "asset_types": ["Training_Data"], "executions": [{"rid":
-            "1-EXEC", "asset_role": "Output"}]}``.
+            "1-EXEC", "asset_role": "Output"}], "executions_error": null}``.
         """
         try:
             with deriva_call():

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -179,10 +179,18 @@ async def test_lookup_asset_no_executions(asset_ctx, capturing_mcp, mock_ml):
     assert out["executions"] == []
 
 
-async def test_lookup_asset_executions_call_failure_falls_back_to_empty_list(
+async def test_lookup_asset_executions_call_failure_surfaces_error(
     asset_ctx, capturing_mcp, mock_ml
 ):
-    """If list_executions raises, the detail payload still serializes (best-effort)."""
+    """Issue #41 regression: a list_executions failure now surfaces in
+    ``executions_error`` rather than being silently swallowed into ``[]``.
+
+    Prior behaviour: blanket ``except Exception`` flipped the list to
+    ``[]`` and gave no way for the caller to distinguish "no
+    executions" from "lookup failed". Today the asset detail still
+    serializes (best-effort on the rest of the payload), but the
+    failure is reported.
+    """
     asset = _make_asset_mock(asset_rid="1-AAAA")
     asset.list_executions.side_effect = RuntimeError("association table missing")
     mock_ml.lookup_asset.return_value = asset
@@ -195,6 +203,71 @@ async def test_lookup_asset_executions_call_failure_falls_back_to_empty_list(
     # Best-effort: the asset detail still came through.
     assert out["rid"] == "1-AAAA"
     assert out["executions"] == []
+    # New in #41: the error is reported, not swallowed.
+    assert out["executions_error"] == "RuntimeError: association table missing"
+
+
+async def test_lookup_asset_no_execution_association_returns_clean_empty(
+    asset_ctx, capturing_mcp, mock_ml
+):
+    """Issue #41: the legitimate "asset table has no Execution association"
+    case (raised by ``DerivaModel.find_association``) keeps the clean
+    empty-list shape -- no spurious error message. This is the only
+    case we silence; everything else surfaces in ``executions_error``.
+    """
+    from deriva_ml.core.exceptions import DerivaMLException
+
+    asset = _make_asset_mock(asset_rid="1-AAAA")
+    asset.list_executions.side_effect = DerivaMLException(
+        "No association tables found between Image and Execution."
+    )
+    mock_ml.lookup_asset.return_value = asset
+
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_lookup_asset"](
+            hostname="h", catalog_id="1", asset_rid="1-AAAA"
+        )
+    )
+    assert out["rid"] == "1-AAAA"
+    assert out["executions"] == []
+    assert out["executions_error"] is None
+
+
+async def test_lookup_asset_b18_fresh_then_failed_lookup(asset_ctx, capturing_mcp, mock_ml):
+    """Issue #41 (B18) scenario regression: an MCP request inserts a
+    fresh association, a second MCP request looks up the asset, and an
+    error inside the executions lookup is now surfaced rather than
+    masquerading as "no executions". Two-call sequence -- the original
+    bug's pattern -- proves the second call's failure is no longer
+    invisible.
+    """
+    # First call: lookup succeeds with no executions yet.
+    asset_v1 = _make_asset_mock(asset_rid="1-AAAA", executions=[])
+    mock_ml.lookup_asset.return_value = asset_v1
+    out1 = json.loads(
+        await capturing_mcp.tools["deriva_ml_lookup_asset"](
+            hostname="h", catalog_id="1", asset_rid="1-AAAA"
+        )
+    )
+    assert out1["executions"] == []
+    assert out1["executions_error"] is None
+
+    # Now an association is "inserted" (mock state change) and the
+    # second lookup hits a transient ermrest error -- the original B18
+    # symptom.
+    asset_v2 = _make_asset_mock(asset_rid="1-AAAA")
+    asset_v2.list_executions.side_effect = RuntimeError("ermrest 503 Service Unavailable")
+    mock_ml.lookup_asset.return_value = asset_v2
+    out2 = json.loads(
+        await capturing_mcp.tools["deriva_ml_lookup_asset"](
+            hostname="h", catalog_id="1", asset_rid="1-AAAA"
+        )
+    )
+    # Pre-fix behaviour: out2["executions"] == [] and no signal of why.
+    # Post-fix behaviour: out2["executions"] == [] AND the caller is
+    # told the lookup failed.
+    assert out2["executions"] == []
+    assert out2["executions_error"] == "RuntimeError: ermrest 503 Service Unavailable"
 
 
 async def test_lookup_asset_failure_returns_error_envelope(asset_ctx, capturing_mcp, mock_ml):


### PR DESCRIPTION
Closes #41 (bug B18).

## Root cause (different from the issue's hypothesis)

The issue suspected per-request `get_ml()` was returning a cached
`DerivaML` with a stale path-builder. **That's not what's happening.**

`src/deriva_ml_mcp/ml_context.py` `get_ml()` builds a **fresh
`DerivaML` per call** -- no `lru_cache`, no module-level dict, just
`return DerivaML(internal, catalog_id, ...)`. Each invocation goes:

`get_ml` -> `DerivaML.__init__` -> `DerivaServer` -> fresh
`ErmrestCatalog` (whose HTTP response cache is per-instance, born
empty). There is no shared state between two calls.

Verified by live repro against catalog 46:

1. Long-lived `DerivaML` instance simulating an MCP container.
2. `_get_asset_detail_impl(ml, "ES6")` -> correct executions list.
3. Insert a **fresh** `Execution_Asset_Execution` row (`ES6` <-> `45A`).
4. Same long-lived `ml`, same helper: returns the new association
   immediately. Same with a freshly-built `ml`. Both paths see fresh
   rows; the cache hypothesis is wrong.

The **actual** bug is in `_get_asset_detail_impl` itself
(`src/deriva_ml_mcp/tools/asset.py:156-165` on `df5f23b`):

```python
executions: list[AssetExecutionRef] = []
try:
    for record in asset.list_executions():
        executions.append(AssetExecutionRef(...))
except Exception:  # noqa: BLE001 -- executions list is best-effort
    executions = []
```

This blanket-catches every exception inside `Asset.list_executions()`
and its internals (`find_association`, `resolve_rid`, the
pathBuilder fetch, and a per-record `lookup_execution` call -- which
itself does a workflow lookup and can fail for many reasons) and
silently collapses the list to `[]`. The B18 journal evidence --
"fresh EQA-linked associations return empty, older CMY associations
work" -- fits a transient error inside the EQA-lookup window
(timing, the newly-registered EQ6 workflow, an auth-token rotation,
a 5xx on `Workflow_Workflow_Type`, ...). Whatever it was, the
silent except turned a real error into a syntactically valid
"no executions" answer indistinguishable from an asset that
genuinely has none. That's the worst possible failure mode for a
provenance read.

## Fix

`tools/asset.py::_get_asset_detail_impl`:

- Narrow the silenced case to the **legitimate** "this asset table
  has no Execution association at all" path, detected by the
  deterministic exception message from
  `DerivaModel.find_association` ("No association tables found
  between ... and Execution.").
- Surface every other exception via a new optional
  `executions_error: str | None` field on `AssetDetail`. The rest
  of the asset detail (filename, length, url, types, ...) still
  comes through (best-effort), but the caller can now distinguish
  `executions=[] / executions_error=null` (no data) from
  `executions=[] / executions_error="<exc>"` (lookup failed).

`_response_models.py::AssetDetail`: added `executions_error` field,
documented the two empty-list shapes.

`tools/asset.py::deriva_ml_lookup_asset` docstring: documents the
new wire shape so an LLM caller knows to inspect the field.

## Alternatives rejected

- **(A) Bypass a cache for executions** -- there is no cache.
- **(B) Invalidate the path-builder on writes** -- nothing to
  invalidate; each call builds a fresh one.
- **(C) Force a fresh snapshot per request** -- already happening.
- **(D) Fix upstream in `deriva-ml`** -- `Asset.list_executions`
  correctly raises on internal failures; the bug is the MCP
  wrapper's silent except, not the underlying library.

The picked approach is the smallest correct change: it preserves
the legitimate best-effort case while making real failures
visible.

## Regression tests

`tests/test_asset.py`:

- `test_lookup_asset_executions_call_failure_surfaces_error`
  (rewrites the prior "falls back to empty list" test): proves
  `executions_error` carries the exception identity, not silenced.
- `test_lookup_asset_no_execution_association_returns_clean_empty`:
  proves the narrow `DerivaMLException("No association tables found
  between ... and Execution.")` path stays clean
  (`executions=[]`, `executions_error=None`) so domain catalogs
  without execution tracking don't get a spurious error.
- `test_lookup_asset_b18_fresh_then_failed_lookup`: the B18 pattern
  itself -- first call returns clean empty, second call's
  `list_executions` raises (simulating the transient ermrest error
  that masqueraded as "no executions"), proves the failure now
  surfaces.

All 17 `tests/test_asset.py` tests pass; all 277 unit tests pass;
lint and format clean.

## End-to-end verification

Catalog 46 on localhost:

- `_get_asset_detail_impl(ml, "ES6")`: `executions=[(EQA, None),
  (EV0, None)] / executions_error=None` (the original B18 victim;
  works correctly today on the unchanged path).
- `_get_asset_detail_impl(ml, "CXA")`, `"CPG"`, `"ERY"`: same.
- Monkeypatched `list_executions` to raise `RuntimeError("ermrest
  503 Service Unavailable")`: returns
  `executions=[] / executions_error="RuntimeError: ermrest 503
  Service Unavailable"`. Pre-fix this was a silent `[]`.
- JSON shape inspected: `executions_error: null` field serializes
  cleanly.

The MCP container reload + tool exercise on a live catalog 46 is
deferred to the user (no live MCP server running in this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)