### PR TITLE
chore(deps): bump deriva-ml lockfile to v1.39.3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -709,8 +709,8 @@ provides-extras = ["rag", "dev"]
 
 [[package]]
 name = "deriva-ml"
-version = "1.39.2"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#39d88f3940c23145255062c47a3cc7140926ea01" }
+version = "1.39.3"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#3a7d86204ad8208f7f891b4afbeea226e0173278" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
## Summary

Refresh `uv.lock` to pull deriva-ml v1.39.3 (previously v1.39.2). Picks up the close-out PRs from the denormalize audit thread:

- #239 — 13-key describe envelope with `warnings: list[str]` field
- #240 — `cache_age_seconds: float \| None` freshness signal on `DenormalizeResult`
- #243 — RB-07 resolver dedup-after-substitution
- #245 — doc cleanup (40 archived specs/plans + closed audit deleted)

## Test plan
- [x] `uv sync --extra dev` clean
- [x] `uv run pytest --co -q` — 328/348 tests collect (20 deselected by default `-m \"not integration\"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)