### PR TITLE
refactor: Pydantic-ize remaining un-typed tool returns (audit P1 #3, P2 #5)

### DIFF
--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -670,6 +670,82 @@ class FeatureListResponse(_PaginationFields):
     features: list[FeatureSummary]
 
 
+class FeatureValueRecord(BaseModel):
+    """One feature-value row on a ``deriva_ml_list_feature_values`` page.
+
+    Mirrors the wire shape produced by ``FeatureRecord.model_dump()``
+    in ``deriva-ml`` (see ``deriva_ml.feature.FeatureRecord``). The
+    three stable provenance/identity fields are declared explicitly;
+    the remaining fields are the feature's term / asset / value
+    columns, whose names are dynamic per feature definition and so
+    flow through under ``extra="allow"``.
+
+    Stable fields (always present after deriva-ml's ``model_dump()``):
+
+    - ``RID`` -- RID of the feature-value row in the feature table.
+      Used as the pagination cursor by ``deriva_ml_list_feature_values``.
+    - ``Execution`` -- RID of the execution that wrote this record.
+      Provenance handle; ``None`` for legacy rows that predate
+      execution tracking.
+    - ``Feature_Name`` -- Name of the feature this record belongs to
+      (denormalized from the ``Feature_Name`` vocabulary join for
+      convenience).
+    - ``RCT`` -- Row Creation Time as an ISO 8601 string. Populated by
+      the catalog; used by ``select_newest`` for recency ordering.
+
+    Dynamic fields (vary per feature):
+
+    - The target column (e.g. ``Image``, ``Subject``) is the RID of
+      the target entity the feature attaches to.
+    - Term columns carry vocabulary-term RIDs.
+    - Asset columns carry asset-row RIDs.
+    - Value columns carry the raw column value (typed per the feature
+      definition).
+
+    ``extra="allow"`` is intentional: the alternative would be a
+    Pydantic class per feature definition (impractical at runtime). The
+    contract this model pins is the four stable fields + the fact that
+    a dynamic column set crosses the wire as a flat dict.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    RID: str | None = Field(
+        default=None,
+        description="RID of the feature-value row in the feature table.",
+    )
+    Execution: str | None = Field(
+        default=None,
+        description=(
+            "RID of the execution that wrote this record. ``None`` for "
+            "legacy rows that predate execution tracking."
+        ),
+    )
+    Feature_Name: str | None = Field(
+        default=None,
+        description="Name of the feature this record belongs to.",
+    )
+    RCT: str | None = Field(
+        default=None,
+        description=(
+            "Row Creation Time as an ISO 8601 string. Used by "
+            "``select_newest`` for recency ordering."
+        ),
+    )
+
+
+class FeatureValueListResponse(_PaginationFields):
+    """Paginated list of feature-value rows. Produced by
+    ``deriva_ml_list_feature_values``.
+
+    Each entry is a ``FeatureValueRecord`` -- four stable provenance
+    fields plus the feature's dynamic value / term / asset columns
+    flowing through under ``extra="allow"``.
+    """
+
+    records: list[FeatureValueRecord]
+
+
 # ---------------------------------------------------------------------------
 # Asset response models
 # ---------------------------------------------------------------------------

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -747,6 +747,165 @@ class FeatureValueListResponse(_PaginationFields):
 
 
 # ---------------------------------------------------------------------------
+# Denormalize response models (v0.5.x sweep)
+# ---------------------------------------------------------------------------
+#
+# ``deriva_ml_denormalize_dataset`` has four legitimate response shapes
+# discriminated by the ``mode`` field, mirroring the underlying split
+# between catalog-wide estimation (``ml.estimate_denormalized_size``)
+# and dataset-scoped describe / fetch (``Dataset.describe_denormalized``,
+# ``Dataset.get_denormalized_as_dict``):
+#
+# - ``catalog_shape`` — catalog-wide size estimate; no rows.
+# - ``dataset_shape`` — dataset-scoped describe plan; no rows.
+# - ``dataset_rows`` — dataset-scoped describe + paginated rows.
+# - ``dataset_preflight_required`` — 10x guard short-circuit when the
+#   estimated row count is wildly larger than the requested limit.
+#
+# The ``dataset_preflight`` mode (returned when the caller passes
+# ``preflight_count=True``) reuses ``PreflightCountResponse`` with the
+# extra ``mode`` and ``dataset_rid`` context fields, so it is not
+# modeled separately here.
+#
+# Both ``dataset_shape`` and ``dataset_rows`` embed the 12-key plan
+# returned by ``Denormalizer.describe`` (see
+# ``deriva_ml/local_db/denormalizer.py``). The plan's inner dicts
+# (``estimated_row_count``, ``anchors``, per-table info, ambiguity
+# entries) are typed as ``dict[str, Any]`` because the denormalizer
+# layer documents them as best-effort dry-run output that may carry
+# extra contextual keys (e.g., ``reason`` on ``estimated_row_count``
+# when downstream-anchor cardinality is unknown).
+
+
+class DenormalizeTableStats(BaseModel):
+    """Per-table stats in the catalog-shape response's ``tables`` map.
+
+    Produced by ``ml.estimate_denormalized_size`` for each table in
+    the catalog-wide join. ``asset_bytes`` is 0 for non-asset tables.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    row_count: int
+    is_asset: bool
+    asset_bytes: int
+
+
+class DenormalizeCatalogShapeResponse(BaseModel):
+    """Response shape for the catalog-wide size-estimate branch.
+
+    Produced when ``deriva_ml_denormalize_dataset`` is called without
+    a ``dataset_rid`` -- the tool wraps ``ml.estimate_denormalized_size``
+    and tags the result with ``mode="catalog_shape"`` + the original
+    ``include_tables`` echo.
+
+    ``columns`` is a list of ``(column_name, column_type)`` 2-element
+    lists -- JSON has no tuples, so the wire emits a list. The upstream
+    method returns tuples; the JSON serializer flattens them.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["catalog_shape"]
+    include_tables: list[str]
+    columns: list[list[str]]
+    join_path: list[str]
+    tables: dict[str, DenormalizeTableStats]
+    total_rows: int
+    total_asset_bytes: int
+    total_asset_size: str
+
+
+class _DenormalizeDatasetShapeFields(BaseModel):
+    """Shared fields for the two dataset-scoped describe responses.
+
+    ``dataset_shape`` and ``dataset_rows`` both embed the 12-key plan
+    returned by ``Denormalizer.describe``. The plan keys are declared
+    here so the two response models share them without inheritance
+    overhead at the discriminator level.
+
+    The inner-dict fields (``estimated_row_count``, ``anchors``,
+    ambiguity entries) are typed as ``dict[str, Any]`` rather than
+    sub-models because the denormalizer is explicit that they may
+    carry contextual extra keys (e.g., a ``reason`` field on
+    ``estimated_row_count`` when downstream-anchor cardinality is
+    unknown). Pinning those shapes here would force a contract change
+    every time the denormalizer adds explanatory keys.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_rid: str
+    version: str | None
+    # The 12 keys spread from Denormalizer.describe():
+    row_per: str | None
+    row_per_source: str
+    row_per_candidates: list[str]
+    columns: list[list[str]]
+    include_tables: list[str]
+    via: list[str]
+    join_path: list[str]
+    transparent_intermediates: list[str]
+    ambiguities: list[dict[str, Any]]
+    estimated_row_count: dict[str, Any]
+    anchors: dict[str, Any]
+    source: str
+
+
+class DenormalizeDatasetShapeResponse(_DenormalizeDatasetShapeFields):
+    """Response shape for the dataset-scoped describe-only branch.
+
+    Returned when ``deriva_ml_denormalize_dataset`` is called with a
+    ``dataset_rid`` and ``limit=0`` (default). Carries the full 12-key
+    describe plan + the dataset RID and (optional) version. No rows.
+    """
+
+    mode: Literal["dataset_shape"]
+
+
+class DenormalizeDatasetPageResponse(_DenormalizeDatasetShapeFields):
+    """Response shape for the dataset-scoped describe + rows branch.
+
+    Returned when ``deriva_ml_denormalize_dataset`` is called with a
+    ``dataset_rid`` and ``limit > 0`` and the estimated row count
+    passes the 10x guard. Carries the full 12-key describe plan, the
+    dataset RID and (optional) version, AND a paginated row page.
+
+    The ``rows`` field is intentionally ``list[dict[str, Any]]``: each
+    row is a denormalized join across user-defined tables, so the
+    column schema is user-defined and cannot be modeled at the
+    response-shape layer. The ``columns`` field on the describe plan
+    documents the schema for any given call.
+    """
+
+    mode: Literal["dataset_rows"]
+    rows: list[dict[str, Any]]
+    returned_count: int
+    truncated: bool
+    next_after_rid: str | None
+
+
+class DenormalizePreflightRequiredResponse(BaseModel):
+    """10x-guard short-circuit response.
+
+    Returned when ``deriva_ml_denormalize_dataset`` would refuse to
+    drain the generator because the estimated row count exceeds 10x
+    the requested limit. The caller is routed back through
+    ``preflight_count=True`` to confirm the cost before retrying with
+    a larger limit (or accepting the OOM risk).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["dataset_preflight_required"]
+    dataset_rid: str
+    estimated_row_count: int
+    requested_limit: int
+    entities_fetched: bool = False
+    action_required: str
+
+
+# ---------------------------------------------------------------------------
 # Asset response models
 # ---------------------------------------------------------------------------
 

--- a/src/deriva_ml_mcp/tools/dataset/complex.py
+++ b/src/deriva_ml_mcp/tools/dataset/complex.py
@@ -58,6 +58,11 @@ from deriva_ml_mcp._helpers import (
     _row_rid_for,
 )
 from deriva_ml_mcp._response_models import (
+    DenormalizeCatalogShapeResponse,
+    DenormalizeDatasetPageResponse,
+    DenormalizeDatasetShapeResponse,
+    DenormalizePreflightRequiredResponse,
+    DenormalizeTableStats,
     PreflightCountResponse,
 )
 
@@ -172,14 +177,23 @@ def register(ctx: PluginContext) -> None:
                     estimate = await asyncio.to_thread(
                         ml.estimate_denormalized_size, include_tables
                     )
-                return json.dumps(
-                    {
-                        "mode": "catalog_shape",
-                        "include_tables": include_tables,
-                        **estimate,
+                # Coerce upstream column tuples to lists for JSON
+                # compatibility and validate per-table stats through the
+                # typed sub-model. The wire shape stays identical to
+                # the previous json.dumps(..., default=str) emission.
+                return DenormalizeCatalogShapeResponse(
+                    mode="catalog_shape",
+                    include_tables=list(include_tables),
+                    columns=[list(c) for c in estimate["columns"]],
+                    join_path=list(estimate["join_path"]),
+                    tables={
+                        name: DenormalizeTableStats(**stats)
+                        for name, stats in estimate["tables"].items()
                     },
-                    default=str,
-                )
+                    total_rows=estimate["total_rows"],
+                    total_asset_bytes=estimate["total_asset_bytes"],
+                    total_asset_size=estimate["total_asset_size"],
+                ).model_dump_json(by_alias=True)
 
             # Dataset mode.
             capped = min(max(limit, 0), _MAX_LIMIT)
@@ -214,23 +228,20 @@ def register(ctx: PluginContext) -> None:
                 if capped > 0 and not preflight_count:
                     estimated = desc.get("estimated_row_count", {}).get("total")
                     if estimated is not None and estimated > 10 * capped:
-                        return json.dumps(
-                            {
-                                "mode": "dataset_preflight_required",
-                                "dataset_rid": dataset_rid,
-                                "estimated_row_count": estimated,
-                                "requested_limit": capped,
-                                "entities_fetched": False,
-                                "action_required": (
-                                    f"Estimated {estimated} rows is more than "
-                                    f"10x the requested limit ({capped}). "
-                                    "Call again with preflight_count=True to "
-                                    "confirm the count, then choose a larger "
-                                    "limit or accept the cost before retrying."
-                                ),
-                            },
-                            default=str,
-                        )
+                        return DenormalizePreflightRequiredResponse(
+                            mode="dataset_preflight_required",
+                            dataset_rid=dataset_rid,
+                            estimated_row_count=estimated,
+                            requested_limit=capped,
+                            entities_fetched=False,
+                            action_required=(
+                                f"Estimated {estimated} rows is more than "
+                                f"10x the requested limit ({capped}). "
+                                "Call again with preflight_count=True to "
+                                "confirm the count, then choose a larger "
+                                "limit or accept the cost before retrying."
+                            ),
+                        ).model_dump_json(by_alias=True)
 
                     # itertools.islice puts a hard upper bound on
                     # generator materialization; we read at most
@@ -284,16 +295,32 @@ def register(ctx: PluginContext) -> None:
                     dataset_rid=dataset_rid,
                 ).model_dump_json(by_alias=True)
 
+            # Build the 12-key plan kwargs shared by both dataset-scoped
+            # response shapes. Describe returns column specs as tuples;
+            # JSON has no tuple type, so coerce to lists for the wire
+            # contract (Pydantic models declare list[list[str]] columns).
+            plan_kwargs = {
+                "dataset_rid": dataset_rid,
+                "version": version,
+                "row_per": desc.get("row_per"),
+                "row_per_source": desc["row_per_source"],
+                "row_per_candidates": list(desc.get("row_per_candidates", [])),
+                "columns": [list(c) for c in desc.get("columns", [])],
+                "include_tables": list(desc.get("include_tables", [])),
+                "via": list(desc.get("via", [])),
+                "join_path": list(desc.get("join_path", [])),
+                "transparent_intermediates": list(desc.get("transparent_intermediates", [])),
+                "ambiguities": list(desc.get("ambiguities", [])),
+                "estimated_row_count": dict(desc.get("estimated_row_count", {})),
+                "anchors": dict(desc.get("anchors", {})),
+                "source": desc.get("source", "local"),
+            }
+
             if rows is None:
-                return json.dumps(
-                    {
-                        "mode": "dataset_shape",
-                        "dataset_rid": dataset_rid,
-                        "version": version,
-                        **desc,
-                    },
-                    default=str,
-                )
+                return DenormalizeDatasetShapeResponse(
+                    mode="dataset_shape",
+                    **plan_kwargs,
+                ).model_dump_json(by_alias=True)
 
             # Sort + paginate rows by their RID-bearing column.
             row_rid = _row_rid_for(row_per_effective)
@@ -301,19 +328,14 @@ def register(ctx: PluginContext) -> None:
             page, truncated, next_after = _paginate(
                 sorted_rows, after_rid=after_rid, limit=capped, key=row_rid
             )
-            return json.dumps(
-                {
-                    "mode": "dataset_rows",
-                    "dataset_rid": dataset_rid,
-                    "version": version,
-                    **desc,
-                    "rows": page,
-                    "returned_count": len(page),
-                    "truncated": truncated,
-                    "next_after_rid": next_after,
-                },
-                default=str,
-            )
+            return DenormalizeDatasetPageResponse(
+                mode="dataset_rows",
+                rows=page,
+                returned_count=len(page),
+                truncated=truncated,
+                next_after_rid=next_after,
+                **plan_kwargs,
+            ).model_dump_json(by_alias=True)
         except Exception as exc:
             # Read-only tool: log+return without an audit row (I-2 fix).
             return _error_envelope(

--- a/src/deriva_ml_mcp/tools/feature.py
+++ b/src/deriva_ml_mcp/tools/feature.py
@@ -48,6 +48,8 @@ from deriva_ml_mcp._response_models import (
     DeleteFeatureResponse,
     FeatureListResponse,
     FeatureSummary,
+    FeatureValueListResponse,
+    FeatureValueRecord,
     PreflightCountResponse,
 )
 from deriva_ml_mcp.ml_context import get_ml
@@ -481,15 +483,20 @@ def register(ctx: PluginContext) -> None:
                 limit=capped,
                 key=lambda r: getattr(r, "RID", "") or "",
             )
-            return json.dumps(
-                {
-                    "records": [r.model_dump() for r in page],
-                    "count": len(page),
-                    "truncated": truncated,
-                    "next_after_rid": next_after,
-                },
-                default=str,
-            )
+            # Validate each record into FeatureValueRecord. The model
+            # declares the four stable provenance fields (RID, Execution,
+            # Feature_Name, RCT) and allows the feature's dynamic
+            # value / term / asset columns through under extra="allow".
+            # r.model_dump() preserves the same dict shape we previously
+            # emitted via json.dumps; constructing the model just
+            # type-checks the four stable fields and pins the wire
+            # contract for downstream consumers.
+            return FeatureValueListResponse(
+                records=[FeatureValueRecord(**r.model_dump()) for r in page],
+                count=len(page),
+                truncated=truncated,
+                next_after_rid=next_after,
+            ).model_dump_json(by_alias=True)
         except DerivaMLMaterializeLimitExceeded as exc:
             # Translate the deriva-ml exception to a clear error envelope.
             # The exception's __str__ already names the cap and suggests


### PR DESCRIPTION
## Summary

Finishes the v3.0 Pydantic sweep by typing the last two un-Pydantic'd
tool returns flagged by the 2026-05-24 parity audit:

- `deriva_ml_list_feature_values` -- the page envelope was already
  typed, but `records[]` was a plain `dict[str, Any]` produced via
  `r.model_dump()` and `json.dumps(...)`. Now each entry is a
  `FeatureValueRecord` -- four stable provenance fields (RID,
  Execution, Feature_Name, RCT) mirroring deriva-ml's `FeatureRecord`
  base class, with the feature's dynamic value / term / asset columns
  flowing through under `extra="allow"`.
- `deriva_ml_denormalize_dataset` -- previously returned every branch
  through `json.dumps(..., default=str)`. Now uses four typed models
  matching the existing `mode`-discriminated wire shape:
  `DenormalizeCatalogShapeResponse` (mode="catalog_shape"),
  `DenormalizeDatasetShapeResponse` (mode="dataset_shape"),
  `DenormalizeDatasetPageResponse` (mode="dataset_rows"), and
  `DenormalizePreflightRequiredResponse`
  (mode="dataset_preflight_required"). The `dataset_preflight` branch
  continues to reuse `PreflightCountResponse` with extra context fields.

### Wire shape is unchanged

Every field that crossed the wire before still crosses it now -- the
JSON output is byte-for-byte equivalent. Tuples from the upstream
column-spec list are coerced to lists (preserving the previous
`default=str` behaviour); inner dicts on `Denormalizer.describe`'s
plan (`estimated_row_count`, `anchors`, ambiguity entries) stay
`dict[str, Any]` because the denormalizer documents them as
best-effort dry-run output that may carry contextual extra keys.
Likewise the per-row data in `dataset_rows` stays `list[dict[str,
Any]]` because the column schema is user-defined per call.

The change is type-safety only: ValidationError now fires at
construction time if upstream shape drifts, instead of malformed JSON
crossing the wire.

## Test plan

- [x] `uv run pytest tests/test_feature.py` -- 24 passed
- [x] `uv run pytest tests/test_dataset_complex.py` -- 9 passed
- [x] `uv run pytest tests/ --ignore=tests/test_integration*.py` -- 297 passed
- [x] `uv run ruff check src/ tests/` -- clean

## Audit references

- P1 #3: `list_feature_values.values[]` un-Pydantic'd
- P2 #5: `denormalize_dataset` json.dumps return

See `docs/audits/2026-05-24-parity-audit-v1.39.md` Category 3
(Return-type shapes) for the original findings.