### PR TITLE
chore(asset): use typed NoAssociationException for lookup_asset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,10 @@ dependencies = [
     # (v1.32.0) and validate_dataset_specs / validate_execution_configuration
     # (v1.33.0). v3.3.5 raises to >=1.36.6 to require the new
     # split_dataset(row_per=, via=, ignore_unrelated_anchors=) kwargs
-    # added in deriva-ml #174/#176.
-    "deriva-ml>=1.36.6",
+    # added in deriva-ml #174/#176. Raised again to >=1.36.7 to require
+    # the typed NoAssociationException / AmbiguousAssociationException
+    # added in deriva-ml #180/#185.
+    "deriva-ml>=1.36.7",
     # Pin deriva-py to the `deriva-ml` branch in the built wheel metadata --
     # not just in [tool.uv] (which is local-only and does not ship). Installers
     # other than uv (pip, plain build envs) would otherwise resolve whatever

--- a/src/deriva_ml_mcp/tools/asset.py
+++ b/src/deriva_ml_mcp/tools/asset.py
@@ -53,6 +53,7 @@ from typing import TYPE_CHECKING, Any
 
 from deriva_mcp_core import deriva_call
 from deriva_mcp_core.telemetry import audit_event
+from deriva_ml.core.exceptions import NoAssociationException
 
 # Note on testing audit_event: see ``make_patch_audit("asset")`` in
 # ``tests/_helpers.py``. Single-patch facade is impossible due to
@@ -149,20 +150,21 @@ def _get_asset_detail_impl(ml: Any, asset_rid: str) -> AssetDetail:
     syntactically valid but semantically wrong "no executions" answer.
     Now:
 
-    - If ``find_association`` raises because the asset table has no
-      ``Execution`` association at all (genuine "no execution
-      tracking" case), ``executions`` is ``[]`` and
-      ``executions_error`` is ``None`` -- same shape as the empty case.
+    - If ``find_association`` raises ``NoAssociationException``
+      because the asset table has no ``Execution`` association at all
+      (genuine "no execution tracking" case), ``executions`` is ``[]``
+      and ``executions_error`` is ``None`` -- same shape as the empty
+      case.
     - If any other exception is raised, ``executions`` is ``[]`` and
       ``executions_error`` is ``"<ExcClass>: <message>"``. The caller
       can distinguish "no associations" from "lookup failed" without
       re-running.
 
-    The narrow "no association" detection keys on the
-    ``DerivaMLException`` message produced by
-    ``DerivaModel.find_association`` ("No association tables found
-    between ... and Execution.") -- the exception type alone is too
-    broad because the same class covers many distinct failures.
+    The narrow "no association" detection branches on the typed
+    ``NoAssociationException`` subclass raised by
+    ``DerivaModel.find_association`` (deriva-ml #180/#185). Prior
+    revisions of this helper had to match the exception message text;
+    the typed-subclass surface makes that unnecessary.
 
     Args:
         ml: A connected ``deriva_ml.DerivaML`` instance.
@@ -176,17 +178,13 @@ def _get_asset_detail_impl(ml: Any, asset_rid: str) -> AssetDetail:
     executions_error: str | None = None
     try:
         records = list(asset.list_executions())
-    except Exception as exc:  # noqa: BLE001 -- classified below
-        # "No association tables found between <table> and Execution."
-        # is the legitimate "this asset table has no execution
-        # tracking" case raised by ``DerivaModel.find_association`` --
-        # surface that as a clean empty list. Anything else is a real
-        # error worth showing to the caller.
-        msg = str(exc)
-        if "No association tables found" in msg and "Execution" in msg:
-            executions_error = None
-        else:
-            executions_error = f"{exc.__class__.__name__}: {exc}"
+    except NoAssociationException:
+        # Legitimate "this asset table has no execution tracking" case
+        # raised by ``DerivaModel.find_association``. Surface as a
+        # clean empty list with no error.
+        executions_error = None
+    except Exception as exc:  # noqa: BLE001 -- everything else is a real error
+        executions_error = f"{exc.__class__.__name__}: {exc}"
     else:
         for record in records:
             executions.append(

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -211,9 +211,38 @@ async def test_lookup_asset_no_execution_association_returns_clean_empty(
     asset_ctx, capturing_mcp, mock_ml
 ):
     """Issue #41: the legitimate "asset table has no Execution association"
-    case (raised by ``DerivaModel.find_association``) keeps the clean
-    empty-list shape -- no spurious error message. This is the only
-    case we silence; everything else surfaces in ``executions_error``.
+    case (raised by ``DerivaModel.find_association`` as the typed
+    ``NoAssociationException``) keeps the clean empty-list shape --
+    no spurious error message. This is the only case we silence;
+    everything else surfaces in ``executions_error``.
+    """
+    from deriva_ml.core.exceptions import NoAssociationException
+
+    asset = _make_asset_mock(asset_rid="1-AAAA")
+    asset.list_executions.side_effect = NoAssociationException("Image", "Execution")
+    mock_ml.lookup_asset.return_value = asset
+
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_lookup_asset"](
+            hostname="h", catalog_id="1", asset_rid="1-AAAA"
+        )
+    )
+    assert out["rid"] == "1-AAAA"
+    assert out["executions"] == []
+    assert out["executions_error"] is None
+
+
+async def test_lookup_asset_generic_no_association_message_is_not_silenced(
+    asset_ctx, capturing_mcp, mock_ml
+):
+    """Regression: a bare ``DerivaMLException`` carrying the literal
+    message ``"No association tables found ... Execution"`` is **not**
+    silently swallowed -- it surfaces in ``executions_error``.
+
+    This proves the helper no longer depends on the exception's message
+    text to decide whether the error was the legitimate "no association"
+    case. Only the typed ``NoAssociationException`` subclass triggers
+    the clean-empty path now.
     """
     from deriva_ml.core.exceptions import DerivaMLException
 
@@ -230,7 +259,9 @@ async def test_lookup_asset_no_execution_association_returns_clean_empty(
     )
     assert out["rid"] == "1-AAAA"
     assert out["executions"] == []
-    assert out["executions_error"] is None
+    assert out["executions_error"] is not None
+    assert "DerivaMLException" in out["executions_error"]
+    assert "No association tables found" in out["executions_error"]
 
 
 async def test_lookup_asset_b18_fresh_then_failed_lookup(asset_ctx, capturing_mcp, mock_ml):


### PR DESCRIPTION
## Summary

- Refactor `_get_asset_detail_impl` in `src/deriva_ml_mcp/tools/asset.py` to branch on the typed `NoAssociationException` subclass instead of pattern-matching `"No association tables found"` in the exception's message text.
- Bump the `deriva-ml` floor from `>=1.36.6` to `>=1.36.7` to require the new typed subclasses.
- Update the existing `test_lookup_asset_no_execution_association_returns_clean_empty` to construct `NoAssociationException` directly, and add a new regression test (`test_lookup_asset_generic_no_association_message_is_not_silenced`) proving that a bare `DerivaMLException` with the literal "No association tables found" message is **not** silenced by the new code -- the helper no longer depends on the exception's text.

PR #43 (B18 fix) had to key on exception message text to detect the legitimate "this asset table has no execution association" case versus a real transient error. deriva-ml [#185](https://github.com/informatics-isi-edu/deriva-ml/pull/185) added typed subclasses for `find_association`'s failure modes; the wrapper now branches on type instead of message string. The wire shape (`executions`, `executions_error`) is unchanged.

Refs deriva-ml [#180](https://github.com/informatics-isi-edu/deriva-ml/issues/180), deriva-ml [#185](https://github.com/informatics-isi-edu/deriva-ml/pull/185) (merged), deriva-ml-mcp [#43](https://github.com/informatics-isi-edu/deriva-ml-mcp/pull/43) (predecessor).

## Test plan

- [x] `uv run python -m pytest tests/` -- 334 passed
- [x] `uv run ruff check src tests` -- clean
- [x] `uv run ruff format src tests` -- no changes to touched files
- [x] Pre-fix verification: with the source change stashed, the new `test_lookup_asset_generic_no_association_message_is_not_silenced` fails (the old message-text matcher silences the generic `DerivaMLException`). With the fix restored, both the new and the original-empty-case tests pass.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>