### PR TITLE
chore(deps): bump deriva-ml to v1.37.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -709,8 +709,8 @@ provides-extras = ["rag", "dev"]
 
 [[package]]
 name = "deriva-ml"
-version = "1.37.3.post1+g7698c89eb"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#7698c89eb013ce6492cc40c3d2f390d0ffc1548d" }
+version = "1.37.4"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#cbf745cab2192d83c5b8e36c6c394ec851780861" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
## Summary
- Bump `deriva-ml` from `1.37.3.post1+g7698c89eb` to `1.37.4` (released as part of #192 merge)
- Lockfile-only change; `deriva-ml-mcp` source already targets the ConfigValidator + ConfigBootstrap APIs (PR #45)

## Test plan
- [x] `uv sync --extra dev`
- [x] `uv run pytest` → 335 passed, 22 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)