### PR TITLE
chore: P2 hygiene sweep (audit findings #3, #4, #7, #11, #13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -655,22 +655,23 @@ deriva-docker workflow.
 
   **PR #28 (`fix(complex): wrap sync deriva-ml calls in asyncio.to_thread`)**
   fixed this in `tools/dataset/complex.py` for the three known-slow tools
-  (`cache_dataset`, `denormalize_dataset`, `split_dataset`). It did **not**
-  cover the other tool modules (`asset.py`, `feature.py`, `maintenance.py`,
-  `workflow.py`, `dataset/mutate.py`, `dataset/read.py`,
-  `execution/mutate.py`, `execution/read.py`). All of those still need
-  the `asyncio.to_thread` wrapping; until they do, the same symptom
-  recurs intermittently for any of their tools that hit non-trivial
-  catalog work.
+  (`cache_dataset`, `denormalize_dataset`, `split_dataset`). Subsequent
+  passes extended the wrapping to every remaining tool module
+  (`asset.py`, `feature.py`, `maintenance.py`, `workflow.py`,
+  `dataset/mutate.py`, `dataset/read.py`, `execution/read.py`, and
+  `resources/ml.py`). As of the P2 hygiene sweep (2026-05-24), the AST
+  test in `tests/test_async_thread_wrap.py` confirms **all modules are
+  clean** — no unwrapped sync deriva-ml call exists inside any
+  `with deriva_call():` block in any checked module.
 
   **The lesson — for plugin design.** Async-defined tools that call sync
   libraries are a footgun. The rule must be applied uniformly the first
   time, not retrofitted module-by-module. When adding a new tool, the
   template should already include `asyncio.to_thread`; when reviewing a
   PR that adds a tool, the absence of `asyncio.to_thread` around any
-  sync deriva-ml/deriva-py call is a blocking review comment. PR #28's
-  scoping (one module out of nine) is the failure mode this rule guards
-  against.
+  sync deriva-ml/deriva-py call is a blocking review comment.
+  `tests/test_async_thread_wrap.py` enforces the rule structurally so
+  CI catches regressions automatically.
 
 ## Spec & Plan
 

--- a/src/deriva_ml_mcp/_response_models.py
+++ b/src/deriva_ml_mcp/_response_models.py
@@ -340,16 +340,6 @@ class WorkflowSummary(BaseModel):
     description: str | None
 
 
-class WorkflowDetail(WorkflowSummary):
-    """Full Workflow detail. Produced by ``_get_workflow_impl``.
-
-    Currently shape-identical to ``WorkflowSummary`` (Workflows have
-    no extra detail-only fields today). Kept as a separate type so
-    detail-only fields can be added in future without touching the
-    summary shape.
-    """
-
-
 class WorkflowListResponse(_PaginationFields):
     """Paginated list of Workflows. Produced by ``_list_workflows_impl``."""
 

--- a/src/deriva_ml_mcp/tools/dataset/mutate.py
+++ b/src/deriva_ml_mcp/tools/dataset/mutate.py
@@ -251,6 +251,7 @@ def register(ctx: PluginContext) -> None:
         members_by_table: dict[str, list[str]] | None = None,
         description: str = "",
         execution_rid: str | None = None,
+        validate: bool = True,
     ) -> str:
         """Add records (or whole datasets) as members of a dataset.
 
@@ -276,6 +277,10 @@ def register(ctx: PluginContext) -> None:
                 row's ``Description`` column. **Replaces** any prior
                 dev-period description rather than appending.
             execution_rid: Optional execution to attribute the change to.
+            validate: If True (default), validates that the member RIDs
+                exist in the catalog before inserting. Pass False to skip
+                validation for bulk inserts where RID existence is
+                already confirmed, trading safety for throughput.
 
         Returns:
             JSON string ``{"status": "added", "added_count",
@@ -323,6 +328,7 @@ def register(ctx: PluginContext) -> None:
                 await asyncio.to_thread(
                     ds.add_dataset_members,
                     members=members,
+                    validate=validate,
                     description=description,
                     execution_rid=execution_rid,
                 )

--- a/src/deriva_ml_mcp/tools/execution/read.py
+++ b/src/deriva_ml_mcp/tools/execution/read.py
@@ -753,6 +753,121 @@ def register(ctx: PluginContext) -> None:
             )
 
     @ctx.tool(mutates=False)
+    async def deriva_ml_find_experiments(
+        hostname: str,
+        catalog_id: str,
+        workflow_rid: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        after_rid: str | None = None,
+        preflight_count: bool = False,
+    ) -> str:
+        """Find executions that are Hydra-driven experiments.
+
+        Returns executions that have a Hydra configuration asset
+        (``*-config.yaml`` in ``Execution_Metadata``). Experiment
+        detail (``config_choices``, ``model_config``) is available
+        per-execution via ``deriva_ml_get_execution`` followed by
+        inspecting the ``experiment`` field on the detail payload.
+
+        Returns execution summaries in the same shape as
+        ``deriva_ml_list_executions`` -- the two can be used
+        interchangeably by callers that only need summary fields.
+
+        Args:
+            workflow_rid: If set, restrict to experiments of this workflow
+                (by RID).
+            status: If set, restrict to one ``ExecutionStatus`` value
+                (e.g. ``"Uploaded"``, ``"Stopped"``).
+            limit: Max experiments per page (default 100, max 1000).
+            after_rid: RID of last row from previous page to advance
+                cursor.
+            preflight_count: If True, return only the total count.
+
+        Returns:
+            Page: ``{"executions": [...], "count", "truncated",
+            "next_after_rid"}``. Preflight: ``{"total_count",
+            "entities_fetched": False, "action_required"}``.
+
+        Raises:
+            RuntimeError: Wrapped, propagated from
+                ``deriva_ml.DerivaML.find_experiments`` or
+                ``ExecutionStatus`` parsing.
+
+        Example:
+            ``{"executions": [{"rid": "1-EXEC", "workflow_rid":
+            "1-WF", "status": "Uploaded", ...}], "count": 2,
+            "truncated": false, "next_after_rid": null}``.
+        """
+        try:
+            with deriva_call():
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``ml.find_experiments``
+                # performs catalog I/O to scan Execution_Metadata for
+                # config files. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                status_enum = ExecutionStatus(status) if status else None
+
+                if preflight_count:
+
+                    def _count_experiments() -> int:
+                        return len(
+                            list(ml.find_experiments(workflow_rid=workflow_rid, status=status_enum))
+                        )
+
+                    total = await asyncio.to_thread(_count_experiments)
+                    return PreflightCountResponse(
+                        total_count=total,
+                        action_required=(
+                            f"Found {total} experiments. Choose a limit and call "
+                            "again with preflight_count=False."
+                        ),
+                    ).model_dump_json(by_alias=True)
+
+                def _drain_experiments() -> list[Any]:
+                    # Drain into ExecutionRecord objects without triggering
+                    # the lazy Experiment.hydra_config download (which
+                    # fetches YAML from Hatrac and violates the MCP
+                    # stateless/bounded-resource rule). We resolve each
+                    # experiment to its ExecutionRecord so _summarize_execution
+                    # can build a summary without any file I/O.
+                    return [
+                        ml.lookup_execution(exp.execution_rid)
+                        for exp in ml.find_experiments(
+                            workflow_rid=workflow_rid, status=status_enum
+                        )
+                    ]
+
+                records = await asyncio.to_thread(_drain_experiments)
+
+            records_sorted = sorted(
+                records,
+                key=lambda e: getattr(e, "execution_rid", "") or "",
+            )
+            capped = min(max(limit, 0), _MAX_LIMIT)
+            page, truncated, next_after = _paginate(
+                records_sorted,
+                after_rid=after_rid,
+                limit=capped,
+                key=partial(_read_rid, rid_key="execution_rid"),
+            )
+            return ExecutionListResponse(
+                executions=[_summarize_execution(r) for r in page],
+                count=len(page),
+                truncated=truncated,
+                next_after_rid=next_after,
+            ).model_dump_json(by_alias=True)
+        except Exception as exc:
+            return _error_envelope(
+                exc,
+                operation="find_experiments",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,
+            )
+
+    @ctx.tool(mutates=False)
     async def deriva_ml_get_lineage(
         hostname: str,
         catalog_id: str,

--- a/src/deriva_ml_mcp/tools/workflow.py
+++ b/src/deriva_ml_mcp/tools/workflow.py
@@ -45,7 +45,6 @@ from deriva_ml_mcp._response_models import (
     CreateWorkflowResponse,
     PreflightCountResponse,
     UpdateWorkflowResponse,
-    WorkflowDetail,
     WorkflowListResponse,
     WorkflowSummary,
 )
@@ -132,7 +131,7 @@ def _list_workflows_impl(
     )
 
 
-def _get_workflow_impl(ml: Any, workflow_rid: str) -> WorkflowDetail:
+def _get_workflow_impl(ml: Any, workflow_rid: str) -> WorkflowSummary:
     """Read one workflow's full summary.
 
     Args:
@@ -140,12 +139,15 @@ def _get_workflow_impl(ml: Any, workflow_rid: str) -> WorkflowDetail:
         workflow_rid: The RID of the workflow to look up.
 
     Returns:
-        ``WorkflowDetail`` -- see ``deriva_ml_mcp._response_models``.
-        (Currently shape-equivalent to ``WorkflowSummary``.)
+        ``WorkflowSummary`` -- see ``deriva_ml_mcp._response_models``.
+        The ``WorkflowDetail`` wrapper type was retired in the P2
+        hygiene sweep because it was shape-identical to
+        ``WorkflowSummary`` and had no detail-only fields.
+        Resources that previously returned ``WorkflowDetail`` now
+        return ``WorkflowSummary`` directly (same wire shape).
     """
     wf = ml.lookup_workflow(workflow_rid)
-    summary = _summarize_workflow(wf)
-    return WorkflowDetail(**summary.model_dump())
+    return _summarize_workflow(wf)
 
 
 def register(ctx: PluginContext) -> None:

--- a/tests/test_dataset_mutate.py
+++ b/tests/test_dataset_mutate.py
@@ -198,7 +198,7 @@ async def test_add_dataset_members_with_list(dataset_ctx, capturing_mcp, mock_ml
     assert out["dataset_rid"] == "1-AAAA"
     assert out["new_version"] == "1.1.0"
     ds.add_dataset_members.assert_called_once_with(
-        members=["r1", "r2", "r3"], description="adding three", execution_rid="EXEC-1"
+        members=["r1", "r2", "r3"], validate=True, description="adding three", execution_rid="EXEC-1"
     )
     success = _success_calls(mock_audit, "deriva_ml_add_dataset_members")
     assert success

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -482,3 +482,68 @@ async def test_get_lineage_error_path_workflow_rid(execution_ctx, capturing_mcp,
     assert mock_audit.call_count == 0
 
 
+# ---------------------------------------------------------------------------
+# find_experiments (P2 hygiene sweep)
+# ---------------------------------------------------------------------------
+
+
+async def test_find_experiments_happy_path(execution_ctx, capturing_mcp, mock_ml):
+    """``deriva_ml_find_experiments`` returns execution summaries for
+    executions that have Hydra config assets.
+
+    The tool calls ``ml.find_experiments()`` (catalog scan for
+    ``*-config.yaml`` in Execution_Metadata), then resolves each
+    ``Experiment.execution_rid`` via ``ml.lookup_execution`` to build
+    the summary. The response shape is the same as
+    ``deriva_ml_list_executions``.
+    """
+    exp_a = MagicMock()
+    exp_a.execution_rid = "1-EXPA"
+    exp_b = MagicMock()
+    exp_b.execution_rid = "1-EXPB"
+
+    mock_ml.find_experiments.return_value = [exp_a, exp_b]
+    mock_ml.lookup_execution.side_effect = lambda rid: _make_execution_record_mock(
+        rid=rid, status=ExecutionStatus.Uploaded
+    )
+
+    result = await capturing_mcp.tools["deriva_ml_find_experiments"](
+        hostname="h", catalog_id="1"
+    )
+    out = json.loads(result)
+
+    assert out["count"] == 2
+    assert out["truncated"] is False
+    rids = [e["rid"] for e in out["executions"]]
+    assert "1-EXPA" in rids
+    assert "1-EXPB" in rids
+    assert all(e["status"] == "Uploaded" for e in out["executions"])
+    mock_ml.find_experiments.assert_called_once_with(workflow_rid=None, status=None)
+
+
+async def test_find_experiments_preflight_count(execution_ctx, capturing_mcp, mock_ml):
+    """``preflight_count=True`` returns ``{"total_count": N, ...}``."""
+    exp = MagicMock()
+    exp.execution_rid = "1-EXPA"
+    mock_ml.find_experiments.return_value = [exp]
+
+    result = await capturing_mcp.tools["deriva_ml_find_experiments"](
+        hostname="h", catalog_id="1", preflight_count=True
+    )
+    out = json.loads(result)
+    assert out["total_count"] == 1
+    assert out["entities_fetched"] is False
+    assert "action_required" in out
+
+
+async def test_find_experiments_error_path(execution_ctx, capturing_mcp, mock_ml):
+    """``ml.find_experiments`` raising wraps as ``{"error": ...}`` without
+    an audit row (read-only tool, silent on failure)."""
+    mock_ml.find_experiments.side_effect = RuntimeError("catalog unreachable")
+    with _patch_execution_audit() as mock_audit:
+        result = await capturing_mcp.tools["deriva_ml_find_experiments"](
+            hostname="h", catalog_id="1"
+        )
+    out = json.loads(result)
+    assert "error" in out
+    assert mock_audit.call_count == 0

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -97,6 +97,8 @@ _EXECUTION_TOOLS = frozenset(
         "deriva_ml_find_workflow_executions",
         "deriva_ml_list_execution_children",
         "deriva_ml_list_execution_parents",
+        # P2 hygiene sweep: experiment-scoped browse (wraps find_experiments).
+        "deriva_ml_find_experiments",
         # v3.3: provenance traversal (data-flow walk; see deriva-ml ADR-0001).
         "deriva_ml_get_lineage",
     }


### PR DESCRIPTION
## Summary

Five small hygiene items from the 2026-05-24 parity audit. Each is independent; bundled because each alone is too small for its own PR.

### (a) `validate` kwarg on `deriva_ml_add_dataset_members` (audit #4)

Added `validate: bool = True` to the tool signature and forwarded it to `ds.add_dataset_members(validate=...)`. Callers doing bulk inserts with pre-confirmed RIDs can pass `False` to skip the per-RID existence check and improve throughput; default `True` preserves previous behavior. Updated the existing test assertion to match.

### (b) asyncio.to_thread CLAUDE.md warning (audit #11)

The warning said the other tool modules "still need" `asyncio.to_thread` wrapping after PR #28. Spot-checked the source and the AST test in `tests/test_async_thread_wrap.py` — all modules are clean. Updated the note to reflect the current state and point to the structural test that now enforces the rule.

### (c) Behavioral test for `validate_execution_configuration` (audit #3)

Already satisfied. Tests `test_validate_execution_configuration_success` and `test_validate_execution_configuration_error_path` were already present and passing in `tests/test_dataset_read.py`. No new code needed.

### (d) `deriva_ml_find_experiments` tool (audit #7, chose option 1)

Added `deriva_ml_find_experiments(hostname, catalog_id, workflow_rid, status, limit, after_rid, preflight_count)` to `tools/execution/read.py`. Wraps `DerivaML.find_experiments()` (pure catalog I/O — scans `Execution_Metadata` for `*-config.yaml` files). Returns `ExecutionListResponse` (same shape as `list_executions`). The tool resolves each `Experiment.execution_rid` to an `ExecutionRecord` to avoid triggering the lazy `Experiment.hydra_config` download (which fetches from Hatrac and violates the stateless rule). Added 3 behavioral tests and updated `test_plugin.py`.

Chose option 1 (add the tool) because `find_experiments()` is pure catalog I/O with no local-filesystem dependency — a clean MCP surface.

### (e) Drop `WorkflowDetail` (audit #13, chose option 1: drop)

`WorkflowDetail` was shape-identical to `WorkflowSummary` with no detail-only fields and no plan to add them in the foreseeable future. Dropped the empty wrapper class from `_response_models.py`; `_get_workflow_impl` now returns `WorkflowSummary` directly. No wire shape change.

Chose option 1 (drop) because the "future use" promise had sat unfulfilled for over a year and the smaller surface is better.

## Test plan

- [x] `uv run pytest tests/ -q` (300 tests, excluding integration) — all pass
- [x] `uv run ruff check src/ tests/` — no issues
- [x] `tests/test_async_thread_wrap.py` — all 3 checks pass (including new tool)
- [x] `tests/test_plugin.py::test_all_registered_tools_exact` — passes with `deriva_ml_find_experiments` in the frozenset

🤖 Generated with [Claude Code](https://claude.com/claude-code)