### PR TITLE
feat: add deriva_ml_find_assets cross-table query tool (audit P1 #2)

### DIFF
--- a/src/deriva_ml_mcp/tools/asset.py
+++ b/src/deriva_ml_mcp/tools/asset.py
@@ -1,6 +1,7 @@
 """Asset domain tools for deriva-ml-mcp.
 
-Read tools: ``deriva_ml_list_assets``, ``deriva_ml_lookup_asset``.
+Read tools: ``deriva_ml_list_assets``, ``deriva_ml_find_assets``,
+``deriva_ml_lookup_asset``.
 Mutation tools: ``deriva_ml_update_asset``.
 
 Asset table discovery is exposed through the
@@ -324,6 +325,161 @@ def register(ctx: PluginContext) -> None:
             return _error_envelope(
                 exc,
                 operation="list_assets",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,
+            )
+
+    @ctx.tool(mutates=False)
+    async def deriva_ml_find_assets(
+        hostname: str,
+        catalog_id: str,
+        asset_type: str | None = None,
+        asset_table: str | None = None,
+        limit: int = 100,
+        after_rid: str | None = None,
+        preflight_count: bool = False,
+    ) -> str:
+        """Find assets across one or all asset tables, filtered by asset_type.
+
+        Cross-table query surface for the Python
+        ``DerivaML.find_assets`` method. Use this when you have an
+        identifying piece of info (``asset_type``) but don't know which
+        asset table to look in -- a single call discovers assets by
+        type across every asset table in the catalog, instead of
+        enumerating asset tables and issuing N parallel
+        ``deriva_ml_list_assets`` calls plus client-side filtering.
+
+        At least one of ``asset_type`` or ``asset_table`` must be set.
+        Calling with neither would return every asset in every asset
+        table, which is wasteful: use ``deriva_ml_list_assets`` per
+        table when you want the full contents of one table, or scope
+        this tool with an identifier when you want a focused search.
+
+        See ``deriva_ml_getting_started`` (PAGINATION CONTRACT) for the
+        two-step pagination flow.
+
+        ``asset_types`` field note: execution-linked assets carry an
+        auto-assigned ``Input_File`` or ``Output_File`` tag in
+        ``asset_types`` alongside any caller-supplied content tags
+        (per the deriva-ml ``Asset_Role`` contract; see
+        ``deriva_ml_concepts``). Filter with subset/any-of semantics,
+        not exact-set equality, when matching on content tags.
+
+        Args:
+            asset_type: Optional Asset_Type term name to filter by.
+                Only assets carrying this type are returned. If
+                ``asset_table`` is None this scans every asset table
+                in the catalog.
+            asset_table: Optional asset table name (e.g. ``"Image"``,
+                ``"Trained_Model"``). When set, restricts the search
+                to that one table -- shape-equivalent to
+                ``deriva_ml_list_assets(asset_table=...)`` with the
+                additional ``asset_type`` filter applied.
+            limit: Max assets per page (default 100, max 1000).
+            after_rid: RID of last row from previous page to advance
+                cursor.
+            preflight_count: If True, return only the total count.
+
+        Returns:
+            Page: ``{"assets": [{"rid", "filename", "length", "md5",
+            "asset_table", "asset_types"}, ...], "count", "truncated",
+            "next_after_rid"}``. The ``asset_table`` field on each row
+            identifies which asset table the asset came from -- the
+            information a caller needs to act on cross-table results.
+            Preflight: ``{"total_count", "entities_fetched": False,
+            "action_required"}``.
+
+        Raises:
+            RuntimeError: Wrapped as ``{"error": ...}``, propagated
+                from ``deriva_ml.DerivaML.find_assets`` (e.g. unknown
+                asset table or asset_type term). Validation errors
+                (neither identifier supplied) also return as
+                ``{"error": ...}``.
+
+        Example:
+            ``{"assets": [{"rid": "1-AAAA", "filename": "model.pt",
+            "length": 12345, "md5": "abc", "asset_table":
+            "Trained_Model", "asset_types": ["Model_File"]}, {"rid":
+            "1-BBBB", "filename": "v2.pt", "length": 9876, "md5":
+            "def", "asset_table": "Model_Variant", "asset_types":
+            ["Model_File"]}], "count": 2, "truncated": false,
+            "next_after_rid": null}``.
+        """
+        # Argument validation -- return error directly without audit.
+        if asset_type is None and asset_table is None:
+            return json.dumps(
+                {
+                    "error": (
+                        "at least one of asset_type or asset_table must be provided; "
+                        "to enumerate one asset table without a type filter use "
+                        "deriva_ml_list_assets(asset_table=...)"
+                    )
+                }
+            )
+        try:
+            with deriva_call():
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``ml.find_assets``
+                # returns a generator that materializes over the wire, so
+                # the drain (list/sorted) must happen inside the worker
+                # thread, not on the event loop. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                if preflight_count:
+
+                    def _count_found_assets() -> int:
+                        return len(
+                            list(
+                                ml.find_assets(
+                                    asset_table=asset_table,
+                                    asset_type=asset_type,
+                                )
+                            )
+                        )
+
+                    total = await asyncio.to_thread(_count_found_assets)
+                    scope = (
+                        f"asset_type={asset_type!r}"
+                        if asset_type is not None
+                        else f"asset_table={asset_table!r}"
+                    )
+                    return PreflightCountResponse(
+                        total_count=total,
+                        action_required=(
+                            f"Found {total} assets matching {scope}. "
+                            "Choose a limit and call again with "
+                            "preflight_count=False."
+                        ),
+                    ).model_dump_json(by_alias=True)
+
+                def _list_and_sort_found_assets() -> list[Any]:
+                    return sorted(
+                        ml.find_assets(
+                            asset_table=asset_table,
+                            asset_type=asset_type,
+                        ),
+                        key=lambda a: getattr(a, "asset_rid", "") or "",
+                    )
+
+                assets = await asyncio.to_thread(_list_and_sort_found_assets)
+                capped = min(max(limit, 0), _MAX_LIMIT)
+                page, truncated, next_after = _paginate(
+                    assets,
+                    after_rid=after_rid,
+                    limit=capped,
+                    key=partial(_read_rid, rid_key="asset_rid"),
+                )
+            return AssetListResponse(
+                assets=[_summarize_asset(a) for a in page],
+                count=len(page),
+                truncated=truncated,
+                next_after_rid=next_after,
+            ).model_dump_json(by_alias=True)
+        except Exception as exc:
+            return _error_envelope(
+                exc,
+                operation="find_assets",
                 hostname=hostname,
                 catalog_id=catalog_id,
                 audit=False,

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -133,6 +133,184 @@ async def test_list_assets_failure_returns_error_envelope(asset_ctx, capturing_m
 
 
 # ---------------------------------------------------------------------------
+# find_assets (cross-table query surface)
+#
+# Wraps DerivaML.find_assets(asset_table=None, asset_type=None). At
+# least one identifier is required at the MCP layer -- unfiltered scan
+# of every asset in every table is intentionally not exposed (use
+# deriva_ml_list_assets per table when you want the full contents of
+# one table).
+# ---------------------------------------------------------------------------
+
+
+async def test_find_assets_by_type_returns_matching_rows(asset_ctx, capturing_mcp, mock_ml):
+    """Happy path: asset_type filter passed through; results render
+    via the same _summarize_asset path as list_assets (sorted ascending
+    by RID).
+    """
+    mock_ml.find_assets.return_value = iter(
+        [
+            _make_asset_mock("1-BBBB", asset_table="Trained_Model", asset_types=["Model_File"]),
+            _make_asset_mock("1-AAAA", asset_table="Trained_Model", asset_types=["Model_File"]),
+        ]
+    )
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_assets"](
+            hostname="h", catalog_id="1", asset_type="Model_File"
+        )
+    )
+    assert out["count"] == 2
+    assert [a["rid"] for a in out["assets"]] == ["1-AAAA", "1-BBBB"]
+    assert {a["asset_table"] for a in out["assets"]} == {"Trained_Model"}
+    assert out["truncated"] is False
+    assert out["next_after_rid"] is None
+    mock_ml.find_assets.assert_called_with(asset_table=None, asset_type="Model_File")
+
+
+async def test_find_assets_cross_table_returns_rows_from_multiple_tables(
+    asset_ctx, capturing_mcp, mock_ml
+):
+    """Cross-table semantics: when the same asset_type is present in
+    two different asset tables, find_assets returns rows from both --
+    the per-row asset_table field tells the caller which table each
+    row came from.
+    """
+    mock_ml.find_assets.return_value = iter(
+        [
+            _make_asset_mock("1-AAAA", asset_table="Trained_Model", asset_types=["Model_File"]),
+            _make_asset_mock("1-CCCC", asset_table="Model_Variant", asset_types=["Model_File"]),
+            _make_asset_mock("1-BBBB", asset_table="Trained_Model", asset_types=["Model_File"]),
+        ]
+    )
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_assets"](
+            hostname="h", catalog_id="1", asset_type="Model_File"
+        )
+    )
+    assert out["count"] == 3
+    # Mixed tables surface in the per-row asset_table field.
+    tables_by_rid = {a["rid"]: a["asset_table"] for a in out["assets"]}
+    assert tables_by_rid == {
+        "1-AAAA": "Trained_Model",
+        "1-BBBB": "Trained_Model",
+        "1-CCCC": "Model_Variant",
+    }
+
+
+async def test_find_assets_empty_match_returns_empty_list_not_error(
+    asset_ctx, capturing_mcp, mock_ml
+):
+    """No matches => count=0, empty assets list, no error envelope."""
+    mock_ml.find_assets.return_value = iter([])
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_assets"](
+            hostname="h", catalog_id="1", asset_type="Missing_Type"
+        )
+    )
+    assert out["count"] == 0
+    assert out["assets"] == []
+    assert out["truncated"] is False
+    assert out["next_after_rid"] is None
+    assert "error" not in out
+
+
+async def test_find_assets_scoped_to_one_table(asset_ctx, capturing_mcp, mock_ml):
+    """asset_table without asset_type narrows the scan to one table."""
+    mock_ml.find_assets.return_value = iter(
+        [_make_asset_mock("1-AAAA", asset_table="Image")]
+    )
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_assets"](
+            hostname="h", catalog_id="1", asset_table="Image"
+        )
+    )
+    assert out["count"] == 1
+    assert out["assets"][0]["asset_table"] == "Image"
+    mock_ml.find_assets.assert_called_with(asset_table="Image", asset_type=None)
+
+
+async def test_find_assets_both_scoping_kwargs_are_forwarded(asset_ctx, capturing_mcp, mock_ml):
+    """asset_type + asset_table both honored -- the Python find_assets
+    signature accepts both simultaneously."""
+    mock_ml.find_assets.return_value = iter(
+        [_make_asset_mock("1-AAAA", asset_table="Trained_Model", asset_types=["Model_File"])]
+    )
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_assets"](
+            hostname="h",
+            catalog_id="1",
+            asset_type="Model_File",
+            asset_table="Trained_Model",
+        )
+    )
+    assert out["count"] == 1
+    mock_ml.find_assets.assert_called_with(
+        asset_table="Trained_Model", asset_type="Model_File"
+    )
+
+
+async def test_find_assets_validation_requires_one_identifier(
+    asset_ctx, capturing_mcp, mock_ml
+):
+    """Neither asset_type nor asset_table => validation error envelope,
+    no catalog call. Unfiltered cross-catalog scans are intentionally
+    not exposed."""
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_assets"](
+            hostname="h", catalog_id="1"
+        )
+    )
+    assert "error" in out
+    assert "at least one" in out["error"]
+    mock_ml.find_assets.assert_not_called()
+
+
+async def test_find_assets_pagination_truncates(asset_ctx, capturing_mcp, mock_ml):
+    """Standard cursor pagination: page filled => truncated=True,
+    next_after_rid = last RID of page."""
+    mock_ml.find_assets.return_value = iter(
+        [_make_asset_mock(f"1-{i:04d}", asset_table="Image", asset_types=["X"]) for i in range(5)]
+    )
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_assets"](
+            hostname="h", catalog_id="1", asset_type="X", limit=2
+        )
+    )
+    assert out["count"] == 2
+    assert out["truncated"] is True
+    assert out["next_after_rid"] == "1-0001"
+
+
+async def test_find_assets_preflight_count(asset_ctx, capturing_mcp, mock_ml):
+    """preflight_count returns total without rendering rows."""
+    mock_ml.find_assets.return_value = iter(
+        [_make_asset_mock(f"1-{i:04d}", asset_table="Image", asset_types=["X"]) for i in range(7)]
+    )
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_assets"](
+            hostname="h", catalog_id="1", asset_type="X", preflight_count=True
+        )
+    )
+    assert out["total_count"] == 7
+    assert out["entities_fetched"] is False
+    assert "asset_type" in out["action_required"]
+
+
+async def test_find_assets_failure_returns_error_envelope(asset_ctx, capturing_mcp, mock_ml):
+    """Read-only: a deriva-ml failure surfaces as {"error": ...} with
+    no audit emission."""
+    mock_ml.find_assets.side_effect = RuntimeError("Model_File: term not found")
+    with _patch_asset_audit() as mock_audit:
+        out = json.loads(
+            await capturing_mcp.tools["deriva_ml_find_assets"](
+                hostname="h", catalog_id="1", asset_type="Model_File"
+            )
+        )
+    assert out == {"error": "Model_File: term not found"}
+    assert mock_audit.call_count == 0
+
+
+# ---------------------------------------------------------------------------
 # lookup_asset
 # ---------------------------------------------------------------------------
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -102,15 +102,19 @@ _EXECUTION_TOOLS = frozenset(
     }
 )
 
-# Asset domain -- 3 tools (2 read + 1 metadata-mutation). File I/O is
+# Asset domain -- 4 tools (3 read + 1 metadata-mutation). File I/O is
 # intentionally NOT covered here; that lives in the deriva-skills
 # `work-with-assets` skill which generates Python the user runs locally.
 # Asset table discovery moved to the ``ml/assets/{schema}`` resource in
 # v3.4; the ``deriva_ml_list_asset_tables`` tool was retired alongside
-# the ``ml/asset-tables`` resource.
+# the ``ml/asset-tables`` resource. ``find_assets`` surfaces the
+# cross-table ``DerivaML.find_assets`` API as a single MCP call --
+# alternative to enumerating asset tables then issuing N
+# ``list_assets`` calls plus client-side filtering.
 _ASSET_TOOLS = frozenset(
     {
         "deriva_ml_list_assets",
+        "deriva_ml_find_assets",
         "deriva_ml_lookup_asset",
         "deriva_ml_update_asset",
     }


### PR DESCRIPTION
## Summary

Adds ``deriva_ml_find_assets`` — a single MCP call that surfaces the
existing ``DerivaML.find_assets`` Python method as a cross-table
asset query. Closes audit **P1 #2** from
``docs/audits/2026-05-24-parity-audit-v1.39.md`` (Category 1:
public-API coverage).

Today's per-table-only ``deriva_ml_list_assets`` forces a caller
asking *"find all Model_File assets across every asset table"* into a
three-step ritual:

1. Enumerate asset tables via the
   ``deriva://catalog/{h}/{c}/ml/assets/{schema}`` resource (per
   schema).
2. Issue N parallel ``deriva_ml_list_assets`` calls (one per asset
   table).
3. Filter client-side on ``asset_type``.

The new tool collapses this into one call: the cross-table walk
happens inside ``DerivaML.find_assets``, and the result page carries
the per-row ``asset_table`` field so callers can tell which table each
match came from.

### Design notes

- **Name** follows the MCP wire convention: ``find_*`` = "I have an
  identifying piece of info but not the RID." ``asset_type`` is the
  identifier (audit Category 5).
- **Required scoping.** At least one of ``asset_type`` or
  ``asset_table`` must be set. An unfiltered scan across every asset
  in every table is wasteful and is intentionally not exposed; the
  validation error envelope tells the caller to use
  ``deriva_ml_list_assets(asset_table=...)`` when they want the full
  contents of one table.
- **Reuses existing response models** unchanged. ``AssetSummary``
  already carries ``asset_table`` per row, so no new Pydantic model
  was needed — cross-table results are self-identifying.
- **Pagination** follows the standard ``_paginate`` +
  ``_read_rid(rid_key="asset_rid")`` cursor pattern shared with
  ``list_assets``. ``asset_type="Model_File"`` can legitimately
  return thousands of rows; preflight + cursor pages are honored.
- **``mutates=False``** — read tool. Failures route through
  ``_error_envelope`` with no audit emission, same as
  ``list_assets`` / ``lookup_asset``.

### Files changed

- ``src/deriva_ml_mcp/tools/asset.py``: new
  ``deriva_ml_find_assets`` tool plus module-docstring update.
- ``tests/test_plugin.py``: register the new tool in the
  ``_ASSET_TOOLS`` frozenset (the exact-equality gate in
  ``test_all_registered_tools_exact``).
- ``tests/test_asset.py``: 9 new tests covering happy path,
  cross-table semantics, empty match, scope variants, validation,
  pagination, preflight, and failure envelope.

No changes to ``_response_models.py`` were required.

## Test plan

- [x] ``DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/test_asset.py
      tests/test_plugin.py -v`` — 38 passing (29 pre-existing + 9
      new).
- [x] ``uv run ruff check src/ tests/`` — clean.
- [ ] Integration smoke against a real catalog (deferred to the
      caller's next session — the change is shape-equivalent to the
      well-tested ``list_assets`` path; the Python ``find_assets``
      method itself has unit and integration coverage in
      ``deriva-ml``).

## Scope

This PR is intentionally scoped to one audit finding (P1 #2). PR 1
covers the prompts surface; PR 3 covers the un-Pydantic'd
``list_feature_values`` / ``denormalize_dataset`` returns.