### PR TITLE
chore: reconcile commit_execution narrative (audit P1 #1, post-#47 rebase)

### DIFF
--- a/docs/scratch/phase5-execution-analysis.md
+++ b/docs/scratch/phase5-execution-analysis.md
@@ -1,5 +1,7 @@
 # Phase 5 — Execution domain analysis (scratch)
 
+> **STATUS: DEFERRED (2026-05-24).** The `commit_execution` MCP tool proposed in this document is **permanently deferred** in favor of a future `work-with-executions` skill in [deriva-ml-skills](https://github.com/informatics-isi-edu/deriva-ml-skills). Per the v0.5.0 stateless-MCP architectural rule (see [CLAUDE.md](../../CLAUDE.md) and [`docs/superpowers/notes/audit-2026-05-23.md`](../superpowers/notes/audit-2026-05-23.md)), execution lifecycle does not belong on the MCP wire — it composes only at the caller's local Python where the asset manifest + SQLite registry live. This document is preserved as **historical design context** showing what a hypothetical MCP-side commit tool would have needed to do (including the bug-fix call-sequence per ADR-0009 on the deriva-ml side); it is **NOT a roadmap**.
+
 > **Status note (2026-05-24):** This analysis was originally drafted
 > against deriva-ml's pre-v1.39 surface. Updated 2026-05-24 to reflect
 > the unified `commit_output_assets` surface that shipped in deriva-ml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,12 @@ dependencies = [
     # `Execution.commit_output_assets()` + `DerivaML.commit_pending_executions()`.
     # v1.39.0 was briefly tagged v2.0.0 and re-tagged after the user decided
     # v2.0 should wait for more bake time; the upper bound <2.0 keeps us out
-    # of any future v2.0 release until we re-validate. The `commit_execution`
-    # MCP tool (when it is implemented) MUST drive the v1.39 method names —
-    # see docs/scratch/phase5-execution-analysis.md for the corrected
-    # compose-sequence.
+    # of any future v2.0 release until we re-validate.
+    # Pinned to v1.39+ for ADR-0009's unified `commit_output_assets` /
+    # `commit_pending_executions` surface. The MCP plugin does not expose
+    # execution lifecycle (stateless rule, v0.5.0); this pin protects
+    # against any future code path that depends on the v1.39 method names
+    # in the underlying library.
     "deriva-ml>=1.39,<2.0",
     # Pin deriva-py to the `deriva-ml` branch in the built wheel metadata --
     # not just in [tool.uv] (which is local-only and does not ship). Installers

--- a/src/deriva_ml_mcp/prompts.py
+++ b/src/deriva_ml_mcp/prompts.py
@@ -584,11 +584,14 @@ reach for:
               ``list_*`` (paginated) or ``get_*`` (single hit)
               depending on the search's arity.
 
-    create_ / update_ / delete_ / add_ / start_ / commit_ / abort_
+    create_ / update_ / delete_ / add_
               Mutating operations. Every one emits an audit row
               (success or ``_failed``). Mutating tools have NO
               resource counterpart -- resources are read-only by
-              MCP convention.
+              MCP convention. (Execution lifecycle verbs such as
+              ``start_`` / ``commit_`` / ``abort_`` are permanently
+              deferred to a future ``work-with-executions`` skill in
+              deriva-ml-skills; no such tools exist in this plugin.)
 
     lookup_*  Specialized RID-or-name resolution (currently only
               ``lookup_asset``). Treat as a sibling of ``get_*``.


### PR DESCRIPTION
Rebased + resurrected from closed PR #48 after #47 merged with a conflicting `pyproject.toml` comment.

## What this PR does

Addresses audit P1 #1: removes all language implying `commit_execution` is a forthcoming MCP tool, replacing it with explicit "permanently deferred to a skill" framing throughout.

**Three commits:**
- `docs(scratch)`: mark `phase5-execution-analysis.md` as DEFERRED
- `chore(deps)`: rewrite `deriva-ml` pin comment — removes "when it is implemented MUST drive..." and replaces with "The MCP plugin does not expose execution lifecycle (stateless rule, v0.5.0); this pin protects against any future code path that depends on the v1.39 method names in the underlying library."
- `docs(prompts)`: drop `start_`/`commit_`/`abort_` from MCP verb list in `prompts.py`

## How the pyproject.toml conflict was resolved

PR #47's comment said `commit_execution` (when implemented) MUST drive the v1.39 method names. PR #48's (this PR's) version drops that language entirely and instead states execution lifecycle is not exposed by the MCP plugin. The resolved comment keeps #47's v1.39 pin rationale (ADR-0009 unified upload surface, v2.0 re-tag history) and adds #48's explicit "permanently deferred" framing.

Closes the narrative gap left by the #47 + #48 conflict.