### PR TITLE
fix: call find_vocabularies on ml.model, not the DerivaML facade

### DIFF
--- a/src/deriva_ml_mcp_plugin/resources/rag.py
+++ b/src/deriva_ml_mcp_plugin/resources/rag.py
@@ -1020,7 +1020,10 @@ async def _index_vocabularies(
     serializer = _VocabSerializer()
     indexed: dict[str, int] = {}
 
-    vocab_tables = await asyncio.to_thread(ml.find_vocabularies)
+    # find_vocabularies lives on the DerivaModel (ml.model), not on the
+    # DerivaML facade -- deriva-ml >=1.41 exposes it there. (list_vocabulary_terms
+    # below remains on ml directly.)
+    vocab_tables = await asyncio.to_thread(ml.model.find_vocabularies)
     for vocab_table in vocab_tables:
         qname = _table_qname(vocab_table)
         if only_vocab is not None and qname != only_vocab:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -415,7 +415,7 @@ def test_vocab_hook_writes_to_vocab_prefix_not_data_prefix(ctx):
     term.rid = "1-TRAIN"
 
     fake_ml = MagicMock()
-    fake_ml.find_vocabularies.return_value = [vocab_table]
+    fake_ml.model.find_vocabularies.return_value = [vocab_table]
     fake_ml.list_vocabulary_terms.return_value = [term]
 
     fake_store = MagicMock()

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -695,7 +695,7 @@ def test_index_vocabularies_writes_one_source_per_vocab() -> None:
     }
 
     fake_ml = MagicMock()
-    fake_ml.find_vocabularies.return_value = vocabs
+    fake_ml.model.find_vocabularies.return_value = vocabs
     fake_ml.list_vocabulary_terms.side_effect = lambda t: terms_by_table[
         f"{t.schema.name}.{t.name}"
     ]
@@ -726,6 +726,48 @@ def test_index_vocabularies_writes_one_source_per_vocab() -> None:
             assert chunk.source.startswith("vocab:h.example:1:")
 
 
+def test_index_vocabularies_calls_find_vocabularies_on_model_not_facade() -> None:
+    """Regression: find_vocabularies lives on ml.model, not the DerivaML facade.
+
+    deriva-ml >=1.41 exposes ``find_vocabularies`` on the ``DerivaModel``
+    (``ml.model``), not on the ``DerivaML`` object. A plain ``MagicMock``
+    auto-creates ``ml.find_vocabularies``, so it masked the real
+    ``AttributeError: 'DerivaML' object has no attribute 'find_vocabularies'``
+    seen at runtime. Here we ``del`` the facade attribute so accessing
+    ``ml.find_vocabularies`` raises (like the real object) -- the code must go
+    through ``ml.model.find_vocabularies`` or this test fails.
+    """
+    from deriva_ml import DerivaML
+
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    # Sanity-check the assumption this regression guards: the real facade
+    # does not expose find_vocabularies (if deriva-ml moves it back, revisit).
+    assert not hasattr(DerivaML, "find_vocabularies"), (
+        "DerivaML now exposes find_vocabularies directly; the ml.model "
+        "indirection in _index_vocabularies may no longer be needed."
+    )
+
+    fake_ml = MagicMock()
+    # Make the mock behave like the real DerivaML: no find_vocabularies on the
+    # facade. Accessing it now raises AttributeError instead of auto-creating.
+    del fake_ml.find_vocabularies
+    fake_ml.model.find_vocabularies.return_value = [_vocab_table("deriva-ml", "Dataset_Type")]
+    fake_ml.list_vocabulary_terms.return_value = [_vocab_term("Training", None, [], "1-T1")]
+    fake_store = MagicMock()
+    fake_store.delete_source = AsyncMock()
+    fake_store.add = AsyncMock()
+
+    with (
+        patch.object(rag_module, "get_rag_store", return_value=fake_store),
+        patch.object(rag_module, "get_ml", return_value=fake_ml),
+    ):
+        result = _run(rag_module._index_vocabularies("h.example", "1"))
+
+    assert result == {"deriva-ml.Dataset_Type": 1}
+    fake_ml.model.find_vocabularies.assert_called_once()
+
+
 def test_index_vocabularies_filter_only_writes_requested_vocab() -> None:
     """``only_vocab='schema.X'`` indexes only that vocab; others are skipped."""
     from deriva_ml_mcp_plugin.resources import rag as rag_module
@@ -735,7 +777,7 @@ def test_index_vocabularies_filter_only_writes_requested_vocab() -> None:
         _vocab_table("deriva-ml", "Workflow_Type"),
     ]
     fake_ml = MagicMock()
-    fake_ml.find_vocabularies.return_value = vocabs
+    fake_ml.model.find_vocabularies.return_value = vocabs
     fake_ml.list_vocabulary_terms.return_value = [_vocab_term("X", None, [], "1-T")]
 
     fake_store = MagicMock()
@@ -762,7 +804,7 @@ def test_index_vocabularies_per_vocab_failures_are_isolated(caplog) -> None:
     bad = _vocab_table("deriva-ml", "Broken_Vocab")
     good = _vocab_table("deriva-ml", "Working_Vocab")
     fake_ml = MagicMock()
-    fake_ml.find_vocabularies.return_value = [bad, good]
+    fake_ml.model.find_vocabularies.return_value = [bad, good]
 
     def fake_terms(t):
         if t is bad:
@@ -798,7 +840,7 @@ def test_index_vocabularies_short_circuits_when_store_none() -> None:
         result = _run(rag_module._index_vocabularies("h.example", "1"))
 
     assert result == {}
-    fake_ml.find_vocabularies.assert_not_called()
+    fake_ml.model.find_vocabularies.assert_not_called()
 
 
 def test_index_vocabularies_uses_shared_source_across_users() -> None:
@@ -814,7 +856,7 @@ def test_index_vocabularies_uses_shared_source_across_users() -> None:
 
     vocabs = [_vocab_table("deriva-ml", "Dataset_Type")]
     fake_ml = MagicMock()
-    fake_ml.find_vocabularies.return_value = vocabs
+    fake_ml.model.find_vocabularies.return_value = vocabs
     fake_ml.list_vocabulary_terms.return_value = [_vocab_term("Training", None, [], "1-T")]
 
     fake_store = MagicMock()


### PR DESCRIPTION
## Problem

The vocabulary RAG index pass crashes at runtime against live catalogs:

```
AttributeError: 'DerivaML' object has no attribute 'find_vocabularies'
  File ".../deriva_ml_mcp_plugin/resources/rag.py", line 1023, in _index_vocabularies
    vocab_tables = await asyncio.to_thread(ml.find_vocabularies)
```

Observed on the `dev.eye-ai.org/eye-ai` vocab index pass (the `_make_vocab_hook` on-connect hook).

## Root cause

`deriva-ml >= 1.41` exposes `find_vocabularies` on the **`DerivaModel`** (`ml.model.find_vocabularies`), **not** on the `DerivaML` facade. `_index_vocabularies` called it on the facade.

`list_vocabulary_terms` *is* still on the facade — so only the one call was wrong.

**Why CI stayed green:** the vocab tests used a plain `MagicMock`, which auto-creates `ml.find_vocabularies` on attribute access — masking the missing method. The bug only surfaced at runtime against a real `DerivaML`.

## Fix

- `resources/rag.py`: `ml.find_vocabularies` → `ml.model.find_vocabularies` (one call site; the others were docstrings).
- Tests: mock `ml.model.find_vocabularies` instead of `ml.find_vocabularies`.
- **New regression test** `test_index_vocabularies_calls_find_vocabularies_on_model_not_facade`: `del`s the facade attribute so accessing `ml.find_vocabularies` raises `AttributeError` like the real object. It **fails without the fix** (reproduces the exact runtime error) and **passes with it**, and asserts the real `DerivaML` class lacks the facade method (so it'll flag a revisit if deriva-ml moves it back).

## Verification

- `uv run pytest` → **329 passed** (was 328; +1 regression test). Lint clean.
- **Against the live catalog** (`dev.eye-ai.org/eye-ai`): `ml.model.find_vocabularies()` returns 33 vocab tables; `hasattr(ml, "find_vocabularies")` is `False`.

## Scope note

This fixes **Error 1** of two runtime errors seen on that catalog. The second (`setuptools-scm was unable to detect version` during `lookup_workflow` → `Workflow()` construction in a non-git CWD) is a separate issue in the Execution-row index path and likely belongs in `deriva-ml`'s workflow version introspection — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
