### PR TITLE
chore(deps): sync deriva-ml to v1.41.2 (01b2fc3c)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -712,8 +712,8 @@ provides-extras = ["rag", "dev"]
 
 [[package]]
 name = "deriva-ml"
-version = "1.41.1"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#5377f999161da0dd15d2c3c965389da825e09561" }
+version = "1.41.2"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#01b2fc3c69ca06cba1aae61606de818f16948cb0" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
## What

Refresh `uv.lock` to pin **deriva-ml v1.41.2** (`01b2fc3c`), up from v1.41.1 (`5377f999`).

v1.41.2 is a patch release whose only change over v1.41.1 is PR #271 — a standalone `generate_association_indexes` operator tool (`scripts/generate_association_indexes.py`). No API surface used by this repo changed.

## Verification

`uv lock --upgrade-package deriva-ml --refresh-package deriva-ml` →
`Updated deriva-ml v1.41.1 (5377f999) -> v1.41.2 (01b2fc3c)`. Single-file lockfile change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)