### PR TITLE
Add deriva_ml_find_dataset_executions + dataset filter on list_executions

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -27,7 +27,8 @@ environment; executions originate there, not in the MCP server.
 
 Read-side execution tools remain on the MCP surface:
 `deriva_ml_list_executions`, `deriva_ml_get_execution`,
-`deriva_ml_find_workflow_executions`, `deriva_ml_list_execution_children`,
+`deriva_ml_find_workflow_executions`, `deriva_ml_find_dataset_executions`,
+`deriva_ml_list_execution_children`,
 `deriva_ml_list_execution_parents`, `deriva_ml_get_lineage`. Plus the
 three execution-related resources
 (`/ml/executions`, `/ml/execution/{rid}`, `/ml/lineage/{rid}`). These

--- a/src/deriva_ml_mcp_plugin/_response_models.py
+++ b/src/deriva_ml_mcp_plugin/_response_models.py
@@ -106,7 +106,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, SerializeAsAny
 
 # ---------------------------------------------------------------------------
 # Preflight-count response (shared by every paginated tool's
@@ -385,6 +385,38 @@ class ExecutionSummary(BaseModel):
     upload_duration: timedelta | str | None = None
 
 
+class DatasetExecutionSummary(ExecutionSummary):
+    """ExecutionSummary plus the dataset-edge role/version for dataset-scoped queries.
+
+    Returned (in place of plain ``ExecutionSummary``) by
+    ``_list_executions_impl`` whenever a dataset filter is active --
+    i.e. by ``deriva_ml_find_dataset_executions`` and by
+    ``deriva_ml_list_executions(dataset=...)``. The two extra fields
+    answer "how is this execution related to the dataset I asked
+    about?":
+
+    - ``dataset_role`` -- ``"input"`` when the execution *consumed* the
+      dataset (a ``Dataset_Execution`` edge), ``"output"`` when it
+      *produced* the dataset version (authored a ``Dataset_Version``).
+      The role is derived relationally per row, never read from a
+      config file.
+    - ``dataset_version`` -- the version string of the dataset edge for
+      that execution, or ``None`` when no version is pinned/resolvable
+      (e.g. an input edge consumed at the live/unpinned state).
+
+    Serialization note: ``ExecutionListResponse.executions`` is typed
+    ``list[SerializeAsAny[ExecutionSummary]]`` so a list carrying these
+    subclass instances keeps ``dataset_role`` / ``dataset_version`` on
+    the wire (plain Pydantic v2 base-typed serialization would drop
+    subclass-only fields). A list of plain ``ExecutionSummary`` rows
+    serializes byte-identically to before, so the no-dataset path is
+    unaffected.
+    """
+
+    dataset_role: str  # "input" | "output"
+    dataset_version: str | None = None
+
+
 class ExecutionInputDatasetRef(BaseModel):
     """One input dataset on an Execution detail's ``inputs.datasets`` list.
 
@@ -559,9 +591,20 @@ class ExecutionListResponse(_PaginationFields):
     Also returned by ``deriva_ml_find_workflow_executions`` (since v2.3),
     which reuses this shape -- it's a paginated list of executions
     filtered by workflow.
+
+    The ``executions`` field is wrapped in ``SerializeAsAny`` so that
+    when ``_list_executions_impl`` runs with a dataset filter and
+    populates the list with ``DatasetExecutionSummary`` subclass
+    instances, the subclass-only fields (``dataset_role`` /
+    ``dataset_version``) survive ``model_dump_json``. Without
+    ``SerializeAsAny``, Pydantic v2 serializes each row against the
+    declared base type (``ExecutionSummary``) and silently drops the
+    subclass fields. A list of plain ``ExecutionSummary`` rows is
+    unaffected -- it serializes byte-identically to before, so the
+    no-dataset path keeps its exact wire shape.
     """
 
-    executions: list[ExecutionSummary]
+    executions: list[SerializeAsAny[ExecutionSummary]]
 
 
 class ExecutionChildrenResponse(BaseModel):

--- a/src/deriva_ml_mcp_plugin/prompts.py
+++ b/src/deriva_ml_mcp_plugin/prompts.py
@@ -4,7 +4,7 @@ These are MCP prompts (registered via ``@ctx.prompt(...)``), not Python
 docstrings. FastMCP surfaces them through the MCP ``prompts/list`` and
 ``prompts/get`` endpoints so an LLM client can pull them up by name at
 the start of a conversation -- they are the cold-start anchor for the
-plugin's 43 tools and 18 resources.
+plugin's 44 tools and 18 resources.
 
 The two prompts complement the four built-in core prompts shipped by
 ``deriva-mcp-core`` (``query_guide``, ``entity_guide``,
@@ -162,6 +162,7 @@ DERIVA-ML DOMAIN OBJECTS, NOT AS RAW TABLES.
              with ``deriva_ml_list_executions`` /
              ``deriva_ml_get_execution`` /
              ``deriva_ml_find_workflow_executions`` /
+             ``deriva_ml_find_dataset_executions`` /
              ``deriva_ml_get_lineage`` after the run lands. The full
              lifecycle (create / start / commit / abort / update /
              add_feature_values / create_execution_dataset /
@@ -673,7 +674,7 @@ you're driving the library directly from a notebook or skill.
 
 THE FIVE ML DOMAINS
 -------------------
-Forty of the 43 tools are organized into five domain modules (the
+Forty-one of the 44 tools are organized into five domain modules (the
 other three are the catalog-maintenance tools
 ``deriva_ml_create_vocabulary``, ``deriva_ml_reindex_vocabularies``,
 and ``deriva_ml_resync_indexes``). Pick the domain first, then the
@@ -703,12 +704,17 @@ for the wire name.
                   URL + checksum + workflow_type). Verbs: list / get /
                   find_workflow_by_url / create / update.
 
-    execution  -- 7 tools (read-only). A single run of a workflow
+    execution  -- 8 tools (read-only). A single run of a workflow
                   against datasets and assets. The MCP surface for
                   executions is observational only: list / get /
-                  find_workflow_executions / list_execution_children /
+                  find_workflow_executions / find_dataset_executions /
+                  list_execution_children /
                   list_execution_parents / find_experiments /
-                  get_lineage. The full
+                  get_lineage. ``find_dataset_executions`` answers
+                  "which runs used this dataset?" -- role is derived
+                  relationally (input = a Dataset_Execution edge,
+                  output = Dataset_Version authorship), never from a
+                  config file. The full
                   lifecycle (create / start / commit / abort / update /
                   add_feature_values / create_execution_dataset /
                   add_nested_execution) is owned by the caller's local
@@ -1033,7 +1039,7 @@ and ``description``. There is no compat shim; update any references.
 
 THE MENU
 --------
-Quick orientation: 43 tools -- 40 across the 5 ML domains (dataset,
+Quick orientation: 44 tools -- 41 across the 5 ML domains (dataset,
 feature, workflow, execution, asset) plus 3 catalog-maintenance tools
 (create_vocabulary, reindex_vocabularies, resync_indexes) -- + 18
 read-only resources under the

--- a/src/deriva_ml_mcp_plugin/tools/execution/read.py
+++ b/src/deriva_ml_mcp_plugin/tools/execution/read.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import asyncio
 from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from deriva_mcp_core import deriva_call
 from deriva_ml.execution.execution import ExecutionStatus
@@ -175,6 +175,40 @@ def _dataset_version_str(dataset: Any) -> str | None:
     """
     version = getattr(dataset, "version", None)
     return str(version) if version is not None else None
+
+
+# Cursor key separator for the dataset-scoped path. A single execution
+# can appear TWICE in a ``dataset_role="any"`` result -- once as an
+# "input" row (it consumed version N) and once as an "output" row (it
+# authored version N+1) of the SAME dataset RID. Those two rows share a
+# ``rid`` but differ in ``dataset_role``. Paginating on ``rid`` alone
+# would let ``_paginate``'s strict ``key(it) > after_rid`` skip the
+# second same-rid row whenever the pair straddles a page boundary
+# (silent row loss). So the dataset path keys the cursor on the
+# composite ``f"{rid}\x00{dataset_role}"`` instead. ``\x00`` (NUL) is
+# used as the joiner because it sorts before every printable character
+# and can never occur inside a RID or a role token, so the composite
+# ordering is a clean refinement of RID order and the round-trip cursor
+# is unambiguous.
+_DATASET_CURSOR_SEP = "\x00"
+
+
+def _dataset_cursor_key(row: DatasetExecutionSummary) -> str:
+    """Composite pagination key for a dataset-scoped execution row.
+
+    Returns ``f"{rid}\\x00{dataset_role}"`` so the input and output rows
+    of a dual-role execution occupy distinct cursor positions. The
+    returned string is exactly what flows back to the client as
+    ``next_after_rid`` and is re-supplied as ``after_rid`` on the next
+    call, so the cursor round-trips correctly through ``_paginate``.
+
+    Args:
+        row: A ``DatasetExecutionSummary`` row.
+
+    Returns:
+        The composite cursor key.
+    """
+    return f"{row.rid or ''}{_DATASET_CURSOR_SEP}{row.dataset_role}"
 
 
 def _summarize_dataset_execution(
@@ -349,12 +383,17 @@ def _list_executions_impl(
         if sort:
             rows: list[Any] = tagged
         else:
-            rows = sorted(tagged, key=lambda e: e.rid or "")
+            # Sort on the SAME composite key the cursor uses so the
+            # ascending order and the strict ``> after_rid`` comparison
+            # in _paginate agree (otherwise a dual-role pair could be
+            # ordered by rid but cursored by composite, reintroducing
+            # the skip).
+            rows = sorted(tagged, key=_dataset_cursor_key)
         page, truncated, next_after = _paginate(
             rows,
             after_rid=after_rid,
             limit=limit,
-            key=partial(_read_rid, rid_key="rid"),
+            key=_dataset_cursor_key,
         )
         return ExecutionListResponse(
             executions=page,
@@ -654,7 +693,7 @@ def register(ctx: PluginContext) -> None:
         preflight_count: bool = False,
         sort: bool = False,
         dataset: str | None = None,
-        dataset_role: str = "any",
+        dataset_role: Literal["input", "output", "any"] = "any",
         dataset_version: str | None = None,
     ) -> str:
         """Browse executions in the catalog, optionally filtered by workflow, workflow type, status, or dataset.
@@ -930,7 +969,7 @@ def register(ctx: PluginContext) -> None:
         hostname: str,
         catalog_id: str,
         dataset_rid: str,
-        dataset_role: str = "any",
+        dataset_role: Literal["input", "output", "any"] = "any",
         dataset_version: str | None = None,
         status: str | None = None,
         limit: int = 100,

--- a/src/deriva_ml_mcp_plugin/tools/execution/read.py
+++ b/src/deriva_ml_mcp_plugin/tools/execution/read.py
@@ -43,6 +43,7 @@ from deriva_ml_mcp_plugin._helpers import (
     _read_rid,
 )
 from deriva_ml_mcp_plugin._response_models import (
+    DatasetExecutionSummary,
     ExecutionAssetRef,
     ExecutionChildrenResponse,
     ExecutionDetail,
@@ -129,6 +130,79 @@ def _resolve_workflow_rid(record: Any) -> str | None:
         return None
 
 
+def _build_dataset_arg(dataset: str | None, dataset_version: str | None) -> Any | None:
+    """Build the ``dataset`` argument passed to the executions impl.
+
+    Args:
+        dataset: A Dataset RID string, or ``None`` when no dataset filter
+            is requested.
+        dataset_version: A version string to pin via ``DatasetSpec``, or
+            ``None`` for the bare-RID (live/current) query.
+
+    Returns:
+        ``None`` when ``dataset`` is ``None``; a
+        ``deriva_ml.dataset.aux_classes.DatasetSpec`` pinned to
+        ``dataset_version`` when a version is supplied; otherwise the
+        bare RID string.
+    """
+    if dataset is None:
+        return None
+    if dataset_version is not None:
+        # Local import per the plan: keep the DatasetSpec dependency off
+        # the module-import path (the installed deriva-ml may pin a
+        # version whose DatasetSpec import surface differs).
+        from deriva_ml.dataset.aux_classes import DatasetSpec
+
+        return DatasetSpec(rid=dataset, version=dataset_version)
+    return dataset
+
+
+def _dataset_version_str(dataset: Any) -> str | None:
+    """Extract a version string from a dataset filter argument.
+
+    The dataset filter passed to :func:`_list_executions_impl` is either
+    a bare RID string (no pinned version) or a
+    ``deriva_ml.dataset.aux_classes.DatasetSpec`` (version pinned via
+    the tool's ``dataset_version`` arg). When it's a spec carrying a
+    non-null ``version``, return that version stringified; otherwise
+    return ``None`` (bare RID, or spec with no version).
+
+    Args:
+        dataset: A RID string or a ``DatasetSpec``.
+
+    Returns:
+        The pinned version string, or ``None``.
+    """
+    version = getattr(dataset, "version", None)
+    return str(version) if version is not None else None
+
+
+def _summarize_dataset_execution(
+    record: Any, *, dataset_role: str, dataset_version: str | None
+) -> DatasetExecutionSummary:
+    """Render an ``ExecutionRecord`` into a dataset-scoped summary row.
+
+    Wraps the plain :func:`_summarize_execution` fields and adds the
+    per-row dataset-edge ``dataset_role`` / ``dataset_version`` so the
+    caller can see how each execution relates to the queried dataset.
+
+    Args:
+        record: An ``ExecutionRecord`` (or ``Execution``) object.
+        dataset_role: ``"input"`` or ``"output"`` for THIS record's edge.
+        dataset_version: The dataset version string for the edge, or
+            ``None`` when unpinned / unresolvable.
+
+    Returns:
+        ``DatasetExecutionSummary`` Pydantic instance.
+    """
+    base = _summarize_execution(record)
+    return DatasetExecutionSummary(
+        **base.model_dump(),
+        dataset_role=dataset_role,
+        dataset_version=dataset_version,
+    )
+
+
 def _summarize_execution(record: Any) -> ExecutionSummary:
     """Render an ``ExecutionRecord`` (or ``Execution``) into the validated summary.
 
@@ -194,6 +268,8 @@ def _list_executions_impl(
     after_rid: str | None,
     limit: int,
     sort: bool = False,
+    dataset: Any | None = None,
+    dataset_role: str = "any",
 ) -> ExecutionListResponse:
     """Fetch + paginate executions. Pure helper -- shared by tool and resource.
 
@@ -220,11 +296,73 @@ def _list_executions_impl(
             cursor still works ("skip up to this RID in the RCT-sorted
             result"), but pagination through very large sorted result
             sets is bounded by the internal fetch cap.
+        dataset: Optional dataset filter -- a Dataset RID string or a
+            ``deriva_ml.dataset.aux_classes.DatasetSpec`` (when the caller
+            pinned a version). When set, the helper returns
+            ``DatasetExecutionSummary`` rows carrying the per-row
+            ``dataset_role`` / ``dataset_version`` instead of plain
+            ``ExecutionSummary``; when ``None`` (the default) the
+            response shape is byte-identical to the non-dataset path.
+        dataset_role: ``"input"`` (executions that consumed the
+            dataset), ``"output"`` (executions that produced the dataset
+            version), or ``"any"`` (both). Only consulted when
+            ``dataset`` is set.
 
     Returns:
         ``ExecutionListResponse`` -- see ``deriva_ml_mcp_plugin._response_models``.
+        Its ``executions`` rows are plain ``ExecutionSummary`` when
+        ``dataset is None`` and ``DatasetExecutionSummary`` otherwise.
+
+    Note (per-row role + version resolution):
+        The library's ``find_executions(dataset=, dataset_role=)`` yields
+        plain ``ExecutionRecord`` objects -- it does NOT tag role or
+        version per row. To attach a role to each execution, this helper
+        partitions the query by edge: when ``dataset_role == "any"`` it
+        issues two ``find_executions`` calls (``dataset_role="input"``
+        and ``dataset_role="output"``) and tags each returned record
+        with the role of the call that produced it; for a specific role
+        it issues one call and tags every row with that role. The
+        ``dataset_version`` is taken from the pinned ``DatasetSpec``
+        version (same for every row in a pinned query), or ``None`` for
+        a bare-RID (unpinned) query.
     """
     status_enum = ExecutionStatus(status) if status else None
+
+    # Dataset-scoped path: partition by edge so each row can carry its
+    # role. See the "per-row role + version resolution" note above.
+    if dataset is not None:
+        version = _dataset_version_str(dataset)
+        roles = ("input", "output") if dataset_role == "any" else (dataset_role,)
+        tagged: list[DatasetExecutionSummary] = []
+        for role in roles:
+            for record in ml.find_executions(
+                workflow=workflow_rid,
+                workflow_type=workflow_type,
+                status=status_enum,
+                sort=True if sort else None,
+                dataset=dataset,
+                dataset_role=role,
+            ):
+                tagged.append(
+                    _summarize_dataset_execution(record, dataset_role=role, dataset_version=version)
+                )
+        if sort:
+            rows: list[Any] = tagged
+        else:
+            rows = sorted(tagged, key=lambda e: e.rid or "")
+        page, truncated, next_after = _paginate(
+            rows,
+            after_rid=after_rid,
+            limit=limit,
+            key=partial(_read_rid, rid_key="rid"),
+        )
+        return ExecutionListResponse(
+            executions=page,
+            count=len(page),
+            truncated=truncated,
+            next_after_rid=next_after,
+        )
+
     raw = list(
         ml.find_executions(
             workflow=workflow_rid,
@@ -255,6 +393,50 @@ def _list_executions_impl(
         truncated=truncated,
         next_after_rid=next_after,
     )
+
+
+def _count_dataset_executions(
+    ml: Any,
+    *,
+    dataset: Any,
+    dataset_role: str,
+    workflow_rid: str | None,
+    workflow_type: str | None,
+    status_enum: Any,
+) -> int:
+    """Count executions on the dataset's input/output edge(s).
+
+    Mirrors the partition-by-edge strategy of :func:`_list_executions_impl`
+    so the preflight count matches the page that a non-preflight call
+    would produce: when ``dataset_role == "any"`` it sums the input and
+    output edge counts; otherwise it counts the one requested edge.
+
+    Args:
+        ml: A connected ``deriva_ml.DerivaML`` instance.
+        dataset: A Dataset RID string or ``DatasetSpec``.
+        dataset_role: ``"input"`` / ``"output"`` / ``"any"``.
+        workflow_rid: Optional workflow RID filter.
+        workflow_type: Optional workflow-type filter.
+        status_enum: Optional ``ExecutionStatus`` (already parsed).
+
+    Returns:
+        Total matching execution count across the selected edge(s).
+    """
+    roles = ("input", "output") if dataset_role == "any" else (dataset_role,)
+    total = 0
+    for role in roles:
+        total += len(
+            list(
+                ml.find_executions(
+                    workflow=workflow_rid,
+                    workflow_type=workflow_type,
+                    status=status_enum,
+                    dataset=dataset,
+                    dataset_role=role,
+                )
+            )
+        )
+    return total
 
 
 def _get_execution_detail_impl(ml: Any, execution_rid: str) -> ExecutionDetail:
@@ -471,8 +653,11 @@ def register(ctx: PluginContext) -> None:
         after_rid: str | None = None,
         preflight_count: bool = False,
         sort: bool = False,
+        dataset: str | None = None,
+        dataset_role: str = "any",
+        dataset_version: str | None = None,
     ) -> str:
-        """Browse executions in the catalog, optionally filtered by workflow, workflow type, or status.
+        """Browse executions in the catalog, optionally filtered by workflow, workflow type, status, or dataset.
 
         See ``deriva_ml_getting_started`` (PAGINATION CONTRACT) for the two-step pagination flow.
 
@@ -494,11 +679,28 @@ def register(ctx: PluginContext) -> None:
                 creation time. Recommended for "show me the most
                 recent runs" queries. Default False preserves the
                 stable RID-ascending order used for cursor pagination.
+            dataset: If set (a Dataset RID), restrict to executions that
+                used this dataset. Each returned row gains a
+                ``dataset_role`` (``"input"`` / ``"output"``) and a
+                nullable ``dataset_version``. For the dataset-centric
+                intent, prefer ``deriva_ml_find_dataset_executions``;
+                this parameter exists so the general browse tool can
+                reach the same query. When ``dataset`` is omitted, the
+                response shape is unchanged (no dataset keys).
+            dataset_role: ``"input"`` (executions that consumed the
+                dataset), ``"output"`` (executions that produced the
+                dataset version), or ``"any"`` (both). Only consulted
+                when ``dataset`` is set.
+            dataset_version: If set (with ``dataset``), pin the query to
+                this dataset version via a ``DatasetSpec``; otherwise the
+                bare RID resolves to the current/live state.
 
         Returns:
             Page: ``{"executions": [...], "count",
             "truncated", "next_after_rid"}``. Preflight: ``{"total_count",
-            "entities_fetched": False, "action_required"}``.
+            "entities_fetched": False, "action_required"}``. When a
+            dataset filter is active, each execution row additionally
+            carries ``dataset_role`` and ``dataset_version``.
 
         Raises:
             RuntimeError: Wrapped, propagated from
@@ -520,21 +722,39 @@ def register(ctx: PluginContext) -> None:
                 # not on the event loop. See deriva-mcp-core
                 # plugin-authoring-guide.md §"Synchronous work in threads".
                 ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                # Build the dataset arg: a version-pinned DatasetSpec when
+                # dataset_version is given, else the bare RID. None when
+                # no dataset filter is requested -- the no-dataset path is
+                # byte-identical to before this feature.
+                dataset_arg = _build_dataset_arg(dataset, dataset_version)
                 if preflight_count:
                     status_enum = ExecutionStatus(status) if status else None
 
-                    def _count_executions() -> int:
-                        return len(
-                            list(
-                                ml.find_executions(
-                                    workflow=workflow_rid,
-                                    workflow_type=workflow_type,
-                                    status=status_enum,
+                    if dataset_arg is not None:
+
+                        def _count() -> int:
+                            return _count_dataset_executions(
+                                ml,
+                                dataset=dataset_arg,
+                                dataset_role=dataset_role,
+                                workflow_rid=workflow_rid,
+                                workflow_type=workflow_type,
+                                status_enum=status_enum,
+                            )
+                    else:
+
+                        def _count() -> int:
+                            return len(
+                                list(
+                                    ml.find_executions(
+                                        workflow=workflow_rid,
+                                        workflow_type=workflow_type,
+                                        status=status_enum,
+                                    )
                                 )
                             )
-                        )
 
-                    total = await asyncio.to_thread(_count_executions)
+                    total = await asyncio.to_thread(_count)
                     return PreflightCountResponse(
                         total_count=total,
                         action_required=(
@@ -552,6 +772,8 @@ def register(ctx: PluginContext) -> None:
                     after_rid=after_rid,
                     limit=capped,
                     sort=sort,
+                    dataset=dataset_arg,
+                    dataset_role=dataset_role,
                 )
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
@@ -698,6 +920,130 @@ def register(ctx: PluginContext) -> None:
             return _error_envelope(
                 exc,
                 operation="find_workflow_executions",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,
+            )
+
+    @ctx.tool(mutates=False)
+    async def deriva_ml_find_dataset_executions(
+        hostname: str,
+        catalog_id: str,
+        dataset_rid: str,
+        dataset_role: str = "any",
+        dataset_version: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        after_rid: str | None = None,
+        preflight_count: bool = False,
+        sort: bool = False,
+    ) -> str:
+        """Find executions that used a dataset (input, output, or any).
+
+        Distinct from ``deriva_ml_list_executions(dataset=...)`` to surface
+        the dataset-centric query as a first-class tool -- the LLM intent
+        ("which runs used this dataset?") differs from the general
+        "browse executions" intent, mirroring the
+        ``deriva_ml_find_workflow_executions`` precedent.
+
+        The per-row ``dataset_role`` is derived **relationally**, never
+        from a config file: ``"input"`` means the execution consumed the
+        dataset (a ``Dataset_Execution`` edge); ``"output"`` means the
+        execution authored the dataset version (a ``Dataset_Version``
+        authorship). Each returned row also carries ``dataset_version``
+        (the pinned version when ``dataset_version`` is supplied, else
+        null).
+
+        Args:
+            dataset_rid: The RID of the dataset whose executions to find.
+            dataset_role: ``"input"`` (consumed the dataset), ``"output"``
+                (produced the dataset version), or ``"any"`` (both,
+                default).
+            dataset_version: If set, pin the query to this dataset
+                version via a ``DatasetSpec``; otherwise the bare RID
+                resolves to the current/live state.
+            status: Optional ``ExecutionStatus`` filter.
+            limit: Max executions per page (default 100, max 1000).
+            after_rid: RID of last row from previous page to advance cursor.
+            preflight_count: If True, return only total count.
+            sort: If True, return results newest-first by record
+                creation time. Recommended for "show me the most
+                recent runs" queries. Default False preserves the
+                stable RID-ascending order used for cursor pagination.
+
+        Returns:
+            Same shape as ``deriva_ml_list_executions`` with a dataset
+            filter active: each execution row carries ``dataset_role``
+            and ``dataset_version`` in addition to the summary fields.
+            Preflight: ``{"total_count", "entities_fetched": False,
+            "action_required"}``.
+
+        Raises:
+            RuntimeError: Wrapped, propagated from
+                ``deriva_ml.DerivaML.find_executions``.
+
+        Example:
+            ``{"executions": [{"rid": "1-EXEC", "workflow_rid": "1-WF",
+            "status": "Stopped", "dataset_role": "input",
+            "dataset_version": "1.2.0", ...}], "count": 1,
+            "truncated": false, "next_after_rid": null}``.
+        """
+        try:
+            with deriva_call():
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``ml.find_executions``
+                # returns a generator that materializes over the wire, so
+                # the drain (list) must happen inside the worker thread,
+                # not on the event loop. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                # Version-pinned DatasetSpec when a version is given, else
+                # the bare RID. ``dataset_rid`` is always present here so
+                # the result is never None.
+                dataset_arg = _build_dataset_arg(dataset_rid, dataset_version)
+                if preflight_count:
+                    status_enum = ExecutionStatus(status) if status else None
+
+                    def _count() -> int:
+                        return _count_dataset_executions(
+                            ml,
+                            dataset=dataset_arg,
+                            dataset_role=dataset_role,
+                            workflow_rid=None,
+                            workflow_type=None,
+                            status_enum=status_enum,
+                        )
+
+                    total = await asyncio.to_thread(_count)
+                    return PreflightCountResponse(
+                        total_count=total,
+                        action_required=(
+                            f"Found {total} executions for dataset {dataset_rid}. "
+                            "Choose a limit and call again with preflight_count=False."
+                        ),
+                    ).model_dump_json(by_alias=True)
+
+                capped = min(max(limit, 0), _MAX_LIMIT)
+                # workflow_rid / workflow_type are None: this tool is
+                # dataset-scoped by design. Cross-filtering by workflow
+                # belongs in deriva_ml_list_executions.
+                payload = await asyncio.to_thread(
+                    _list_executions_impl,
+                    ml,
+                    workflow_rid=None,
+                    workflow_type=None,
+                    status=status,
+                    after_rid=after_rid,
+                    limit=capped,
+                    sort=sort,
+                    dataset=dataset_arg,
+                    dataset_role=dataset_role,
+                )
+            return payload.model_dump_json(by_alias=True)
+        except Exception as exc:
+            return _error_envelope(
+                exc,
+                operation="find_dataset_executions",
                 hostname=hostname,
                 catalog_id=catalog_id,
                 audit=False,

--- a/tests/test_find_dataset_executions.py
+++ b/tests/test_find_dataset_executions.py
@@ -1,0 +1,280 @@
+"""Unit tests for the dataset-scoped execution query surface.
+
+Covers the two tools that expose the library's
+``ml.find_executions(dataset=..., dataset_role=...)``:
+
+- ``deriva_ml_find_dataset_executions`` -- the dataset-centric intent
+  tool (mirrors ``deriva_ml_find_workflow_executions``).
+- ``deriva_ml_list_executions(dataset=...)`` -- the same query reachable
+  from the general browse tool.
+
+All tests drive the ``mock_ml`` MagicMock; none touch a live catalog.
+The library-side ``find_executions(dataset=, dataset_role=)`` is NOT in
+the installed deriva-ml package, but a MagicMock accepts the kwargs and
+returns whatever the test configures, so the impl can be exercised
+end-to-end against the mock.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from deriva_ml.execution.execution import ExecutionStatus
+
+from tests._helpers import make_patch_audit
+
+_patch_execution_audit = make_patch_audit("execution")
+
+
+def _make_execution_record_mock(
+    rid: str = "1-EXEC",
+    workflow_rid: str = "1-WF",
+    status: ExecutionStatus = ExecutionStatus.Created,
+    description: str = "",
+    start_time: datetime | None = None,
+    stop_time: datetime | None = None,
+    duration: str | None = None,
+) -> MagicMock:
+    """Build an ``ExecutionRecord``-shaped MagicMock (same shape as test_execution.py)."""
+    record = MagicMock()
+    record.execution_rid = rid
+    record.workflow_rid = workflow_rid
+    workflow = MagicMock()
+    workflow.rid = workflow_rid
+    record.workflow = workflow
+    record.status = status
+    record.description = description
+    record.start_time = start_time
+    record.stop_time = stop_time
+    record.duration = duration
+    return record
+
+
+@pytest.fixture()
+def execution_ctx(ctx, mock_ml):
+    """Register execution tools with mock_ml as the DerivaML stand-in."""
+    with patch("deriva_ml_mcp_plugin.tools.execution.get_ml", return_value=mock_ml):
+        from deriva_ml_mcp_plugin.tools import execution as execution_module
+
+        execution_module.register(ctx)
+        yield ctx
+
+
+def _role_partitioned_side_effect(*, input_rids: list[str], output_rids: list[str]):
+    """Return a side_effect for ``find_executions`` that partitions by ``dataset_role``.
+
+    The impl is expected to query input and output edges separately
+    (one ``find_executions`` call per role) when it needs per-row role
+    tagging. This helper returns the per-role record lists so a test
+    can assert the resulting role tags.
+    """
+
+    def _side_effect(*args, **kwargs):
+        role = kwargs.get("dataset_role")
+        if role == "input":
+            return [_make_execution_record_mock(rid=r) for r in input_rids]
+        if role == "output":
+            return [_make_execution_record_mock(rid=r) for r in output_rids]
+        return []
+
+    return _side_effect
+
+
+# ---------------------------------------------------------------------------
+# deriva_ml_find_dataset_executions
+# ---------------------------------------------------------------------------
+
+
+async def test_find_dataset_executions_any_role_tags_rows(execution_ctx, capturing_mcp, mock_ml):
+    """dataset_role="any" returns rows tagged with their input/output role."""
+    mock_ml.find_executions.side_effect = _role_partitioned_side_effect(
+        input_rids=["1-IN"], output_rids=["1-OUT"]
+    )
+    result = await capturing_mcp.tools["deriva_ml_find_dataset_executions"](
+        hostname="h", catalog_id="1", dataset_rid="1-DSET"
+    )
+    payload = json.loads(result)
+    assert payload["count"] == 2
+    rows = {e["rid"]: e for e in payload["executions"]}
+    assert rows["1-IN"]["dataset_role"] == "input"
+    assert rows["1-OUT"]["dataset_role"] == "output"
+    # Every row carries the dataset_role + dataset_version keys.
+    for e in payload["executions"]:
+        assert "dataset_role" in e
+        assert "dataset_version" in e
+
+
+async def test_find_dataset_executions_input_role_only(execution_ctx, capturing_mcp, mock_ml):
+    """dataset_role="input" queries the input edge and tags rows 'input'."""
+    mock_ml.find_executions.return_value = [_make_execution_record_mock(rid="1-IN")]
+    result = await capturing_mcp.tools["deriva_ml_find_dataset_executions"](
+        hostname="h", catalog_id="1", dataset_rid="1-DSET", dataset_role="input"
+    )
+    payload = json.loads(result)
+    assert payload["count"] == 1
+    assert payload["executions"][0]["dataset_role"] == "input"
+    # The bare RID is forwarded as the dataset arg.
+    _args, kwargs = mock_ml.find_executions.call_args
+    assert kwargs["dataset"] == "1-DSET"
+    assert kwargs["dataset_role"] == "input"
+
+
+async def test_find_dataset_executions_version_builds_datasetspec(
+    execution_ctx, capturing_mcp, mock_ml
+):
+    """A scalar dataset_version constructs a DatasetSpec(rid, version) for the impl."""
+    from deriva_ml.dataset.aux_classes import DatasetSpec
+
+    mock_ml.find_executions.return_value = [_make_execution_record_mock(rid="1-IN")]
+    result = await capturing_mcp.tools["deriva_ml_find_dataset_executions"](
+        hostname="h",
+        catalog_id="1",
+        dataset_rid="1-DSET",
+        dataset_role="input",
+        dataset_version="1.2.0",
+    )
+    payload = json.loads(result)
+    # The dataset arg passed to the library is a DatasetSpec pinned to the version.
+    _args, kwargs = mock_ml.find_executions.call_args
+    spec = kwargs["dataset"]
+    assert isinstance(spec, DatasetSpec)
+    assert spec.rid == "1-DSET"
+    assert str(spec.version) == "1.2.0"
+    # The version surfaces on each row.
+    assert payload["executions"][0]["dataset_version"] == "1.2.0"
+
+
+async def test_find_dataset_executions_preflight(execution_ctx, capturing_mcp, mock_ml):
+    """preflight_count=True honors the dataset filter and returns a total count."""
+    mock_ml.find_executions.side_effect = _role_partitioned_side_effect(
+        input_rids=["1-IN-A", "1-IN-B"], output_rids=["1-OUT"]
+    )
+    result = await capturing_mcp.tools["deriva_ml_find_dataset_executions"](
+        hostname="h", catalog_id="1", dataset_rid="1-DSET", preflight_count=True
+    )
+    payload = json.loads(result)
+    assert payload["total_count"] == 3
+    assert payload["entities_fetched"] is False
+    assert "action_required" in payload
+
+
+async def test_find_dataset_executions_error_path(execution_ctx, capturing_mcp, mock_ml):
+    """A failure wraps as {"error": ...} without an audit row (read-only tool)."""
+    mock_ml.find_executions.side_effect = RuntimeError("kaboom")
+    with _patch_execution_audit() as mock_audit:
+        result = await capturing_mcp.tools["deriva_ml_find_dataset_executions"](
+            hostname="h", catalog_id="1", dataset_rid="1-DSET"
+        )
+    payload = json.loads(result)
+    assert "error" in payload
+    assert "kaboom" in payload["error"]
+    assert mock_audit.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# deriva_ml_list_executions(dataset=...) -- shape parity + regression guard
+# ---------------------------------------------------------------------------
+
+
+async def test_list_executions_without_dataset_has_no_dataset_keys(
+    execution_ctx, capturing_mcp, mock_ml
+):
+    """Regression guard: no dataset filter -> rows are plain ExecutionSummary.
+
+    The existing wire shape must be byte-identical to before this
+    feature: no ``dataset_role`` / ``dataset_version`` keys appear.
+    """
+    mock_ml.find_executions.return_value = [
+        _make_execution_record_mock(rid="1-AAA"),
+        _make_execution_record_mock(rid="1-BBB"),
+    ]
+    result = await capturing_mcp.tools["deriva_ml_list_executions"](hostname="h", catalog_id="1")
+    payload = json.loads(result)
+    assert payload["count"] == 2
+    for e in payload["executions"]:
+        assert "dataset_role" not in e
+        assert "dataset_version" not in e
+
+
+async def test_list_executions_with_dataset_returns_dataset_rows(
+    execution_ctx, capturing_mcp, mock_ml
+):
+    """With a dataset filter, rows are DatasetExecutionSummary-shaped."""
+    mock_ml.find_executions.side_effect = _role_partitioned_side_effect(
+        input_rids=["1-IN"], output_rids=["1-OUT"]
+    )
+    result = await capturing_mcp.tools["deriva_ml_list_executions"](
+        hostname="h", catalog_id="1", dataset="1-DSET"
+    )
+    payload = json.loads(result)
+    assert payload["count"] == 2
+    rows = {e["rid"]: e for e in payload["executions"]}
+    assert rows["1-IN"]["dataset_role"] == "input"
+    assert rows["1-OUT"]["dataset_role"] == "output"
+
+
+async def test_list_executions_dataset_version_builds_datasetspec(
+    execution_ctx, capturing_mcp, mock_ml
+):
+    """list_executions with dataset_version builds a DatasetSpec passed to the library."""
+    from deriva_ml.dataset.aux_classes import DatasetSpec
+
+    mock_ml.find_executions.return_value = [_make_execution_record_mock(rid="1-IN")]
+    await capturing_mcp.tools["deriva_ml_list_executions"](
+        hostname="h",
+        catalog_id="1",
+        dataset="1-DSET",
+        dataset_role="input",
+        dataset_version="2.0.0",
+    )
+    _args, kwargs = mock_ml.find_executions.call_args
+    spec = kwargs["dataset"]
+    assert isinstance(spec, DatasetSpec)
+    assert spec.rid == "1-DSET"
+    assert str(spec.version) == "2.0.0"
+
+
+async def test_list_executions_dataset_preflight(execution_ctx, capturing_mcp, mock_ml):
+    """list_executions preflight count honors the dataset filter."""
+    mock_ml.find_executions.side_effect = _role_partitioned_side_effect(
+        input_rids=["1-IN"], output_rids=["1-OUT-A", "1-OUT-B"]
+    )
+    result = await capturing_mcp.tools["deriva_ml_list_executions"](
+        hostname="h", catalog_id="1", dataset="1-DSET", preflight_count=True
+    )
+    payload = json.loads(result)
+    assert payload["total_count"] == 3
+    assert payload["entities_fetched"] is False
+
+
+# ---------------------------------------------------------------------------
+# Serialization: DatasetExecutionSummary subclass fields survive the wire
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_execution_summary_serializes_subclass_fields():
+    """DatasetExecutionSummary keeps dataset_role/version on model_dump_json."""
+    from deriva_ml_mcp_plugin._response_models import (
+        DatasetExecutionSummary,
+        ExecutionListResponse,
+    )
+
+    row = DatasetExecutionSummary(
+        rid="1-EXEC",
+        workflow_rid="1-WF",
+        status="Completed",
+        description="run",
+        start_time=None,
+        stop_time=None,
+        duration=None,
+        dataset_role="input",
+        dataset_version="1.0.0",
+    )
+    resp = ExecutionListResponse(executions=[row], count=1, truncated=False, next_after_rid=None)
+    payload = json.loads(resp.model_dump_json(by_alias=True))
+    e = payload["executions"][0]
+    assert e["dataset_role"] == "input"
+    assert e["dataset_version"] == "1.0.0"

--- a/tests/test_find_dataset_executions.py
+++ b/tests/test_find_dataset_executions.py
@@ -251,6 +251,71 @@ async def test_list_executions_dataset_preflight(execution_ctx, capturing_mcp, m
 
 
 # ---------------------------------------------------------------------------
+# Dual-role pagination hazard: same execution RID on BOTH edges
+# ---------------------------------------------------------------------------
+
+
+async def test_find_dataset_executions_dual_role_survives_page_boundary(
+    execution_ctx, capturing_mcp, mock_ml
+):
+    """A dual-role execution's two rows must both survive pagination.
+
+    Scenario: execution ``1-DUAL`` both CONSUMED and PRODUCED the same
+    dataset RID, so it appears once on the input edge and once on the
+    output edge -- two rows sharing ``rid="1-DUAL"`` but differing in
+    ``dataset_role``. With a composite cursor keyed on
+    ``(rid, dataset_role)`` they occupy distinct cursor positions; a
+    naive ``rid``-only cursor would skip the second same-rid row when
+    the pair straddles a page boundary (silent row loss).
+
+    Layout (composite-key ascending order, ``\\x00`` sorts first):
+        1-AAAA / input
+        1-DUAL / input
+        1-DUAL / output
+        1-ZZZZ / output
+    With ``limit=2`` the dual-role pair straddles the page-1/page-2
+    boundary, exercising exactly the hazard.
+    """
+    mock_ml.find_executions.side_effect = _role_partitioned_side_effect(
+        input_rids=["1-AAAA", "1-DUAL"], output_rids=["1-DUAL", "1-ZZZZ"]
+    )
+
+    # Page 1.
+    page1 = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_dataset_executions"](
+            hostname="h", catalog_id="1", dataset_rid="1-DSET", limit=2
+        )
+    )
+    assert page1["count"] == 2
+    assert page1["truncated"] is True
+    assert page1["next_after_rid"] is not None
+
+    # Page 2 (follow the cursor exactly as a client would).
+    page2 = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_dataset_executions"](
+            hostname="h",
+            catalog_id="1",
+            dataset_rid="1-DSET",
+            limit=2,
+            after_rid=page1["next_after_rid"],
+        )
+    )
+
+    # Collect (rid, role) pairs across BOTH pages.
+    seen = [(e["rid"], e["dataset_role"]) for e in page1["executions"] + page2["executions"]]
+
+    # No drop: both 1-DUAL rows present, one per role.
+    assert ("1-DUAL", "input") in seen
+    assert ("1-DUAL", "output") in seen
+    # No duplicate: exactly four rows, all distinct (rid, role).
+    assert len(seen) == 4
+    assert len(set(seen)) == 4
+    # The other two edge rows are present too.
+    assert ("1-AAAA", "input") in seen
+    assert ("1-ZZZZ", "output") in seen
+
+
+# ---------------------------------------------------------------------------
 # Serialization: DatasetExecutionSummary subclass fields survive the wire
 # ---------------------------------------------------------------------------
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -95,6 +95,11 @@ _EXECUTION_TOOLS = frozenset(
         "deriva_ml_list_executions",
         "deriva_ml_get_execution",
         "deriva_ml_find_workflow_executions",
+        # dataset-scoped execution query: mirrors find_workflow_executions
+        # to surface "which runs used this dataset?" as a first-class tool.
+        # Wraps ml.find_executions(dataset=, dataset_role=), the same impl
+        # reachable via deriva_ml_list_executions(dataset=...).
+        "deriva_ml_find_dataset_executions",
         "deriva_ml_list_execution_children",
         "deriva_ml_list_execution_parents",
         # P2 hygiene sweep: experiment-scoped browse (wraps find_experiments).


### PR DESCRIPTION
## Summary
Exposes the library's dataset-execution query on the MCP surface.

- **New tool `deriva_ml_find_dataset_executions(dataset_rid, dataset_role, dataset_version, …)`** — the dataset-centric intent tool, mirroring `deriva_ml_find_workflow_executions`.
- **Extends `deriva_ml_list_executions`** with `dataset` / `dataset_role` / `dataset_version` params; when `dataset` is absent the call path and response shape are byte-identical to before.
- **`DatasetExecutionSummary`** response model — adds `dataset_role` + nullable `dataset_version`, carried only on dataset-scoped queries (preserved on the wire via `SerializeAsAny`).
- Role is derived **relationally** (input = `Dataset_Execution`, output = `Dataset_Version` authorship) — never from config files. `dataset_role` is a validated `Literal`. Dual-role executions paginate correctly via a composite `(rid, role)` cursor key.

## Dependency
**Requires** the library change in informatics-isi-edu/deriva-ml#278 (`find_executions(dataset=, dataset_role=)`). The plugin's `deriva-ml` dependency pin must be bumped to a release containing it before this can function end-to-end. Tests here run against a mocked `ml`, so they pass independently.

## Test Plan
- [x] New tests (`tests/test_find_dataset_executions.py`): role tagging, no-dataset shape regression, DatasetSpec construction, preflight, error path, dual-role page-boundary survival.
- [x] Full non-integration suite: 360 passed.
- [ ] Bump `deriva-ml` dependency pin to the release containing #278; then end-to-end validate against a live catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)