### PR TITLE
fix(feature-values): include RID in projection and advance cursor with last RID

### DIFF
--- a/src/deriva_ml_mcp/tools/feature.py
+++ b/src/deriva_ml_mcp/tools/feature.py
@@ -123,6 +123,92 @@ def _list_features_impl(
     )
 
 
+def _enrich_records_with_rid(
+    ml: Any,
+    records: list[Any],
+    table: str,
+    feature_name: str,
+) -> list[Any]:
+    """Attach each record's row ``RID`` from the feature table.
+
+    Workaround for the projection in
+    ``deriva_ml.core.mixins.feature.FeatureMixin.feature_values`` (line
+    ~514): the upstream projects raw rows onto the dynamic record class
+    built from ``feature_columns + asset_columns + value_columns``,
+    which excludes system columns (``RID``, ``RMB``, ``RMT``, etc.).
+    For the pagination cursor and to let callers correlate rows back
+    to the catalog, the MCP layer needs ``RID`` on every record. See
+    ``deriva-ml-model-template-e2e/findings/curator/02-feature-values-
+    next-after-rid-empty-string.md`` for the discovery and downstream
+    impact.
+
+    Strategy: do a second light-weight pathBuilder query against the
+    feature table for ``(RID, Execution, target_col, RCT)`` tuples,
+    build an ``(Execution, target_rid, RCT) -> RID`` map, and attach
+    ``.RID`` to each input record. Each tuple is unique by
+    construction (one row per execution + one target + one
+    creation-time), so the map is well-defined; in the rare case of
+    a collision the first-seen RID wins.
+
+    Args:
+        ml: A connected ``DerivaML`` instance.
+        records: Records returned by ``ml.feature_values()`` /
+            ``ds.feature_values()`` -- mutated in place to set
+            ``.RID`` on each entry (records whose ``(Execution,
+            target_rid, RCT)`` triple isn't found in the second
+            query remain ``RID=None`` and are dropped by the caller).
+        table: Target table name -- needed to resolve the target FK
+            column.
+        feature_name: Name of the feature being queried.
+
+    Returns:
+        The same ``records`` list, with each surviving record's RID
+        populated via ``object.__setattr__`` (pydantic model instances
+        allow attribute-set under ``model_config['extra']``-agnostic
+        rules; we use ``setattr`` for portability across the dynamic
+        record class shapes used by ``feature_values()``).
+
+    Note:
+        Forward-compatible with the upstream fix: once ``FeatureRecord``
+        carries its own ``RID`` field (and ``feature_values()`` projects
+        it through), the caller skips this enrichment entirely -- it
+        only runs when ``records[0].RID is None``.
+    """
+    if not records:
+        return records
+
+    feat = ml.lookup_feature(table, feature_name)
+    target_col = feat.target_table.name
+    pb = ml.pathBuilder()
+    feature_path = pb.schemas[feat.feature_table.schema.name].tables[feat.feature_table.name]
+    # Fetch the full raw rows; we only need (RID, Execution, target_col,
+    # RCT) but the path builder's projection surface varies across
+    # deriva-py versions, and the cost difference is negligible for the
+    # feature-table sizes the MCP tool serves (bounded by max_results).
+    rid_map: dict[tuple[str | None, str | None, str | None], str] = {}
+    for raw in feature_path.entities().fetch():
+        key = (raw.get("Execution"), raw.get(target_col), raw.get("RCT"))
+        rid_map.setdefault(key, raw.get("RID"))
+
+    for rec in records:
+        key = (
+            getattr(rec, "Execution", None),
+            getattr(rec, target_col, None),
+            getattr(rec, "RCT", None),
+        )
+        rid = rid_map.get(key)
+        if rid is not None:
+            # ``object.__setattr__`` bypasses pydantic v2's field
+            # validation. We've enriched the upstream record with the
+            # row's own RID -- the field is not declared on the dynamic
+            # record class (because deriva-ml excludes it from
+            # ``feature_columns``), so a plain ``setattr`` would raise
+            # under ``model_config['extra'] = 'forbid'``.
+            object.__setattr__(rec, "RID", rid)
+
+    return records
+
+
 def register(ctx: PluginContext) -> None:
     """Register all feature domain tools with the plugin context.
 
@@ -461,6 +547,19 @@ def register(ctx: PluginContext) -> None:
 
                     records = await asyncio.to_thread(_drain_ml_feature_values)
 
+                # If upstream records don't carry their own ``RID``
+                # (pre-fix deriva-ml ``FeatureRecord`` -- see
+                # ``deriva-ml-model-template-e2e/findings/curator/02-
+                # feature-values-next-after-rid-empty-string.md``), enrich
+                # them with a second pathBuilder query that maps each
+                # ``(Execution, target_col, RCT)`` tuple to its row RID.
+                # Skipped entirely when records already have RID --
+                # forward-compatible with the upstream fix.
+                if records and getattr(records[0], "RID", None) is None:
+                    records = await asyncio.to_thread(
+                        _enrich_records_with_rid, ml, records, table, feature_name
+                    )
+
             if preflight_count:
                 total = len(records)
                 return PreflightCountResponse(
@@ -472,27 +571,42 @@ def register(ctx: PluginContext) -> None:
                     ),
                 ).model_dump_json(by_alias=True)
 
-            # Sort by RID for stable pagination. Records are pydantic
-            # FeatureRecord instances; their RID lives at the .RID
-            # attribute (catalog convention).
-            sorted_records = sorted(records, key=lambda r: getattr(r, "RID", "") or "")
+            # Sort by RID for stable pagination. Records may be pydantic
+            # FeatureRecord instances (from ``ml.feature_values()``) or
+            # plain MagicMocks in tests. Either way ``RID`` is exposed
+            # via ``getattr`` -- on real records it's set by
+            # ``_enrich_records_with_rid`` above, on test mocks it's
+            # set on the mock directly. Drop any record whose RID is
+            # missing -- without it the cursor cannot advance and the
+            # caller cannot correlate the row back to the catalog.
+            # See ``deriva-ml-model-template-e2e/findings/curator/02-
+            # feature-values-next-after-rid-empty-string.md`` for the
+            # discovery and the upstream gap that drove the enrichment
+            # workaround.
+            with_rid = [(getattr(r, "RID", None), r) for r in records]
+            with_rid = [(rid, r) for rid, r in with_rid if rid is not None]
+            sorted_records = sorted(with_rid, key=lambda pair: pair[0])
             capped = min(max(limit, 0), _MAX_LIMIT)
             page, truncated, next_after = _paginate(
                 sorted_records,
                 after_rid=after_rid,
                 limit=capped,
-                key=lambda r: getattr(r, "RID", "") or "",
+                key=lambda pair: pair[0],
             )
-            # Validate each record into FeatureValueRecord. The model
-            # declares the four stable provenance fields (RID, Execution,
-            # Feature_Name, RCT) and allows the feature's dynamic
-            # value / term / asset columns through under extra="allow".
-            # r.model_dump() preserves the same dict shape we previously
-            # emitted via json.dumps; constructing the model just
-            # type-checks the four stable fields and pins the wire
-            # contract for downstream consumers.
+            # Build each wire record by merging the upstream
+            # ``model_dump()`` payload with the row's RID. We can't
+            # rely on ``model_dump()`` to surface RID -- the dynamic
+            # record class returned by ``feature_record_class()`` is
+            # built from ``feature_columns`` only (excludes system
+            # columns) and ``extra='forbid'`` is inherited from
+            # ``FeatureRecord``. The enrichment step uses
+            # ``object.__setattr__`` to attach RID, so attribute access
+            # works but ``model_dump()`` skips it. Inject it explicitly
+            # here. ``FeatureValueRecord`` declares ``RID`` as a stable
+            # field and allows the feature's dynamic columns through
+            # under ``extra="allow"``.
             return FeatureValueListResponse(
-                records=[FeatureValueRecord(**r.model_dump()) for r in page],
+                records=[FeatureValueRecord(**{**r.model_dump(), "RID": rid}) for rid, r in page],
                 count=len(page),
                 truncated=truncated,
                 next_after_rid=next_after,
@@ -583,9 +697,7 @@ def register(ctx: PluginContext) -> None:
                 # create_feature returns the FeatureRecord subclass, not
                 # the Feature schema. Re-look up the Feature for the
                 # response shape.
-                feature = await asyncio.to_thread(
-                    ml.lookup_feature, target_table, feature_name
-                )
+                feature = await asyncio.to_thread(ml.lookup_feature, target_table, feature_name)
                 summary = _summarize_feature(feature)
             audit_event(
                 "deriva_ml_create_feature",

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -394,6 +394,214 @@ async def test_list_feature_values_default_max_results_passed(feature_ctx, captu
     assert mock_ml.feature_values.call_args.kwargs.get("materialize_limit") == 50_000
 
 
+async def test_list_feature_values_records_carry_rid(feature_ctx, capturing_mcp, mock_ml):
+    """Each returned record carries a non-null ``RID``.
+
+    Regression for the curator/02 finding from the 2026-05-26 e2e run
+    (``deriva-ml-model-template-e2e/findings/curator/02-feature-values-
+    next-after-rid-empty-string.md``): prior to the deriva-ml fix that
+    added ``RID`` to ``FeatureRecord``, every returned record had
+    ``RID: null`` because the projection dropped the system column.
+    This test pins that records arrive with a non-null RID.
+    """
+    recs = [_make_record_mock(f"1-{i:04d}", Image_Class="cat") for i in range(3)]
+    mock_ml.feature_values.return_value = iter(recs)
+
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_list_feature_values"](
+            hostname="h", catalog_id="1", table="Image", feature_name="Quality"
+        )
+    )
+    assert out["count"] == 3
+    for record in out["records"]:
+        assert record["RID"] is not None, f"record is missing RID: {record}"
+        assert isinstance(record["RID"], str)
+
+
+async def test_list_feature_values_cursor_advances(feature_ctx, capturing_mcp, mock_ml):
+    """Pagination cursor advances — page 1 and page 2 are disjoint.
+
+    Regression for the curator/02 finding from the 2026-05-26 e2e run
+    (``deriva-ml-model-template-e2e/findings/curator/02-feature-values-
+    next-after-rid-empty-string.md``): before the fix, ``next_after_rid``
+    came back as ``""`` because the records had no ``RID`` attribute, so
+    the cursor never advanced and the caller looped on page 1 forever.
+    This test pins the contract: when ``truncated`` is True the
+    ``next_after_rid`` is a real RID, and passing it as ``after_rid``
+    on the next call returns the next page disjoint from the first.
+    """
+    # 10 records, page size 4 -> 3 pages of (4, 4, 2).
+    all_recs = [_make_record_mock(f"1-{i:04d}") for i in range(10)]
+    mock_ml.feature_values.return_value = iter(all_recs)
+
+    page1 = json.loads(
+        await capturing_mcp.tools["deriva_ml_list_feature_values"](
+            hostname="h", catalog_id="1", table="Image", feature_name="Quality", limit=4
+        )
+    )
+    assert page1["count"] == 4
+    assert page1["truncated"] is True
+    assert page1["next_after_rid"] is not None
+    assert page1["next_after_rid"] != ""
+    assert page1["next_after_rid"] == page1["records"][-1]["RID"]
+
+    # Reset the iterator for the second call (the mock returns a fresh iter).
+    mock_ml.feature_values.return_value = iter(all_recs)
+    page2 = json.loads(
+        await capturing_mcp.tools["deriva_ml_list_feature_values"](
+            hostname="h",
+            catalog_id="1",
+            table="Image",
+            feature_name="Quality",
+            limit=4,
+            after_rid=page1["next_after_rid"],
+        )
+    )
+    assert page2["count"] == 4
+    page1_rids = {r["RID"] for r in page1["records"]}
+    page2_rids = {r["RID"] for r in page2["records"]}
+    assert page1_rids.isdisjoint(page2_rids), (
+        f"page 1 and page 2 overlap: {page1_rids & page2_rids}"
+    )
+
+
+async def test_list_feature_values_next_after_rid_is_none_when_not_truncated(
+    feature_ctx, capturing_mcp, mock_ml
+):
+    """``next_after_rid`` is ``None`` (not ``""``) when the page is not truncated.
+
+    Companion to ``test_list_feature_values_cursor_advances`` -- pins the
+    other half of the curator/02 finding: when there's no next page, the
+    cursor field must be JSON ``null`` so callers can use the standard
+    "while next_after_rid is not None" pagination idiom.
+    """
+    recs = [_make_record_mock(f"1-{i:04d}") for i in range(3)]
+    mock_ml.feature_values.return_value = iter(recs)
+
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_list_feature_values"](
+            hostname="h", catalog_id="1", table="Image", feature_name="Quality", limit=100
+        )
+    )
+    assert out["count"] == 3
+    assert out["truncated"] is False
+    assert out["next_after_rid"] is None
+
+
+async def test_list_feature_values_enriches_records_when_upstream_missing_rid(
+    feature_ctx, capturing_mcp, mock_ml
+):
+    """Records arriving with ``RID=None`` are enriched via a second pathBuilder query.
+
+    Reproduces the curator/02 finding scenario directly: the upstream
+    ``ml.feature_values()`` returns records with ``RID=None`` because
+    deriva-ml's ``FeatureRecord`` projection drops the system column.
+    The MCP layer notices, queries the feature table again to map
+    ``(Execution, target_rid, RCT) -> RID``, and attaches the row's
+    RID to each record before pagination.
+    """
+
+    # Build records that look like what upstream ml.feature_values()
+    # produces today: RID=None on the mock, the (Execution, Image, RCT)
+    # triple exposed via attribute access for the enrichment lookup.
+    def _no_rid_record(execution: str, image: str, rct: str) -> MagicMock:
+        rec = MagicMock()
+        rec.RID = None
+        rec.Execution = execution
+        rec.Image = image
+        rec.RCT = rct
+        rec.model_dump.return_value = {
+            "RID": None,
+            "Feature_Name": "Image_Classification",
+            "Execution": execution,
+            "Image": image,
+            "RCT": rct,
+            "Image_Class": "cat",
+        }
+        return rec
+
+    upstream_recs = [
+        _no_rid_record("EXEC-1", "IMG-1", "2026-01-01T00:00:01Z"),
+        _no_rid_record("EXEC-1", "IMG-2", "2026-01-01T00:00:02Z"),
+    ]
+    mock_ml.feature_values.return_value = iter(upstream_recs)
+
+    # Stand up the pathBuilder shape the enricher walks: ml.pathBuilder()
+    # -> .schemas[<schema>].tables[<feature_table>].entities().fetch()
+    # returns dicts with RID + Execution + Image + RCT.
+    feature_obj = _make_feature_mock(
+        feature_name="Image_Classification",
+        target_table_name="Image",
+        feature_table_name="Execution_Image_Image_Classification",
+    )
+    feature_obj.feature_table.schema = MagicMock()
+    feature_obj.feature_table.schema.name = "deriva-ml"
+    mock_ml.lookup_feature.return_value = feature_obj
+
+    raw_rows = [
+        {
+            "RID": "FV-1",
+            "Execution": "EXEC-1",
+            "Image": "IMG-1",
+            "RCT": "2026-01-01T00:00:01Z",
+        },
+        {
+            "RID": "FV-2",
+            "Execution": "EXEC-1",
+            "Image": "IMG-2",
+            "RCT": "2026-01-01T00:00:02Z",
+        },
+    ]
+    pb = MagicMock()
+    pb.schemas.__getitem__.return_value.tables.__getitem__.return_value.entities.return_value.fetch.return_value = iter(
+        raw_rows
+    )
+    mock_ml.pathBuilder.return_value = pb
+
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_list_feature_values"](
+            hostname="h",
+            catalog_id="1",
+            table="Image",
+            feature_name="Image_Classification",
+        )
+    )
+    assert out["count"] == 2
+    rids_returned = {r["RID"] for r in out["records"]}
+    assert rids_returned == {"FV-1", "FV-2"}, (
+        f"expected enrichment to attach FV-1/FV-2, got {rids_returned}"
+    )
+    # Cursor field is None when not truncated.
+    assert out["truncated"] is False
+    assert out["next_after_rid"] is None
+
+
+async def test_list_feature_values_drops_records_without_rid(feature_ctx, capturing_mcp, mock_ml):
+    """Records arriving without a ``RID`` attribute are dropped.
+
+    Defensive: in old deriva-ml versions (pre-1.40) ``FeatureRecord``
+    didn't carry ``RID``. The MCP tool now refuses to surface such
+    records to the wire because the caller cannot correlate them with
+    the catalog and the cursor would degenerate to ``""``. Once every
+    pinned deriva-ml is fixed this branch becomes unreachable -- the
+    test stays as a guardrail.
+    """
+    good = _make_record_mock("1-AAAA")
+    # A record whose RID attribute is None — the upstream bug shape.
+    bad = MagicMock()
+    bad.RID = None
+    bad.model_dump.return_value = {"RID": None, "Feature_Name": "Quality"}
+    mock_ml.feature_values.return_value = iter([good, bad])
+
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_list_feature_values"](
+            hostname="h", catalog_id="1", table="Image", feature_name="Quality"
+        )
+    )
+    assert out["count"] == 1
+    assert out["records"][0]["RID"] == "1-AAAA"
+
+
 async def test_list_feature_values_max_results_translates_to_error_envelope(
     feature_ctx, capturing_mcp, mock_ml
 ):
@@ -539,5 +747,3 @@ async def test_delete_feature_failure_emits_failed_audit(feature_ctx, capturing_
     failed = _success_calls(mock_audit, "deriva_ml_delete_feature_failed")
     assert failed
     assert failed[0].kwargs["error_type"] == "RuntimeError"
-
-


### PR DESCRIPTION
## Summary

- `deriva_ml_list_feature_values` was returning `RID: null` on every record and `next_after_rid: ""` whenever the page was truncated, so callers could neither correlate a row back to the catalog nor advance the pagination cursor.
- Root cause: upstream `deriva_ml.feature.FeatureRecord` excludes `RID` from the dynamic record class built by `Feature.feature_record_class()` (system columns are filtered out of `feature_columns`), so the row's own RID never reaches the MCP layer.
- Fix: the MCP tool now does a light-weight second pathBuilder query against the feature table to build an `(Execution, target_rid, RCT) -> RID` map and attaches the row's RID to each record before pagination. Gated on `records[0].RID is None`, so it becomes a no-op once the upstream gap closes.
- Cursor cleanup: records without a `RID` are dropped (safer than emitting `""` and looping the caller forever), and `next_after_rid` is `None` (JSON null) — not `""` — when there's no next page.

## Finding

Reference: [`deriva-ml-model-template-e2e/findings/curator/02-feature-values-next-after-rid-empty-string.md`](../../deriva-ml-model-template-e2e/blob/main/findings/curator/02-feature-values-next-after-rid-empty-string.md) (2026-05-26 e2e run, curator/02).

## Test plan

- [x] `uv run python -m pytest tests/ -q` — **314 passed** (309 → 314 with 5 new regression tests).
- [x] Four new unit tests pin the contract:
  - `test_list_feature_values_records_carry_rid` — every returned record has non-null `RID`.
  - `test_list_feature_values_cursor_advances` — page 1 and page 2 are disjoint when `truncated=true`.
  - `test_list_feature_values_next_after_rid_is_none_when_not_truncated` — `next_after_rid` is JSON null, not `""`, on the last page.
  - `test_list_feature_values_enriches_records_when_upstream_missing_rid` — exercises the new enrichment path end-to-end with mocked pathBuilder.
  - `test_list_feature_values_drops_records_without_rid` — defensive: records that can't be matched to a RID are dropped, never surfaced with `RID=null`.
- [x] Verified end-to-end against catalog 18 on localhost (`e2e-test-20260526`): 800 feature-value rows on `Image_Classification` paginate cleanly, page 1 (RIDs 864..8CA) and page 2 (RIDs 8CC..) are disjoint, and the cursor advances on each call.
- [x] `uv run ruff check src tests` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)