### PR TITLE
chore(deps): refresh deriva-py pin to e944ad8e (path_walker available)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -658,7 +658,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?rev=deriva-ml#ed5ee69c9f65a383f85acc57d9513757a6d0a96e" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?rev=deriva-ml#e944ad8e8e0b8a3d7270ce49fdd236598b6d2c2a" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },


### PR DESCRIPTION
## Summary

Previous pin (\`ed5ee69c\`) predates the SchemaPathWalker module that landed in deriva-py's \`deriva-ml\` branch as part of the path-walker consolidation (deriva-ml #238 / deriva-py PR #263). deriva-ml's \`denormalize_planner._schema_to_paths\` imports \`deriva.bag.path_walker\` at runtime; against the stale pin it raises \`ModuleNotFoundError\`.

Surfaced by the 2026-05-27 second-pass multipersona run's P0 step 7 (\`load-cifar10 --phase datasets\` on a fresh worktree). The model-template lockfile gets the same bump in its sibling PR.

After this lands, the MCP docker container needs a rebuild via \`./scripts/rebuild-deriva-docker-mcp.sh\` so the running deriva-mcp-test image picks up the new deriva-py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)