### PR TITLE
chore: bump deriva-ml to v1.43.2 + portable deriva-mcp-core git source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-deriva-mcp-core = { path = "../deriva-mcp-core", editable = true }
+deriva-mcp-core = { git = "https://github.com/informatics-isi-edu/deriva-mcp-core.git" }
 # deriva-ml is pulled from github main on every `uv sync --upgrade` so
 # this repo always picks up the latest release. Local edits to a
 # sibling ../deriva-ml checkout are NOT picked up automatically; commit

--- a/uv.lock
+++ b/uv.lock
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "deriva-mcp-core"
 version = "0.1.0"
-source = { editable = "../deriva-mcp-core" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-mcp-core.git#7bf17cf9371a47bdca84540e2efd6ff5dfab3528" }
 dependencies = [
     { name = "chevron" },
     { name = "deriva" },
@@ -689,31 +689,10 @@ dependencies = [
     { name = "python-json-logger" },
 ]
 
-[package.metadata]
-requires-dist = [
-    { name = "asyncpg", marker = "extra == 'rag'", specifier = ">=0.29" },
-    { name = "beautifulsoup4", marker = "extra == 'rag'", specifier = ">=4.12" },
-    { name = "chevron" },
-    { name = "chromadb", marker = "extra == 'rag'", specifier = ">=1.0,<2" },
-    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?branch=master" },
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "mcp", specifier = ">=1.9.0" },
-    { name = "pydantic-settings", specifier = ">=2.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
-    { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.30" },
-    { name = "python-dateutil" },
-    { name = "python-json-logger" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
-    { name = "testing-postgresql", marker = "extra == 'dev'", specifier = ">=1.3" },
-]
-provides-extras = ["rag", "dev"]
-
 [[package]]
 name = "deriva-ml"
-version = "1.42.1"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#ba40dc771f9e8e8bd0c7d4bed9907f183c60b3b6" }
+version = "1.43.2"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#941b52248704ea41890f3f8b4cebbb383bb1ad46" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },
@@ -762,7 +741,7 @@ system-certs = [
 requires-dist = [
     { name = "bump-my-version", marker = "extra == 'dev'" },
     { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?rev=deriva-ml" },
-    { name = "deriva-mcp-core", editable = "../deriva-mcp-core" },
+    { name = "deriva-mcp-core", git = "https://github.com/informatics-isi-edu/deriva-mcp-core.git" },
     { name = "deriva-ml", git = "https://github.com/informatics-isi-edu/deriva-ml.git" },
     { name = "pip-system-certs", marker = "extra == 'system-certs'", specifier = ">=5.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },


### PR DESCRIPTION
## Summary
Two related lock fixes:

1. **Bump locked deriva-ml to v1.43.2** (commit `941b5224`), up from the pre-feature pin (`ba40dc77` / `1.42.1`). v1.43.2 includes `find_executions(dataset=, dataset_role=)` (#278), the legacy-`rid` config parser fix (#279), and the migration `--backfill-only` flag (#280).

2. **Make the lock portable** — `[tool.uv.sources]` switched `deriva-mcp-core` from a local editable path (`../deriva-mcp-core`) to its **git source**, so the lock no longer assumes a sibling checkout exists. The only remaining editable source is the repo root (`.`), which is normal. The `[tool.uv] override-dependencies` guarding the `deriva @ ...@master` pin is unchanged.

## Test Plan
- [x] `uv lock` resolves cleanly (no master-pin conflict); `uv sync` succeeds.
- [x] No `../`-relative or local-path sources remain in uv.lock (verified).
- [ ] CI resolves on a clean checkout (no sibling deriva-mcp-core present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)