### PR TITLE
fix(rag): point MCP docs source at renamed deriva-ml-mcp-plugin repo

### DIFF
--- a/src/deriva_ml_mcp_plugin/resources/rag.py
+++ b/src/deriva_ml_mcp_plugin/resources/rag.py
@@ -138,15 +138,15 @@ _GITHUB_DOCS_PATH_PREFIX = ""
 _GITHUB_DOCS_DOC_TYPE = "ml-docs"
 
 
-# v3.x: index the deriva-ml-mcp repo's own top-level README so MCP
-# server documentation is searchable via rag_search alongside the
+# v3.x: index the deriva-ml-mcp-plugin repo's own top-level README so
+# MCP server documentation is searchable via rag_search alongside the
 # deriva-ml library docs. Same noise caveat as the deriva-ml source
 # above -- repo-root indexing also picks up CLAUDE.md and the
 # docs/scratch/*.md planning notes; the upstream exclude_paths=[...]
 # addition would let us drop these cleanly.
-_GITHUB_MCP_DOCS_NAME = "deriva-ml-mcp-docs"
+_GITHUB_MCP_DOCS_NAME = "deriva-ml-mcp-plugin-docs"
 _GITHUB_MCP_DOCS_OWNER = "informatics-isi-edu"
-_GITHUB_MCP_DOCS_REPO = "deriva-ml-mcp"
+_GITHUB_MCP_DOCS_REPO = "deriva-ml-mcp-plugin"
 _GITHUB_MCP_DOCS_BRANCH = "main"
 _GITHUB_MCP_DOCS_PATH_PREFIX = ""
 _GITHUB_MCP_DOCS_DOC_TYPE = "ml-mcp-docs"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -326,14 +326,14 @@ def test_register_wires_rag_github_sources(ctx):
       - 'deriva-ml-docs' -- the deriva-ml repo's user-guide / api-
         reference / etc. (v3.x: prefix widened from "docs/" to ""
         to also pick up the top-level README.md and CHANGELOG.md).
-      - 'deriva-ml-mcp-docs' -- the deriva-ml-mcp repo's own README
-        (v3.x: new source so MCP-server documentation is searchable
-        via rag_search alongside the library docs).
+      - 'deriva-ml-mcp-plugin-docs' -- the deriva-ml-mcp-plugin repo's
+        own README (v3.x: new source so MCP-server documentation is
+        searchable via rag_search alongside the library docs).
     """
     register(ctx)
     assert len(ctx._rag_sources) == 2
     names = {decl.name for decl in ctx._rag_sources}
-    assert names == {"deriva-ml-docs", "deriva-ml-mcp-docs"}
+    assert names == {"deriva-ml-docs", "deriva-ml-mcp-plugin-docs"}
 
 
 def test_register_wires_four_catalog_connect_hooks(ctx):

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -77,8 +77,8 @@ def rag_ctx(ctx):
 def test_register_rag_sources_declares_two_github_sources(rag_ctx) -> None:
     """register_rag_sources adds two GitHub documentation sources.
 
-    v3.x added a second source ('deriva-ml-mcp-docs') so the
-    deriva-ml-mcp repo's own README is searchable via rag_search
+    v3.x added a second source ('deriva-ml-mcp-plugin-docs') so the
+    deriva-ml-mcp-plugin repo's own README is searchable via rag_search
     alongside the deriva-ml library docs.
     """
     assert len(rag_ctx._rag_sources) == 2
@@ -100,10 +100,10 @@ def test_register_rag_sources_github_source_targets_deriva_ml_docs(rag_ctx) -> N
 
 
 def test_register_rag_sources_mcp_source_targets_deriva_ml_mcp_readme(rag_ctx) -> None:
-    """The second GitHub source points at informatics-isi-edu/deriva-ml-mcp repo root."""
-    decl = next(s for s in rag_ctx._rag_sources if s.name == "deriva-ml-mcp-docs")
+    """The second GitHub source points at informatics-isi-edu/deriva-ml-mcp-plugin repo root."""
+    decl = next(s for s in rag_ctx._rag_sources if s.name == "deriva-ml-mcp-plugin-docs")
     assert decl.repo_owner == "informatics-isi-edu"
-    assert decl.repo_name == "deriva-ml-mcp"
+    assert decl.repo_name == "deriva-ml-mcp-plugin"
     assert decl.branch == "main"
     assert decl.path_prefix == ""
     assert decl.doc_type == "ml-mcp-docs"


### PR DESCRIPTION
## Problem

The RAG startup crawl targeted `informatics-isi-edu/deriva-ml-mcp`, which was renamed to `deriva-ml-mcp-plugin` (the dist/import rename in #62). GitHub now answers every crawl of the old name with a `301 Moved Permanently`, and the crawler's `raise_for_status()` turns that into a hard failure:

```
WARNING  Startup doc update failed for 'deriva-ml-mcp-docs'
httpx.HTTPStatusError: Redirect response '301 Moved Permanently' for url
'https://api.github.com/repos/informatics-isi-edu/deriva-ml-mcp/git/trees/main?recursive=1'
```

So the MCP-server's own README has not been (re)indexed since the rename, and every container startup logs a failure for that source.

## Fix

- `resources/rag.py`: `_GITHUB_MCP_DOCS_REPO` → `deriva-ml-mcp-plugin`, and rename the source `deriva-ml-mcp-docs` → `deriva-ml-mcp-plugin-docs` for consistency with the dist/import rename.
- Update the two tests that assert the source name + repo (`test_plugin.py`, `test_rag.py`).

## Verification

- `uv run --extra dev pytest tests/test_rag.py tests/test_plugin.py -q` → **67 passed**
- `uv run --extra dev ruff check src tests` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)