### PR TITLE
chore(deps): bump deriva-ml lockfile to v1.39.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -709,8 +709,8 @@ provides-extras = ["rag", "dev"]
 
 [[package]]
 name = "deriva-ml"
-version = "1.39.3"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#3a7d86204ad8208f7f891b4afbeea226e0173278" }
+version = "1.39.4"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#4ed881223fe1f57286f7abadbf4cefe4fa2132d4" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
## Summary

Refresh \`uv.lock\` to pull deriva-ml v1.39.4 (previously v1.39.3) — picks up the row-completeness fix in informatics-isi-edu/deriva-ml#246:

\`PagedFetcher._fetch_rid_batch_with_fallback\` was silently dropping RIDs when an oversized GET URL forced shrink-fallback. The chunk-loop replacement guarantees every requested RID is fetched. Surfaced by 2026-05-27 e2e at \`--num-images=1500\`; missed by the 2026-05-26 run at \`--num-images=500\` because RID batches stayed under the URL-guard threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)