### PR TITLE
chore: reconcile commit_execution narrative (audit P1 #1)

### DIFF
--- a/docs/scratch/phase5-execution-analysis.md
+++ b/docs/scratch/phase5-execution-analysis.md
@@ -1,5 +1,7 @@
 # Phase 5 — Execution domain analysis (scratch)
 
+> **STATUS: DEFERRED (2026-05-24).** The `commit_execution` MCP tool proposed in this document is **permanently deferred** in favor of a future `work-with-executions` skill in [deriva-ml-skills](https://github.com/informatics-isi-edu/deriva-ml-skills). Per the v0.5.0 stateless-MCP architectural rule (see [CLAUDE.md](../../CLAUDE.md) and [`docs/superpowers/notes/audit-2026-05-23.md`](../superpowers/notes/audit-2026-05-23.md)), execution lifecycle does not belong on the MCP wire — it composes only at the caller's local Python where the asset manifest + SQLite registry live. This document is preserved as **historical design context** showing what a hypothetical MCP-side commit tool would have needed to do (including the bug-fix call-sequence per ADR-0009 on the deriva-ml side); it is **NOT a roadmap**.
+
 > **Status note (2026-05-24):** This analysis was originally drafted
 > against deriva-ml's pre-v1.39 surface. Updated 2026-05-24 to reflect
 > the unified `commit_output_assets` surface that shipped in deriva-ml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,12 @@ dependencies = [
     # `Execution.commit_output_assets()` + `DerivaML.commit_pending_executions()`.
     # v1.39.0 was briefly tagged v2.0.0 and re-tagged after the user decided
     # v2.0 should wait for more bake time; the upper bound <2.0 keeps us out
-    # of any future v2.0 release until we re-validate. The `commit_execution`
-    # MCP tool (when it is implemented) MUST drive the v1.39 method names —
-    # see docs/scratch/phase5-execution-analysis.md for the corrected
-    # compose-sequence.
+    # of any future v2.0 release until we re-validate.
+    # Pinned to v1.39+ for ADR-0009's unified `commit_output_assets` /
+    # `commit_pending_executions` surface. The MCP plugin does not expose
+    # execution lifecycle (stateless rule, v0.5.0); this pin protects
+    # against any future code path that depends on the v1.39 method names
+    # in the underlying library.
     "deriva-ml>=1.39,<2.0",
     # Pin deriva-py to the `deriva-ml` branch in the built wheel metadata --
     # not just in [tool.uv] (which is local-only and does not ship). Installers

--- a/src/deriva_ml_mcp/prompts.py
+++ b/src/deriva_ml_mcp/prompts.py
@@ -584,11 +584,14 @@ reach for:
               ``list_*`` (paginated) or ``get_*`` (single hit)
               depending on the search's arity.
 
-    create_ / update_ / delete_ / add_ / start_ / commit_ / abort_
+    create_ / update_ / delete_ / add_
               Mutating operations. Every one emits an audit row
               (success or ``_failed``). Mutating tools have NO
               resource counterpart -- resources are read-only by
-              MCP convention.
+              MCP convention. (Execution lifecycle verbs such as
+              ``start_`` / ``commit_`` / ``abort_`` are permanently
+              deferred to a future ``work-with-executions`` skill in
+              deriva-ml-skills; no such tools exist in this plugin.)
 
     lookup_*  Specialized RID-or-name resolution (currently only
               ``lookup_asset``). Treat as a sibling of ``get_*``.


### PR DESCRIPTION
## Summary

Resolves the three-way documentation contradiction surfaced in the 2026-05-24 parity audit (P1 #1 + P2 #1 + P2 #2). Before this PR, three sources disagreed about whether `commit_execution` would ever become an MCP tool:

- `CLAUDE.md` and `docs/superpowers/notes/audit-2026-05-23.md` said "execution lifecycle is out of scope on MCP, period (stateless rule)."
- `docs/scratch/phase5-execution-analysis.md` said "when `commit_execution` is implemented, it MUST drive `commit_output_assets`."
- `pyproject.toml:41-43` said "The `commit_execution` MCP tool (when it is implemented) MUST drive the v1.39 method names."
- `prompts.py:587` advertised `start_ / commit_ / abort_` as valid MCP tool prefixes even though no such tools exist (and the architectural decision says they won't).

## Changes

**3 commits, docs-only:**

1. **`docs/scratch/phase5-execution-analysis.md`** — add a prominent `STATUS: DEFERRED` banner at the top declaring `commit_execution` permanently deferred to a future `work-with-executions` skill in deriva-ml-skills. Body preserved as historical design context (the call sequence it documents — `commit_output_assets` — is still correct and useful for the future skill author).

2. **`pyproject.toml`** — rewrite the dependency comment that said "when it is implemented" to instead explain the pin rationale (ADR-0009's unified `commit_output_assets` / `commit_pending_executions` surface) without implying the tool will arrive on the MCP wire.

3. **`src/deriva_ml_mcp/prompts.py`** — remove `start_ / commit_ / abort_` from the verb-convention table's mutating-verb list; they had no corresponding tools. Added a brief explanatory note pointing to the future skill.

## Audit reference

Parity audit: `docs/audits/2026-05-24-parity-audit-v1.39.md`
- P1 #1 (Category 8): "commit_execution lifecycle ambiguity"
- P2 #1 (Category 6): "Verb-list in prompts.py:587 advertises start_/commit_/abort_ mutating verbs but no such tools exist"
- P2 #2 (Category 8): "pyproject.toml:41-43 dependency comment implies commit_execution will be added"

## Verification

```
# No commit_execution references as MCP tool
grep -rn "commit_execution" src/ pyproject.toml | grep -v "commit_output_assets" | grep -v "audit|phase5"
# → (empty)

# start_/commit_/abort_ only appear in explanatory note, not as advertised verbs
grep -n "start_\|commit_\|abort_" src/deriva_ml_mcp/prompts.py | grep -v "execution_stop|stop_execution"
# → line 592: explanatory note only
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)