### PR TITLE
fix(mcp): audit + fix dropped Pydantic-model fields in execution / workflow projections

### DIFF
--- a/src/deriva_ml_mcp/tools/execution/read.py
+++ b/src/deriva_ml_mcp/tools/execution/read.py
@@ -60,6 +60,75 @@ if TYPE_CHECKING:
     from deriva_mcp_core.plugin.api import PluginContext
 
 
+def _resolve_workflow_rid(record: Any) -> str | None:
+    """Resolve the Workflow FK for an ExecutionRecord, with a defensive recovery path.
+
+    Background: deriva-ml #226 (2026-05-25) renamed the ``Workflow``
+    Pydantic field from ``rid`` to ``workflow_rid``. The two
+    construction sites for ``Workflow`` objects in
+    ``deriva_ml.core.mixins.workflow`` (``find_workflows`` and
+    ``lookup_workflow``) still pass the OLD kwarg name (``rid=...``),
+    and because ``VALIDATION_CONFIG`` does not set ``extra="forbid"``,
+    that value is silently dropped. The result: every ``Workflow``
+    returned by either API has ``workflow_rid=None``, which makes
+    ``ExecutionRecord.workflow_rid`` (a property that reads
+    ``self._workflow.workflow_rid``) also return None on every
+    execution. That surfaced in e2e finding developer/02 as
+    ``deriva_ml_get_execution`` returning ``{"workflow_rid": null}``
+    for every execution in the catalog.
+
+    The clean upstream fix is the two-character change
+    ``rid=`` -> ``workflow_rid=`` in ``find_workflows`` /
+    ``lookup_workflow``. This helper is a defensive MCP-boundary
+    workaround so the bug is plugged without waiting on a deriva-ml
+    release: when ``record.workflow_rid`` is None AND the record is
+    bound to a live catalog (``_ml_instance`` set), do a single
+    attribute-projection query against the ``Execution`` table to
+    recover the Workflow FK directly. Adds one HTTP GET per execution
+    that hit the deriva-ml bug; once the upstream is fixed the fast
+    path returns immediately and the recovery branch becomes dead
+    code (kept as belt-and-suspenders).
+
+    Args:
+        record: An ``ExecutionRecord`` (preferred) or any object
+            with ``execution_rid`` / ``workflow_rid`` /
+            ``_ml_instance`` attributes. Tolerates Mock-shaped
+            objects that don't expose ``_ml_instance``.
+
+    Returns:
+        The Workflow RID as a string, or None if the row has no
+        Workflow FK (legitimate -- e.g. a snapshot row predating
+        execution-workflow linking) or the lookup failed.
+
+    Example:
+        >>> from unittest.mock import MagicMock
+        >>> rec = MagicMock()
+        >>> rec.workflow_rid = "1-WF"
+        >>> _resolve_workflow_rid(rec)
+        '1-WF'
+    """
+    # Fast path: the record's own ``workflow_rid`` attribute returned
+    # a non-empty value. Once upstream is fixed, this is the only
+    # branch reached.
+    rid = getattr(record, "workflow_rid", None)
+    if rid:
+        return rid
+    # Recovery path: deriva-ml #226 regression -- fetch the FK directly
+    # via ermrest using the same private accessor ``lookup_execution``
+    # itself uses (``_retrieve_rid``). Defensive try/except so any
+    # failure (mock object, snapshot catalog, network) returns None
+    # rather than blowing up the whole list response.
+    ml = getattr(record, "_ml_instance", None)
+    execution_rid = getattr(record, "execution_rid", None)
+    if ml is None or not execution_rid:
+        return None
+    try:
+        row = ml._retrieve_rid(execution_rid)
+        return row.get("Workflow")
+    except Exception:  # noqa: BLE001 -- defensive recovery, return None on any failure
+        return None
+
+
 def _summarize_execution(record: Any) -> ExecutionSummary:
     """Render an ``ExecutionRecord`` (or ``Execution``) into the validated summary.
 
@@ -67,6 +136,12 @@ def _summarize_execution(record: Any) -> ExecutionSummary:
     / ``find_executions``) and ``Execution`` (returned by
     ``resume_execution``) — the only attributes read are common to both
     surfaces or fall back to ``None``.
+
+    NOTE(2026-05-26 audit): the ``workflow_rid`` field reads through
+    :func:`_resolve_workflow_rid` to defensively recover from a
+    deriva-ml field-rename regression (#226). Once deriva-ml is patched
+    and pinned, the recovery path becomes dead code -- the fast
+    attribute read returns the correct value.
 
     Args:
         record: An ``ExecutionRecord`` (preferred) or ``Execution`` mock.
@@ -99,7 +174,7 @@ def _summarize_execution(record: Any) -> ExecutionSummary:
     status = getattr(record, "status", None)
     return ExecutionSummary(
         rid=getattr(record, "execution_rid", None),
-        workflow_rid=getattr(record, "workflow_rid", None),
+        workflow_rid=_resolve_workflow_rid(record),
         status=status.value if isinstance(status, ExecutionStatus) else status,
         description=getattr(record, "description", None),
         start_time=getattr(record, "start_time", None),

--- a/src/deriva_ml_mcp/tools/workflow.py
+++ b/src/deriva_ml_mcp/tools/workflow.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from deriva_mcp_core import deriva_call
@@ -39,7 +38,6 @@ from deriva_ml_mcp._helpers import (
     _MAX_LIMIT,
     _error_envelope,
     _paginate,
-    _read_rid,
 )
 from deriva_ml_mcp._response_models import (
     CreateWorkflowResponse,
@@ -52,6 +50,53 @@ from deriva_ml_mcp.ml_context import get_ml
 
 if TYPE_CHECKING:
     from deriva_mcp_core.plugin.api import PluginContext
+
+
+def _resolve_workflow_rid(wf: Any) -> str | None:
+    """Resolve the RID of a Workflow object, with a defensive recovery path.
+
+    Same root cause as ``tools.execution.read._resolve_workflow_rid``:
+    deriva-ml #226 renamed the field from ``rid`` to ``workflow_rid``
+    but its two construction sites (``find_workflows``,
+    ``lookup_workflow``) still pass the OLD kwarg name. Pydantic's
+    permissive config silently drops the value, leaving
+    ``workflow.workflow_rid == None`` on every Workflow returned by
+    either API.
+
+    Fast path: if ``wf.workflow_rid`` is populated, return it. Recovery
+    path: if the workflow is bound to a catalog (``_ml_instance``)
+    and carries either ``checksum`` or ``url``, call
+    ``ml._find_workflow_rid_by_url(checksum_or_url)`` to look the RID
+    up. That helper is server-side filtered (single round trip with
+    one row in the response) so the recovery cost is bounded.
+
+    Args:
+        wf: A ``deriva_ml.execution.workflow.Workflow`` instance, or a
+            Mock-shaped stand-in.
+
+    Returns:
+        The Workflow RID, or None if recovery wasn't possible.
+
+    Example:
+        >>> from unittest.mock import MagicMock
+        >>> wf = MagicMock()
+        >>> wf.workflow_rid = "1-WF"
+        >>> _resolve_workflow_rid(wf)
+        '1-WF'
+    """
+    rid = getattr(wf, "workflow_rid", None)
+    if rid:
+        return rid
+    ml = getattr(wf, "_ml_instance", None)
+    if ml is None:
+        return None
+    lookup_key = getattr(wf, "checksum", None) or getattr(wf, "url", None)
+    if not lookup_key:
+        return None
+    try:
+        return ml._find_workflow_rid_by_url(lookup_key)
+    except Exception:  # noqa: BLE001 -- defensive recovery, return None on any failure
+        return None
 
 
 def _summarize_workflow(wf: Any) -> WorkflowSummary:
@@ -72,9 +117,17 @@ def _summarize_workflow(wf: Any) -> WorkflowSummary:
         previously dict-accessed (``summary["rid"]``) must use
         attribute access (``summary.rid``) or call ``.model_dump()``
         to get a plain dict back.
+
+    NOTE(2026-05-26 audit): ``Workflow.rid`` was renamed to
+    ``Workflow.workflow_rid`` in deriva-ml #226 but the deriva-ml
+    construction sites still pass ``rid=`` and the field is silently
+    dropped. We read through ``_resolve_workflow_rid`` so the
+    Workflow's RID is recovered (via checksum/url lookup) when the
+    upstream property returns None. Once deriva-ml is patched the
+    recovery path becomes dead code.
     """
     return WorkflowSummary(
-        rid=wf.rid,
+        rid=_resolve_workflow_rid(wf),
         name=wf.name,
         url=wf.url,
         checksum=wf.checksum,
@@ -113,15 +166,22 @@ def _list_workflows_impl(
     # Keep stable RID-ascending order for the default path; under
     # sort=True we honor the catalog-side RCT-desc ordering and skip
     # the post-fetch sort (sorting by RID would clobber the RCT order).
+    #
+    # Both the sort key and the pagination cursor read through
+    # ``_resolve_workflow_rid`` so the deriva-ml #226 regression (every
+    # Workflow returns workflow_rid=None) does not collapse the sort
+    # to "all-empty" or break cursor pagination. The recovery branch
+    # in the resolver is a server-side filter (single round trip per
+    # workflow); a fix in deriva-ml will skip it entirely.
     if sort:
         workflows = raw
     else:
-        workflows = sorted(raw, key=lambda w: w.rid)
+        workflows = sorted(raw, key=lambda w: _resolve_workflow_rid(w) or "")
     page, truncated, next_after = _paginate(
         workflows,
         after_rid=after_rid,
         limit=limit,
-        key=partial(_read_rid, rid_key="rid"),
+        key=lambda w: _resolve_workflow_rid(w) or "",
     )
     return WorkflowListResponse(
         workflows=[_summarize_workflow(w) for w in page],
@@ -468,7 +528,13 @@ def register(ctx: PluginContext) -> None:
                 except DerivaMLException:
                     existing = None
                 if existing is not None:
-                    rid = existing.rid
+                    # NOTE(2026-05-26 audit): ``Workflow.rid`` -> ``workflow_rid``
+                    # in deriva-ml #226. Route through the defensive
+                    # resolver so the rename regression (workflow_rid
+                    # populated as None on every Workflow returned by
+                    # lookup_workflow_by_url) doesn't surface here as
+                    # a null ``workflow_rid`` in the response.
+                    rid = _resolve_workflow_rid(existing)
                     status = "exists"
                 else:
                     # Validate every workflow_type term against the
@@ -477,9 +543,7 @@ def register(ctx: PluginContext) -> None:
                     # ``ml.create_workflow(name, workflow_type, description)``,
                     # which we no longer call -- see the note below.
                     for wt in normalized_types:
-                        await asyncio.to_thread(
-                            ml.lookup_term, MLVocab.workflow_type, wt
-                        )
+                        await asyncio.to_thread(ml.lookup_term, MLVocab.workflow_type, wt)
                     # Construct ``Workflow`` directly with url / checksum
                     # / version set at construction time so the model
                     # validator (``setup_url_checksum``) short-circuits

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -423,9 +423,7 @@ async def test_get_lineage_success(execution_ctx, capturing_mcp, mock_ml):
     assert out["root"]["rid"] == "2-PRED"
     assert out["walked_complete"] is True
     # Tool surfaces depth + max_executions to underlying call.
-    mock_ml.lookup_lineage.assert_called_once_with(
-        "2-PRED", depth=2, max_executions=100
-    )
+    mock_ml.lookup_lineage.assert_called_once_with("2-PRED", depth=2, max_executions=100)
 
 
 async def test_get_lineage_defaults_unbounded(execution_ctx, capturing_mcp, mock_ml):
@@ -441,38 +439,41 @@ async def test_get_lineage_defaults_unbounded(execution_ctx, capturing_mcp, mock
 
     mock_ml.lookup_lineage.return_value = LineageResult(
         root=RootDescriptor(
-            rid="1-EXEC", type="Execution",
+            rid="1-EXEC",
+            type="Execution",
             producing_execution=ExecutionSummary(
-                rid="1-EXEC", description="root execution", workflow=None,
+                rid="1-EXEC",
+                description="root execution",
+                workflow=None,
                 status="Completed",
             ),
         ),
         lineage=LineageNode(
             execution=ExecutionSummary(
-                rid="1-EXEC", description="root execution", workflow=None,
+                rid="1-EXEC",
+                description="root execution",
+                workflow=None,
                 status="Completed",
             ),
-            consumed_datasets=[], consumed_assets=[], parents=[],
+            consumed_datasets=[],
+            consumed_assets=[],
+            parents=[],
         ),
-        executions_visited=1, walked_complete=True, cycle_detected=False,
+        executions_visited=1,
+        walked_complete=True,
+        cycle_detected=False,
         depth_capped=False,
     )
 
-    await capturing_mcp.tools["deriva_ml_get_lineage"](
-        hostname="h", catalog_id="1", rid="1-EXEC"
-    )
-    mock_ml.lookup_lineage.assert_called_once_with(
-        "1-EXEC", depth=None, max_executions=500
-    )
+    await capturing_mcp.tools["deriva_ml_get_lineage"](hostname="h", catalog_id="1", rid="1-EXEC")
+    mock_ml.lookup_lineage.assert_called_once_with("1-EXEC", depth=None, max_executions=500)
 
 
 async def test_get_lineage_error_path_workflow_rid(execution_ctx, capturing_mcp, mock_ml):
     """A Workflow RID is not lineage-shaped; ``lookup_lineage`` raises
     and the tool wraps as ``{"error": ...}`` without emitting an audit
     row (read tool, silent on failure)."""
-    mock_ml.lookup_lineage.side_effect = RuntimeError(
-        "Workflow RIDs are not lineage-shaped"
-    )
+    mock_ml.lookup_lineage.side_effect = RuntimeError("Workflow RIDs are not lineage-shaped")
     with _patch_execution_audit() as mock_audit:
         result = await capturing_mcp.tools["deriva_ml_get_lineage"](
             hostname="h", catalog_id="1", rid="1-WF"
@@ -507,9 +508,7 @@ async def test_find_experiments_happy_path(execution_ctx, capturing_mcp, mock_ml
         rid=rid, status=ExecutionStatus.Uploaded
     )
 
-    result = await capturing_mcp.tools["deriva_ml_find_experiments"](
-        hostname="h", catalog_id="1"
-    )
+    result = await capturing_mcp.tools["deriva_ml_find_experiments"](hostname="h", catalog_id="1")
     out = json.loads(result)
 
     assert out["count"] == 2
@@ -547,3 +546,155 @@ async def test_find_experiments_error_path(execution_ctx, capturing_mcp, mock_ml
     out = json.loads(result)
     assert "error" in out
     assert mock_audit.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 2026-05-26 projection audit: workflow_rid recovery (e2e finding developer/02)
+# ---------------------------------------------------------------------------
+#
+# Background: deriva-ml #226 renamed the Workflow field ``rid`` ->
+# ``workflow_rid`` but its construction sites in find_workflows /
+# lookup_workflow still pass the OLD kwarg name. Because
+# ``VALIDATION_CONFIG`` doesn't set extra="forbid", that value is
+# silently dropped, so every Workflow returned by either API has
+# ``workflow_rid=None``, and the ExecutionRecord's workflow_rid
+# property (which reads through self._workflow.workflow_rid) also
+# returns None on every execution. Surfaces as
+# ``deriva_ml_get_execution -> {"workflow_rid": null}`` for every
+# execution in the catalog (e2e finding developer/02, 2026-05-26).
+#
+# The MCP layer plugs this with a defensive recovery in
+# ``_resolve_workflow_rid``: when the fast attribute read returns
+# None but the record is bound to a live catalog, fetch the Workflow
+# FK directly via ``ml._retrieve_rid(execution_rid)``. These tests
+# exercise both the fast path (record exposes workflow_rid) and the
+# recovery path (record's workflow_rid is None -> ermrest lookup).
+
+
+def test_resolve_workflow_rid_fast_path_returns_attribute():
+    """When ``record.workflow_rid`` is populated, return it without I/O."""
+    from deriva_ml_mcp.tools.execution.read import _resolve_workflow_rid
+
+    rec = MagicMock()
+    rec.workflow_rid = "1-WF"
+    # _ml_instance set but should NOT be consulted on the fast path.
+    rec._ml_instance = MagicMock()
+    rec._ml_instance._retrieve_rid.side_effect = AssertionError("recovery path called")
+    assert _resolve_workflow_rid(rec) == "1-WF"
+    rec._ml_instance._retrieve_rid.assert_not_called()
+
+
+def test_resolve_workflow_rid_recovery_fetches_from_ermrest():
+    """When ``record.workflow_rid`` is None, recover via _retrieve_rid."""
+    from deriva_ml_mcp.tools.execution.read import _resolve_workflow_rid
+
+    rec = MagicMock()
+    rec.workflow_rid = None
+    rec.execution_rid = "1-EXEC"
+    rec._ml_instance = MagicMock()
+    rec._ml_instance._retrieve_rid.return_value = {
+        "RID": "1-EXEC",
+        "Workflow": "1-WF-RECOVERED",
+        "Status": "Uploaded",
+    }
+    assert _resolve_workflow_rid(rec) == "1-WF-RECOVERED"
+    rec._ml_instance._retrieve_rid.assert_called_once_with("1-EXEC")
+
+
+def test_resolve_workflow_rid_recovery_returns_none_without_ml_instance():
+    """Mock-shaped records that don't expose ``_ml_instance`` return None safely."""
+    from deriva_ml_mcp.tools.execution.read import _resolve_workflow_rid
+
+    rec = MagicMock()
+    rec.workflow_rid = None
+    rec.execution_rid = "1-EXEC"
+    # Spec restricts attribute access to a closed list -- no _ml_instance.
+    del rec._ml_instance
+    assert _resolve_workflow_rid(rec) is None
+
+
+def test_resolve_workflow_rid_recovery_returns_none_on_fetch_failure():
+    """If ``_retrieve_rid`` raises, recovery returns None (no propagation)."""
+    from deriva_ml_mcp.tools.execution.read import _resolve_workflow_rid
+
+    rec = MagicMock()
+    rec.workflow_rid = None
+    rec.execution_rid = "1-EXEC"
+    rec._ml_instance = MagicMock()
+    rec._ml_instance._retrieve_rid.side_effect = RuntimeError("ermrest unreachable")
+    assert _resolve_workflow_rid(rec) is None
+
+
+def test_resolve_workflow_rid_recovery_returns_none_when_workflow_fk_missing():
+    """``Execution.Workflow == None`` (legitimate) returns None, not raises."""
+    from deriva_ml_mcp.tools.execution.read import _resolve_workflow_rid
+
+    rec = MagicMock()
+    rec.workflow_rid = None
+    rec.execution_rid = "1-EXEC"
+    rec._ml_instance = MagicMock()
+    rec._ml_instance._retrieve_rid.return_value = {"RID": "1-EXEC", "Workflow": None}
+    assert _resolve_workflow_rid(rec) is None
+
+
+async def test_get_execution_recovers_workflow_rid_via_ermrest(
+    execution_ctx, capturing_mcp, mock_ml
+):
+    """End-to-end: a deriva-ml bug-shaped record still gets a real workflow_rid."""
+    # Simulate the deriva-ml #226 regression: ExecutionRecord with
+    # workflow_rid=None but _ml_instance present and the underlying
+    # ermrest row carrying the real Workflow FK.
+    record = _make_execution_record_mock(rid="1-EXEC", workflow_rid=None)
+    record._ml_instance = mock_ml
+    mock_ml._retrieve_rid.return_value = {
+        "RID": "1-EXEC",
+        "Workflow": "1-WF-FROM-ERMREST",
+        "Status": "Uploaded",
+    }
+    mock_ml.lookup_execution.return_value = record
+    result = await capturing_mcp.tools["deriva_ml_get_execution"](
+        hostname="h", catalog_id="1", execution_rid="1-EXEC"
+    )
+    payload = json.loads(result)
+    assert payload["rid"] == "1-EXEC"
+    assert payload["workflow_rid"] == "1-WF-FROM-ERMREST"
+
+
+async def test_list_execution_children_recovers_workflow_rid(execution_ctx, capturing_mcp, mock_ml):
+    """Recovery applies to every child in list_execution_children."""
+    parent = _make_execution_record_mock(rid="1-PARENT", workflow_rid="1-WF")
+    parent._ml_instance = mock_ml
+    child_a = _make_execution_record_mock(rid="1-CHILD-A", workflow_rid=None)
+    child_a._ml_instance = mock_ml
+    child_b = _make_execution_record_mock(rid="1-CHILD-B", workflow_rid=None)
+    child_b._ml_instance = mock_ml
+    parent.list_execution_children.return_value = [child_a, child_b]
+    mock_ml.lookup_execution.return_value = parent
+    mock_ml._retrieve_rid.side_effect = lambda rid: {
+        "1-CHILD-A": {"RID": "1-CHILD-A", "Workflow": "1-WF-A"},
+        "1-CHILD-B": {"RID": "1-CHILD-B", "Workflow": "1-WF-B"},
+    }[rid]
+    result = await capturing_mcp.tools["deriva_ml_list_execution_children"](
+        hostname="h", catalog_id="1", execution_rid="1-PARENT"
+    )
+    payload = json.loads(result)
+    assert payload["count"] == 2
+    rids = {(c["rid"], c["workflow_rid"]) for c in payload["children"]}
+    assert rids == {("1-CHILD-A", "1-WF-A"), ("1-CHILD-B", "1-WF-B")}
+
+
+async def test_get_execution_preserves_workflow_rid_when_present(
+    execution_ctx, capturing_mcp, mock_ml
+):
+    """Sanity check: when workflow_rid IS populated, recovery is not invoked."""
+    record = _make_execution_record_mock(rid="1-EXEC", workflow_rid="1-WF-DIRECT")
+    record._ml_instance = mock_ml
+    mock_ml._retrieve_rid.side_effect = AssertionError(
+        "recovery path called when fast path should have returned"
+    )
+    mock_ml.lookup_execution.return_value = record
+    result = await capturing_mcp.tools["deriva_ml_get_execution"](
+        hostname="h", catalog_id="1", execution_rid="1-EXEC"
+    )
+    payload = json.loads(result)
+    assert payload["workflow_rid"] == "1-WF-DIRECT"

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1031,13 +1031,15 @@ def test_reindex_workflow_writes_one_per_rid_source() -> None:
 
     fake_ml = MagicMock()
     fake_wf = MagicMock()
-    fake_wf.rid = "1-WFAA"
+    # ``Workflow.rid`` -> ``workflow_rid`` (deriva-ml #226, 2026-05-25).
+    fake_wf.workflow_rid = "1-WFAA"
     fake_wf.name = "MyPipe"
     fake_wf.url = "https://example/repo"
     fake_wf.checksum = "abc"
     fake_wf.version = "1.0.0"
     fake_wf.workflow_type = ["Model_Training"]
     fake_wf.description = "demo"
+    del fake_wf.rid
     fake_ml.lookup_workflow.return_value = fake_wf
 
     captured: dict[str, Any] = {}

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -88,13 +88,15 @@ def _make_workflow_mock(
     description: str = "",
 ) -> MagicMock:
     wf = MagicMock()
-    wf.rid = rid
+    # ``Workflow.rid`` -> ``workflow_rid`` (deriva-ml #226, 2026-05-25).
+    wf.workflow_rid = rid
     wf.name = name
     wf.workflow_type = workflow_type or ["Model_Training"]
     wf.url = url
     wf.checksum = checksum
     wf.version = version
     wf.description = description
+    del wf.rid  # match the real model's missing attribute
     return wf
 
 
@@ -109,7 +111,8 @@ def _make_execution_record_mock(
     record.execution_rid = rid
     record.workflow_rid = workflow_rid
     workflow = MagicMock()
-    workflow.rid = workflow_rid
+    workflow.workflow_rid = workflow_rid
+    del workflow.rid
     record.workflow = workflow
     record.status = ExecutionStatus.Stopped
     record.description = description

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -27,17 +27,25 @@ def _make_workflow_mock(
 ) -> MagicMock:
     """Build a Workflow-shaped MagicMock.
 
-    The real Workflow class exposes ``rid``, ``name``, ``workflow_type``
-    (list[str]), ``url``, ``checksum``, ``version``, and ``description``.
+    The real ``deriva_ml.execution.workflow.Workflow`` Pydantic model
+    exposes the RID through the ``workflow_rid`` attribute (renamed
+    from the historical ``rid`` in deriva-ml #226, 2026-05-25). This
+    helper sets the new attribute name so MagicMock-based tests catch
+    the same projection drops a real catalog row would.
     """
     wf = MagicMock()
-    wf.rid = rid
+    wf.workflow_rid = rid
     wf.name = name
     wf.workflow_type = workflow_type or ["Model_Training"]
     wf.url = url
     wf.checksum = checksum
     wf.version = version
     wf.description = description
+    # Remove the auto-generated ``rid`` MagicMock attribute so calls to
+    # ``wf.rid`` raise AttributeError, matching the real model. Without
+    # this delete the test fixture would mask the projection bug the
+    # 2026-05-26 audit fixed.
+    del wf.rid
     return wf
 
 
@@ -495,3 +503,102 @@ async def test_create_workflow_triggers_surgical_reindex(workflow_ctx, capturing
             url="https://github.com/x/r/blob/abc/main.py",
         )
     fake_reindex.assert_awaited_once_with("h", "1", "1-NEW")
+
+
+# ---------------------------------------------------------------------------
+# 2026-05-26 projection audit: workflow_rid recovery on Workflow objects
+# ---------------------------------------------------------------------------
+#
+# deriva-ml #226 renamed Workflow.rid -> Workflow.workflow_rid but the
+# construction sites in find_workflows / lookup_workflow still pass
+# ``rid=``, silently dropping it. ``_resolve_workflow_rid(wf)`` plugs
+# this by re-fetching via ``ml._find_workflow_rid_by_url(checksum or
+# url)`` when the fast attribute path returns None.
+
+
+def test_workflow_resolve_workflow_rid_fast_path():
+    """Workflow with ``workflow_rid`` populated returns immediately."""
+    from deriva_ml_mcp.tools.workflow import _resolve_workflow_rid
+
+    wf = MagicMock()
+    wf.workflow_rid = "1-WF"
+    wf._ml_instance = MagicMock()
+    wf._ml_instance._find_workflow_rid_by_url.side_effect = AssertionError(
+        "recovery path called when fast path should have returned"
+    )
+    assert _resolve_workflow_rid(wf) == "1-WF"
+
+
+def test_workflow_resolve_workflow_rid_recovery_via_checksum():
+    """When workflow_rid is None, recover via checksum lookup."""
+    from deriva_ml_mcp.tools.workflow import _resolve_workflow_rid
+
+    wf = MagicMock()
+    wf.workflow_rid = None
+    wf.checksum = "abc123"
+    wf.url = "https://github.com/example/repo"
+    wf._ml_instance = MagicMock()
+    wf._ml_instance._find_workflow_rid_by_url.return_value = "1-WF-FROM-LOOKUP"
+    assert _resolve_workflow_rid(wf) == "1-WF-FROM-LOOKUP"
+    # Checksum is preferred over URL (matches _add_workflow's lookup key).
+    wf._ml_instance._find_workflow_rid_by_url.assert_called_once_with("abc123")
+
+
+def test_workflow_resolve_workflow_rid_recovery_via_url_when_no_checksum():
+    """No checksum? Recovery falls back to URL."""
+    from deriva_ml_mcp.tools.workflow import _resolve_workflow_rid
+
+    wf = MagicMock()
+    wf.workflow_rid = None
+    wf.checksum = None
+    wf.url = "https://github.com/example/repo"
+    wf._ml_instance = MagicMock()
+    wf._ml_instance._find_workflow_rid_by_url.return_value = "1-WF-VIA-URL"
+    assert _resolve_workflow_rid(wf) == "1-WF-VIA-URL"
+    wf._ml_instance._find_workflow_rid_by_url.assert_called_once_with(
+        "https://github.com/example/repo"
+    )
+
+
+def test_workflow_resolve_workflow_rid_returns_none_with_no_lookup_key():
+    """No checksum AND no URL: recovery returns None safely."""
+    from deriva_ml_mcp.tools.workflow import _resolve_workflow_rid
+
+    wf = MagicMock()
+    wf.workflow_rid = None
+    wf.checksum = None
+    wf.url = None
+    wf._ml_instance = MagicMock()
+    assert _resolve_workflow_rid(wf) is None
+    wf._ml_instance._find_workflow_rid_by_url.assert_not_called()
+
+
+def test_workflow_resolve_workflow_rid_recovery_swallows_errors():
+    """A failing _find_workflow_rid_by_url returns None, not raises."""
+    from deriva_ml_mcp.tools.workflow import _resolve_workflow_rid
+
+    wf = MagicMock()
+    wf.workflow_rid = None
+    wf.checksum = "abc"
+    wf.url = None
+    wf._ml_instance = MagicMock()
+    wf._ml_instance._find_workflow_rid_by_url.side_effect = RuntimeError("network")
+    assert _resolve_workflow_rid(wf) is None
+
+
+async def test_get_workflow_recovers_rid_when_attribute_is_none(
+    workflow_ctx, capturing_mcp, mock_ml
+):
+    """End-to-end: a bug-shaped Workflow surfaces a recovered RID."""
+    # Construct a Workflow MagicMock that simulates the deriva-ml bug:
+    # the helper sets workflow_rid by default, so override it to None.
+    wf = _make_workflow_mock(rid="1-WF-IGNORED")
+    wf.workflow_rid = None
+    wf._ml_instance = mock_ml
+    mock_ml.lookup_workflow.return_value = wf
+    mock_ml._find_workflow_rid_by_url.return_value = "1-WF-RECOVERED"
+    result = await capturing_mcp.tools["deriva_ml_get_workflow"](
+        hostname="h", catalog_id="1", workflow_rid="anything"
+    )
+    payload = json.loads(result)
+    assert payload["rid"] == "1-WF-RECOVERED"


### PR DESCRIPTION
## Summary

Audit fix-pass for e2e finding [developer/02](https://github.com/informatics-isi-edu/deriva-ml-model-template-e2e/blob/main/findings/developer/02-mcp-get-execution-drops-workflow-rid.md):
`deriva_ml_get_execution` returned `{"workflow_rid": null}` for every execution in catalog 18 while ermrest direct reported the real Workflow FK. Same shape for `deriva_ml_list_execution_children` and (latent) for every Workflow returned by `deriva_ml_list_workflows` / `deriva_ml_get_workflow` / `deriva_ml_find_workflow_by_url` / the `exists` branch of `deriva_ml_create_workflow`.

## Root cause

Upstream regression in deriva-ml #226 (2026-05-25): the `Workflow` Pydantic field was renamed `rid` → `workflow_rid`, but the two construction sites (`find_workflows`, `lookup_workflow` in `deriva_ml.core.mixins.workflow`) still pass the OLD kwarg name. `Workflow` uses the permissive `VALIDATION_CONFIG` (no `extra="forbid"`), so the value is silently dropped:

- Every `Workflow` returned by either API has `workflow_rid=None`.
- `ExecutionRecord.workflow_rid` is a property that reads through `self._workflow.workflow_rid`, so it inherits the same None on every execution.

## Fix

Defensive `_resolve_workflow_rid` helpers in `tools.execution.read` and `tools.workflow`:

- **Fast path**: read the attribute. Once the upstream is patched, this is the only branch reached.
- **Recovery path**: fetch the Workflow FK via `ml._retrieve_rid(execution_rid)` (for executions) or `ml._find_workflow_rid_by_url(checksum or url)` (for workflows). One extra round trip per affected row, server-side filter, no scan.

The `tools.workflow` `_list_workflows_impl` sort key and pagination cursor also route through the resolver so the regression doesn't collapse sort to "all empty" or break cursor pagination.

## Audit table — every `deriva_ml_*` tool surveyed

| Tool                                          | Status   |
|-----------------------------------------------|----------|
| `deriva_ml_get_execution`                     | FIXED    |
| `deriva_ml_list_executions`                   | FIXED    |
| `deriva_ml_find_workflow_executions`          | FIXED    |
| `deriva_ml_list_execution_children`           | FIXED    |
| `deriva_ml_list_execution_parents`            | FIXED    |
| `deriva_ml_find_experiments`                  | FIXED    |
| `deriva_ml_list_workflows`                    | FIXED    |
| `deriva_ml_get_workflow`                      | FIXED    |
| `deriva_ml_find_workflow_by_url`              | FIXED    |
| `deriva_ml_create_workflow` (`exists` branch) | FIXED    |
| `deriva_ml_get_lineage`                       | OK       |
| `deriva_ml_list_assets` / `find_assets` / `lookup_asset` | OK |
| `deriva_ml_update_asset`                      | OK       |
| `deriva_ml_list_datasets` / `get_dataset` / `list_dataset_members` / `list_dataset_relations` / `list_dataset_element_types` / `bag_info` / `get_dataset_spec` / `validate_dataset_specs` / `validate_execution_configuration` / `denormalize_dataset` / `validate_config_file` / `bootstrap_config` | OK |
| `deriva_ml_list_features` / `get_feature`     | OK       |
| `deriva_ml_list_feature_values`               | IN-FLIGHT (deriva-ml `fix/feature-record-rid`) |
| `deriva_ml_create_feature` / `delete_feature` | OK       |
| `deriva_ml_create_vocabulary`                 | OK       |
| `deriva_ml_reindex_vocabularies` / `resync_indexes` | OK |
| dataset mutate (`create_dataset`, `add_dataset_members`, `delete_dataset_members`, `update_dataset`, `add_dataset_element_type`, `delete_dataset`, `release`) | OK |

All ten FIXED tools share the same root cause and route through the new resolver after this change. The IN-FLIGHT counterpart for the `FeatureRecord.RID` drop (curator/02) is being addressed in deriva-ml on branch `fix/feature-record-rid` (adds `RID: Optional[str]` to the `FeatureRecord` model); this PR doesn't duplicate that work — the deriva-ml-mcp side already sorts by `getattr(r, "RID", "") or ""` and validates through `FeatureValueRecord(RID=...)`, which becomes correct once the upstream populates it.

## Verification

Against catalog 18 (`e2e-test-20260526` alias on localhost):

```python
from deriva_ml_mcp.tools.execution.read import _summarize_execution
from deriva_ml import DerivaML
ml = DerivaML('localhost', '18')
print(_summarize_execution(ml.lookup_execution('DYC')).model_dump_json())
# {"rid":"DYC","workflow_rid":"DY6", ...}   ← was workflow_rid: null pre-fix
```

`list_execution_children(EA8)` returns all four children (`EC0`, `EJ0`, `ER0`, `EY0`) with `workflow_rid=DY6`, matching ermrest direct.

## Test plan

- [x] `uv run python -m pytest tests/` — 323 passed (309 baseline + 14 new tests covering fast path, recovery, error swallowing, end-to-end tool invocation, and mock-fixture drift detection).
- [x] Live catalog verification on `localhost` catalog 18.
- [x] `uv run ruff check src tests` clean.

## Test count delta

309 → 323 (+14).

## Followup: structural fix

This class of bug — a Pydantic response model that declares a field the projection doesn't populate, and the field's default (`None`) ships back to the client silently — has bitten us twice in two weeks (developer/02 here, curator/02 on `FeatureRecord.RID`).

A clean structural fix would be a decorator / mixin on the response models that walks the model fields at handler entry and asserts that every declared `Optional[str]` / required field has a non-None value before serialization, raising a `ProjectionDropError` (or similar) at MCP-boundary time so the failure is loud and locatable, not silent and downstream.

In practice the constraint is: many response fields are *legitimately* nullable (e.g., snapshot rows that predate a column, or executions with no Workflow FK). So the check would need a per-field opt-in (`expected_non_null: bool`) rather than a blanket assertion. A `must_be_populated: list[str]` class-level setting on each response model would do it.

Not implemented in this PR. Left as a tracking note in case the audit recurs on a third field — at that point the structural fix becomes worth the build cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)