### PR TITLE
docs(prompts): direct attribute access on deriva-ml domain objects

### DIFF
--- a/src/deriva_ml_mcp/prompts.py
+++ b/src/deriva_ml_mcp/prompts.py
@@ -191,6 +191,40 @@ DERIVA-ML DOMAIN OBJECTS, NOT AS RAW TABLES.
              local Python via the user's environment (``ml.download_asset``,
              ``exe.asset_file_path()``).
 
+USE DIRECT ATTRIBUTE ACCESS ON THESE DOMAIN OBJECTS
+---------------------------------------------------
+The five abstractions above are returned as TYPED records (Pydantic
+models / DerivaML domain objects), not as raw dicts. Read their
+fields with the dot operator:
+
+  - ``Dataset``         -> ``.dataset_rid``, ``.current_version``,
+                           ``.dataset_types``, ``.description``
+  - ``Execution``       -> ``.execution_rid``, ``.status``,
+                           ``.workflow``, ``.description``
+  - ``Workflow``        -> ``.workflow_rid``, ``.workflow_type``,
+                           ``.url``, ``.checksum``
+  - ``FeatureRecord``   -> one named attribute per feature column
+                           (``.Diagnosis_Type``, ``.Confidence``, ...)
+                           plus ``.Execution``, ``.Feature_Name``,
+                           ``.RCT``
+  - ``Asset``           -> ``.asset_rid``, ``.filename``, ``.length``,
+                           ``.md5``, ``.asset_types``
+
+The ``repr()`` of any domain object spells out its field names --
+``print(obj)`` is faster than guessing.
+
+DO NOT use ``getattr(obj, "name", default)`` on these objects. The
+attributes either exist by contract or they don't; a wrong name is
+an ``AttributeError`` you WANT to see. ``getattr``-with-default
+converts API ignorance into a silent fallback --
+``getattr(d, "version", "?")`` quietly returns ``"?"`` when the real
+field is ``current_version``, and the bug ships. Dot directly into
+the object, let ``AttributeError`` tell you what's wrong, and fix
+the call. Reach for ``getattr`` only when reflecting over genuinely
+unknown attribute names (e.g. iterating user-supplied column names,
+debug-printing arbitrary records). That is rare; the normal case is
+``obj.field_name``.
+
 THE ASSET_ROLE CONTRACT
 -----------------------
 Every execution-linked asset carries TWO pieces of role metadata


### PR DESCRIPTION
## Summary

Mirror of [`deriva-ml-skills` PR #70](https://github.com/informatics-isi-edu/deriva-ml-skills/pull/70). The `_CONCEPTS_GUIDE` prompt in `src/deriva_ml_mcp/prompts.py` is kept in lockstep with `skills/deriva-ml-context/SKILL.md` in the skills repo (see the SYNC comment at the top of this module).

Adds a new `USE DIRECT ATTRIBUTE ACCESS ON THESE DOMAIN OBJECTS` subsection under the five-abstractions block, sibling to the existing `THE ASSET_ROLE CONTRACT` section. Lists the named attributes on `Dataset` / `Execution` / `Workflow` / `FeatureRecord` / `Asset`, points at `print(obj)` for introspection, and warns against `getattr(obj, "name", default)` on typed Pydantic records.

## The observation

During a deriva-ml provenance debugging session, an operator reached for `getattr(d, 'version', '?')` on a `Dataset` domain object instead of writing `d.current_version` directly. The defensive `'?'` default silently swallowed an API-ignorance bug. The skills already taught `getattr(r, "Confidence", 0)` on `FeatureRecord` in several places (now fixed in the skills PR). The mechanical rule — "once you have a typed domain object, dot directly into it; don't use `getattr` with a default" — was missing from both the skill and this prompt.

The high-level "inheritance with override" rule (`THE RULE: INHERITANCE WITH OVERRIDE` lower in this file) was already correctly stated. What was missing was the mechanical follow-through at the attribute-access level once you have a domain object in hand.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('src/deriva_ml_mcp/prompts.py').read())"` parses cleanly
- [x] Section placement follows the SYNC convention (parallel placement to the skills file)

Pure documentation; no behaviour impact.