### PR TITLE
Make the MCP self-sufficient for skills-less chatbots (rag_search routing + cite_url/selector/resource guidance)

### DIFF
--- a/docs/audits/2026-06-03-skills-to-mcp-surface-audit.md
+++ b/docs/audits/2026-06-03-skills-to-mcp-surface-audit.md
@@ -1,0 +1,233 @@
+# Skills → MCP-surface migration audit (2026-06-03)
+
+> **PRIMARY GOAL (revised):** maximize MCP capability in a **chatbot environment
+> with NO access to skills**. In that setting the MCP's prompts, resources, tool
+> docstrings, and the RAG corpus are the *only* guidance the model ever gets.
+> See the "SKILLS-LESS CHATBOT" section at the bottom — it supersedes the
+> narrower dedup framing below where the two differ.
+
+**Question:** Are there elements of `deriva-ml-skills` that should be migrated or
+duplicated into the MCP's always-on surfaces (prompts, tool docstrings, resources)?
+
+**Method:** Inventoried the MCP's current model-visible surface (prompts, 18
+resources, 44 tool docstrings, `coverage.md`), extracted the load-bearing rules
+from the meta-skills (`using-deriva-mcp`, `deriva-ml-context`,
+`api-naming-conventions`, `help`, `browse-erd`) and the operational skills
+(dataset/execution/feature/asset/troubleshoot/bag), then **deduplicated** every
+candidate against what the MCP already exposes.
+
+**Headline:** The MCP surface is already strong. Most knowledge the skills teach
+is *already present* in the prompts/docstrings — the getting-started + concepts
+prompts cover the (hostname,catalog_id) rule, pagination contract, verb
+conventions, five domains, resource-first rule, inheritance-with-override,
+mutation chain, asset metadata/fileIO split, `rag_search` doc_type values, and
+name-resolution. The dataset/asset/feature tool docstrings already carry the
+version/release semantics, `asset_types` membership rule + Input/Output_File
+tags, and `partition_by`/denormalize semantics. **Do not re-add these.**
+
+A small number of genuine gaps remain — verified absent from the live surface.
+
+---
+
+## CONFIRMED GAPS (real migration candidates)
+
+### G1 — `cite_url` rendering guidance is absent (recommend: PROMPT)
+**Status:** The `cite_url` *field* is returned by the dataset/execution/asset
+resources and tool payloads (`_helpers.py`, `tools/*/read.py`), but **no
+model-visible surface tells the model to render RIDs as Markdown links to
+`cite_url`**, nor explains the snapshot-pinned-vs-live distinction or the
+`/id/...` resolver-vs-`/chaise/...` distinction.
+**Source:** `deriva-ml-context` (cite_url rendering rule) + `browse-erd`
+reference (`/id/` for stored content vs `/chaise/` for UI nav).
+**Why it matters:** Without it, the model presents bare RID strings to users
+(unclickable, non-citable) and, when *writing* RIDs into catalog content
+(descriptions/annotations), may use a `/chaise/` UI URL that breaks on UI
+changes instead of the durable `/id/` resolver form.
+**Recommendation:** Add a short "PRESENTING & STORING RIDs" section to the
+getting-started prompt: (a) render RIDs from resource/tool payloads as
+`[RID](cite_url)`; (b) released-dataset cite_urls are snapshot-pinned, others
+are live; (c) when storing an RID reference *in* the catalog, use the `/id/`
+resolver form, never a `/chaise/` URL.
+
+### G2 — feature-selector exclusivity is implicit, not explicit (recommend: TOOL DOCSTRING)
+**Status:** `deriva_ml_list_feature_values` has `selector`, `selector_workflow`,
+`selector_execution_rid` params; the docstring says "Requires
+`selector_workflow`" / "Requires `selector_execution_rid`" but does **not**
+state the three are **mutually exclusive — pass exactly one**.
+**Source:** `create-feature/references/feature-selectors.md`.
+**Why it matters:** A model could pass `selector="select_newest"` *and*
+`selector_workflow=...` expecting an intersection; the actual behavior is
+undefined/last-wins. One sentence prevents it.
+**Recommendation:** Add to the `deriva_ml_list_feature_values` docstring:
+"`selector`, `selector_workflow`, and `selector_execution_rid` are mutually
+exclusive — supply at most one." (Custom callables remain Python-API-only, which
+is already implied.)
+
+### G3 — `ListMcpResourcesTool` returns concrete resources only, not templates (recommend: PROMPT, one line)
+**Status:** The getting-started prompt lists the `deriva://catalog/.../deriva-ml/...`
+resource *templates* in a table, but does not warn that
+`ListMcpResourcesTool` enumerates only the ~3 static resources, NOT the
+catalog-scoped templates — which must be read directly with `ReadMcpResourceTool`.
+**Source:** `using-deriva-mcp` (the ListMcpResources-vs-templates note).
+**Why it matters:** A model that "checks what resources exist" via
+`ListMcpResourcesTool` sees 3 entries and wrongly concludes the per-RID catalog
+resources don't exist — then falls back to `query_attribute` (the anti-pattern
+the prompt elsewhere warns against). (Observed first-hand: this session hit
+exactly this confusion.)
+**Recommendation:** One line in the getting-started "read-side / resources"
+section: "`ListMcpResourcesTool` lists only the static resources; the
+`deriva://catalog/.../deriva-ml/...` templates above are not enumerated — construct
+the URI and read it directly with `ReadMcpResourceTool`."
+
+---
+
+## NON-GAPS (verified already covered — do NOT migrate)
+
+- **(hostname, catalog_id) rule, pagination contract, error envelope, verb
+  conventions, five domains, the menu/tool-count** — in getting-started prompt.
+- **find_\* vs list_\* naming, inheritance-with-override, built-in vocabularies,
+  entity-resolution workflow, rag_search doc_type values** — in prompts.py
+  (13 `find_` mentions; `catalog-schema`/`catalog-data`/`ml-docs` enumerated at
+  prompts.py:449-451, 823-824).
+- **Release-before-consume / dev-version-not-pinnable** — in dataset tool
+  docstrings (`tools/dataset/mutate.py`, `read.py`).
+- **`asset_types` membership-not-equality + auto Input_File/Output_File tags** —
+  in `tools/asset.py`.
+- **`partition_by` element-vs-row + multi-value denormalize row-multiplication** —
+  in `tools/dataset/complex.py`.
+- **create_workflow dedup on URL+checksum; caller computes git locally** — in
+  `tools/workflow.py` docstring.
+
+## CORRECT BOUNDARIES (absent by design — do NOT add)
+
+- **`DerivaMLDirtyWorkflowError` / git-dirty checks** are absent from MCP
+  `create_workflow` — and should be. The MCP tool does no git introspection
+  (caller computes URL/checksum locally, per `tools/workflow.py:12-13`); the
+  dirty-tree check lives in the local-Python execution path. Belongs in the
+  execution-lifecycle skill, not the MCP.
+- **Execution lifecycle (create/start/commit/abort), feature-value writes, asset
+  file I/O, bag materialization** — deliberately removed/deferred per the
+  stateless rule (`coverage.md`). The "this is local-Python, not MCP" boundary is
+  already stated in the getting-started prompt's MUTATION section. Keep in skills.
+- **Hydra-zen config templates, CLI/ERD launch steps, data-container ("carry
+  structure") guidance, parameter-naming style** — workflow/task knowledge;
+  correctly skill-only.
+
+## PROCESS NOTE — keep the SYNC contract honest
+
+`deriva-ml-context/SKILL.md` carries a SYNC comment: it mirrors `_CONCEPTS_GUIDE`
+in `prompts.py`; "when the conceptual core changes, update both." That contract
+covers the *concepts* body. The three gaps above (G1–G3) are **not** part of that
+mirrored body — they're MCP-surface operational rules currently living only in
+`using-deriva-mcp` / `deriva-ml-context` / `create-feature`. If G1–G3 land in the
+prompt/docstrings, fold them under the same sync discipline so the skill and MCP
+don't re-diverge.
+
+---
+
+## Recommended actions (small, additive — each its own PR)
+
+1. **G1** → add "PRESENTING & STORING RIDs" section to the getting-started
+   prompt (and mirror into `deriva-ml-context` per the sync contract).
+2. **G2** → one sentence in `deriva_ml_list_feature_values` docstring.
+3. **G3** → one line in the getting-started prompt's resources section.
+
+All three are documentation-only, additive, and low-risk. They close the
+highest-value model-misuse gaps without duplicating the (already strong)
+existing surface.
+
+---
+
+# SKILLS-LESS CHATBOT — the primary lens (revised goal)
+
+When the goal is "maximize capability in a chatbot that has no skills," the
+classification changes. Skill knowledge falls into three buckets:
+
+1. **MCP-surface rules** — needed regardless of environment. (G1–G3 above.)
+2. **Workflow how-to** (the execution `with` pattern, asset file I/O, dataset
+   lifecycle, hydra-zen configs) — the chatbot can't *execute* these (they're
+   local Python), but it MUST be able to *explain them to the user*.
+3. **Local-Python-only mutations** (create/commit/abort execution, add_features,
+   asset upload) — correctly absent as tools; a chatbot can't run them anyway.
+
+The architectural cut (MCP = observe + simple mutate; skills/local-Python =
+orchestrate + generate code) is **correct and should stay**. The problem in a
+skills-less chatbot is not missing tools — it is **cold trails**: the MCP
+repeatedly says "see the X skill" for bucket-2 knowledge the chatbot cannot
+reach, instead of routing the model to a source it CAN reach.
+
+## The key fact that makes this cheap to fix
+
+**The how-to corpus already exists and is already RAG-indexed.**
+`deriva-ml/docs/user-guide/` contains `executions.md`, `datasets.md`,
+`features.md`, `denormalization.md`, `offline.md`, `reproducibility.md`,
+`sharing.md`, `hydra-zen.md`, `exploring.md`, `migration.md` — i.e. the
+action-level guidance the skills teach. The entire `deriva-ml` repo root is
+indexed as `doc_type="ml-docs"` (`resources/rag.py`). So the *substance* is
+reachable by a skills-less chatbot via `rag_search(doc_type="ml-docs")`.
+
+**The gap is routing, not content.** The getting-started prompt mentions
+rag_search-for-how-to only once, in passing, scoped to execution work
+(`prompts.py:542`). Every "see the X skill" pointer is a dead end for a chatbot;
+none of them say "...or rag_search `doc_type=ml-docs` for `<topic>`."
+
+## CHATBOT GAPS (in priority order)
+
+### C-G1 — Position rag_search as the skills substitute (highest leverage; PROMPT)
+Add an explicit section to getting-started: **"NO SKILLS? USE THE DOCS."**
+State plainly: when you need how-to/workflow guidance that isn't in a tool
+docstring or this prompt — how to run an execution, the `with
+ml.create_execution(...) as exe:` pattern, registering/downloading asset bytes,
+the dataset version lifecycle, writing a hydra-zen config, offline mode — call
+`rag_search(query="<topic>", doc_type="ml-docs")`. Name the indexed user-guide
+pages so the model knows what's retrievable. This single addition converts every
+cold "see the skill" trail into a reachable path.
+
+### C-G2 — Turn every "see the X skill" pointer into a skill-OR-rag_search pointer (PROMPT + tool docstrings)
+At each dangling reference, append the reachable alternative. Concretely:
+- `prompts.py:~554,726,958` (execution-lifecycle skill) → "...or
+  `rag_search('execution lifecycle', doc_type='ml-docs')` (see
+  `user-guide/executions.md`)."
+- `prompts.py:~984-1003`, `tools/asset.py:~19`, `tools/execution/__init__.py:~8`
+  (work-with-assets skill) → add an asset-I/O how-to pointer. **Caveat:** confirm
+  an asset file-I/O page exists in the indexed corpus; `user-guide/` has no
+  `assets.md`. If absent, that how-to is genuinely unreachable by a chatbot —
+  either (a) add a short `user-guide/assets.md` to the deriva-ml repo (it gets
+  indexed automatically), or (b) inline a brief "to upload/download asset bytes,
+  the user runs this Python locally: ..." snippet in the asset tool docstrings.
+- `prompts.py:~663` (`work-with-executions` skill) → this skill does not exist
+  yet; drop the aspirational pointer or replace with the rag_search route.
+
+### C-G3 — Make the local-Python boundary self-explaining, not skill-delegating (PROMPT/docstrings)
+Where the MCP correctly lacks a mutation (create_execution, add_features, asset
+upload), the chatbot should be able to hand the USER the local-Python pattern,
+not say "use a skill." The canonical `with ml.create_execution(...) as exe:
+exe.add_features(...); ... ; exe.commit_output_assets()` snippet is small and
+stable. Recommend embedding the *minimal* canonical snippet (or a tight pointer
+to the rag_search page that contains it) directly in the MUTATION section of
+getting-started, so a skills-less chatbot can explain "here's the code to run
+locally" instead of dead-ending.
+
+### C-G4 — Capability/"what can I do here" menu is adequate but not action-oriented (optional; PROMPT)
+The five-domains menu lists tools but not *tasks*. A skills-less chatbot fielding
+"how do I set up a new ML project?" / "how do I run an experiment?" has no
+task-level catalog (that lived in the `help` / `setup-derivaml-project` skills).
+Optional enhancement: a short "COMMON TASKS → where to look" table in
+getting-started mapping intents (set up project, define schema, organize data,
+run experiment, troubleshoot) to the relevant tools + rag_search topics. Lower
+priority than C-G1/C-G2 because it's discoverability polish, not a cold trail.
+
+## What NOT to do (still true under the chatbot lens)
+- Do NOT re-add the local-Python execution/asset-upload tools as MCP tools — the
+  stateless rule is correct and a chatbot cannot run them regardless.
+- Do NOT duplicate full skill workflows verbatim into prompts — they're large,
+  and the RAG corpus already holds the substance. Route to it; don't inline it.
+- Do NOT remove the "see the X skill" references for Claude-Code users — keep
+  them AND add the rag_search alternative (serve both environments).
+
+## Revised priority
+For the skills-less-chatbot goal, **C-G1 and C-G2 are the highest-value changes
+in this entire audit** — higher than G1–G3 — because they convert a structurally
+incomplete experience (dead-end pointers) into a complete one using content that
+already exists. C-G3 closes the "explain the local step" gap. G1–G3 remain worth
+doing but are smaller polish by comparison.

--- a/src/deriva_ml_mcp_plugin/prompts.py
+++ b/src/deriva_ml_mcp_plugin/prompts.py
@@ -32,8 +32,10 @@ machine -- moved to the ``user-guide/executions.md`` doc in the
 deriva-ml repo (RAG-indexed). v0.5.0 then removed the eight
 execution-lifecycle TOOLS themselves: per the stateless rule, executions
 originate in the caller's local Python environment, not in the MCP
-server. The lifecycle docs at the deriva-ml-skills ``execution-lifecycle``
-skill remain the authoritative how-to.)
+server. The authoritative how-to lives in ``user-guide/executions.md``
+(retrieve it over this MCP via ``rag_search(query="execution lifecycle",
+doc_type="ml-docs")``); Claude Code clients also have the deriva-ml-skills
+``execution-lifecycle`` skill.)
 
 All prompts are static strings (no f-strings, no tool calls, no catalog
 access required to render). Plain ASCII only (workspace convention).
@@ -659,9 +661,10 @@ reach for:
               (success or ``_failed``). Mutating tools have NO
               resource counterpart -- resources are read-only by
               MCP convention. (Execution lifecycle verbs such as
-              ``start_`` / ``commit_`` / ``abort_`` are permanently
-              deferred to a future ``work-with-executions`` skill in
-              deriva-ml-skills; no such tools exist in this plugin.)
+              ``start_`` / ``commit_`` / ``abort_`` are not MCP tools at
+              all -- they run in the caller's local Python; see the
+              MUTATION section and ``rag_search(query="execution
+              lifecycle", doc_type="ml-docs")``.)
 
     lookup_*  Specialized RID-or-name resolution (currently only
               ``lookup_asset``). Treat as a sibling of ``get_*``.
@@ -723,16 +726,20 @@ for the wire name.
                   the MCP server -- the workflow code, the feature-
                   staging SQLite manifest, the asset bytes, and the
                   ``with Execution(...) as exe:`` context-manager
-                  semantics all live there. See the deriva-ml-skills
-                  ``execution-lifecycle`` skill for the local-Python
-                  pattern.
+                  semantics all live there. For the local-Python
+                  pattern, ``rag_search(query="execution lifecycle",
+                  doc_type="ml-docs")`` (user-guide/executions.md);
+                  Claude Code clients also have the deriva-ml-skills
+                  ``execution-lifecycle`` skill.
 
     asset      -- 4 tools. File-backed catalog rows (images, model
                   weights, etc.) -- catalog-state operations only.
-                  File I/O lives in deriva-skills's work-with-assets
-                  skill. Verbs: list_assets / find_assets / lookup /
-                  update. For "what asset tables exist in a schema?" use
-                  the ml/assets/{schema} resource (no dedicated tool).
+                  File I/O (upload/download) runs in local Python; for
+                  the how-to, ``rag_search(query="asset upload download",
+                  doc_type="ml-docs")`` (user-guide/assets.md). Verbs:
+                  list_assets / find_assets / lookup / update. For "what
+                  asset tables exist in a schema?" use the
+                  ml/assets/{schema} resource (no dedicated tool).
 
 READ-SIDE QUESTIONS: FETCH THE RESOURCE FIRST
 ---------------------------------------------
@@ -755,6 +762,24 @@ ANTI-PATTERN: do NOT call ``deriva_ml_get_execution`` (or
 the entity's full state. Those tools return a thinner record and force
 follow-up ``deriva_ml_list_assets`` / ``query_attribute`` calls. The
 ``ml/<kind>/{rid}`` resource is the one-fetch answer.
+
+PRESENTING & STORING RIDs
+-------------------------
+Resource and tool payloads include a ``cite_url`` field alongside each
+RID. Use it:
+
+  - PRESENTING to a user: render an RID as a Markdown link to its
+    ``cite_url`` -- ``[2-ABCD](https://host/id/cat/2-ABCD)`` -- not a bare
+    string. A bare RID is not clickable or citable.
+  - The ``cite_url`` of a RELEASED dataset version is snapshot-pinned
+    (``/id/cat/rid@snaptime``) -- a permanent, reproducible reference.
+    Assets, executions, workflows, and dev-version datasets have LIVE
+    cite_urls (no snaptime); they track current state.
+  - STORING an RID reference INSIDE the catalog (in a description,
+    annotation, or markdown field): always use the ``/id/`` resolver
+    form (``/id/<cat>/<rid>``), never a ``/chaise/...`` UI URL. The
+    ``/id/`` form survives UI/deployment changes; ``/chaise/`` URLs do
+    not. When a payload gives you a ``cite_url``, use it verbatim.
 
 The full read-only resource family:
 
@@ -783,6 +808,14 @@ The full read-only resource family:
                                                  -- vocabulary tables in one schema
     deriva://catalog/{h}/{c}/deriva-ml/vocabularies/{schema}/{vocab_name}
                                                  -- terms in one vocabulary table
+
+IMPORTANT -- these catalog-scoped resources are URI TEMPLATES, not static
+resources. ``ListMcpResourcesTool`` enumerates only the handful of static
+resources (the orientation guides); it does NOT list the
+``deriva://catalog/.../deriva-ml/...`` templates above. If ListMcpResources
+returns only 2-3 entries, that is expected -- it does NOT mean the catalog
+resources are missing. Construct the URI from (hostname, catalog_id, rid)
+yourself and read it directly with ``ReadMcpResourceTool``.
 
 RESOURCE-TOOL PAIRINGS (when in doubt, prefer the resource)
 -----------------------------------------------------------
@@ -833,6 +866,57 @@ need filtered scans (e.g. "executions with status=Failed for workflow
 asset tables. Reach for ``deriva_ml_*`` mutation tools (create / update
 / commit / abort / start) only for write-side operations -- those have
 no resource counterpart.
+
+NO SKILLS? USE THE DOCS (rag_search is your how-to source)
+----------------------------------------------------------
+Some clients (Claude Code) load companion "skills" with step-by-step
+how-to guidance; many clients (chatbots, SDK agents, raw MCP clients)
+do NOT. If you need workflow/how-to guidance that is not already in a
+tool docstring or this prompt -- how to run an execution, the
+``with ml.create_execution(...) as exe:`` pattern, recording feature
+values, uploading/downloading asset bytes, the dataset version
+lifecycle, writing a hydra-zen config, working offline, denormalizing,
+sharing/reproducibility -- do NOT dead-end on a "see the X skill"
+pointer. Instead retrieve the doc over this MCP:
+
+    rag_search(query="<your how-to question>", doc_type="ml-docs")
+
+The deriva-ml repo's user-guide is fully indexed under
+``doc_type="ml-docs"``; these pages contain the runnable Python
+patterns (not just concepts):
+
+    executions.md      run an execution; with-context pattern;
+                       add_features; commit_output_assets; asset I/O;
+                       state machine; crash/resume
+    datasets.md        create / version / release / split / download a dataset
+    features.md        create a feature; record + read feature values; selectors
+    assets.md          upload (asset_file_path), download (download_asset /
+                       asset.download), metadata reads
+    denormalization.md wide-table joins; multi-value feature row semantics
+    offline.md         materialize for offline; read from a bag; reconnect
+    reproducibility.md version pinning; workflow checksums; dirty-tree rules
+    hydra-zen.md       config composition; CLI overrides
+    sharing.md         MINID / BDBag / catalog clone
+    exploring.md       find_* vs list_*; pathBuilder queries; RID resolution
+
+COMMON TASKS -> WHERE TO LOOK
+-----------------------------
+    Intent                         Tools / route
+    ------------------------------ --------------------------------------------
+    "what's in this catalog?"      rag_search(doc_type="catalog-schema" |
+                                   "catalog-data"); ml/datasets, ml/workflows
+                                   resources
+    "set up / run an experiment"   create_workflow (MCP) -> local Python
+                                   execution; rag_search "execution lifecycle"
+    "organize data for ML"         create_dataset, add_dataset_members,
+                                   split_dataset, release; rag_search "datasets"
+    "label / score records"        create_feature (MCP) + exe.add_features
+                                   (local); rag_search "features"
+    "upload / fetch a file"        exe.asset_file_path / exe.download_asset
+                                   (local); rag_search "asset upload download"
+    "which runs used dataset X?"   find_dataset_executions / get_lineage
+    "why is my run failing?"       rag_search "troubleshoot execution",
+                                   doc_type="ml-docs"
 
 DISCOVERY: RESOLVING USER-MENTIONED NAMES TO CATALOG IDENTIFIERS
 ----------------------------------------------------------------
@@ -952,15 +1036,18 @@ ALWAYS create artefacts inside an execution context. Bare insertions
 (via core's ``insert_records`` etc.) bypass provenance tracking and
 should only be used when no domain-specific path exists.
 
-For the lifecycle state machine details, ``rag_search(query=...,
-doc_type="ml-docs")`` for "execution state machine" -- the
-``user-guide/executions.md`` doc in the deriva-ml repo carries the
-cross-cutting state-machine reference at depth. The deriva-ml-skills
-``execution-lifecycle`` skill carries the user-facing how-to (the
-Python pattern to paste into your editor / notebook).
+For the lifecycle state machine details AND the runnable how-to (the
+``with ml.create_execution(...) as exe:`` pattern, add_features,
+commit_output_assets), call ``rag_search(query="execution lifecycle",
+doc_type="ml-docs")`` -- the ``user-guide/executions.md`` doc in the
+deriva-ml repo carries the full Python pattern and the state-machine
+reference at depth, and is retrievable over this MCP. (Claude Code
+clients also have the deriva-ml-skills ``execution-lifecycle`` skill;
+clients WITHOUT skills should use the rag_search route above -- the
+doc contains the same code patterns.)
 
-ASSETS: METADATA HERE, FILE I/O IN THE SKILL
---------------------------------------------
+ASSETS: METADATA HERE, FILE I/O IN LOCAL PYTHON
+-----------------------------------------------
 The asset surface covers the catalog-state half of the asset
 lifecycle:
 
@@ -978,29 +1065,29 @@ Plus three matching resources:
                                                  -- snapshot of one asset table
 
 What these tools do NOT do: register a new asset from a local file, or
-download asset bytes back to a local path. The MCP server has no
-general way to access the user's local filesystem, so file I/O is
-deliberately out of scope here. For those two flows, use the
-``work-with-assets`` skill in the deriva-skills plugin -- it generates
-the Python the user runs locally (which talks to the catalog directly
-via deriva-ml's ``execution.asset_file_path()`` for upload, and
-``asset.download()`` for fetch).
+download asset bytes to a local path. The MCP server has no general way
+to access the user's local filesystem, so file I/O runs in the user's
+local Python, not over this MCP. The runnable patterns are:
 
-The MCP <-> skill round trip looks like this:
+    upload:   inside ``with ml.create_execution(...) as exe:`` call
+              ``exe.asset_file_path(asset_name, file_name, ...)``,
+              write the file, then ``exe.commit_output_assets()``
+              after the block (asset tagged ``Output_File``).
+    download: ``exe.download_asset(asset_rid, dest_dir)`` for a
+              provenance-tracked input (tagged ``Input_File``), or the
+              bare ``asset.download(dest_dir)`` for a throwaway read
+              with no execution edge.
 
-    1. Inside an execution running in user-local Python (see the
-       MUTATION section above), the user wants to register a new
-       file as an asset. Use the ``work-with-assets`` skill -- it
-       produces a small Python snippet calling
-       ``execution.asset_file_path(...)``, writing the file, and
-       tying it to the running execution.
-    2. The user runs the snippet locally; the file is staged and
-       the asset row is created. The local ``with Execution(...)``
-       context manager handles the upload + commit on exit -- no
-       MCP commit call needed (none exists in v0.5.0+).
-    3. Come back to MCP for ``deriva_ml_lookup_asset`` /
-       ``deriva_ml_update_asset`` follow-ups, or
-       ``deriva_ml_list_assets`` to confirm the new row landed.
+For the full how-to with code, call ``rag_search(query="asset upload
+download", doc_type="ml-docs")`` -- the ``user-guide/assets.md`` doc in
+the deriva-ml repo carries upload, download, and metadata-read patterns
+and is retrievable over this MCP. (Claude Code clients also have the
+deriva-skills ``work-with-assets`` skill; clients WITHOUT skills should
+use the rag_search route -- the doc has the same patterns.)
+
+The round trip: do the local-Python file I/O (above), then come back to
+MCP for ``deriva_ml_lookup_asset`` / ``deriva_ml_update_asset`` /
+``deriva_ml_list_assets`` to confirm and curate the landed rows.
 
 CURATION PATTERN: ONE update_<entity> PER TYPED ENTITY
 ------------------------------------------------------

--- a/src/deriva_ml_mcp_plugin/tools/asset.py
+++ b/src/deriva_ml_mcp_plugin/tools/asset.py
@@ -16,9 +16,14 @@ metadata (asset_type tags + Description) on an existing asset row.
 File I/O is deliberately out of scope -- registering a new asset from
 a local file or downloading asset bytes back to a local path requires
 filesystem access the MCP server does not (and should not) have. Those
-flows live in the ``deriva-skills`` ``work-with-assets`` skill, which
-generates Python the user runs locally; once the file is staged, this
-module's tools cover the metadata-curation half of the round trip.
+flows run in the user's local Python: ``exe.asset_file_path(...)`` +
+``exe.commit_output_assets()`` for upload, ``exe.download_asset(...)``
+or ``asset.download(...)`` for download. For the runnable how-to, call
+``rag_search(query="asset upload download", doc_type="ml-docs")`` (the
+``user-guide/assets.md`` doc, retrievable over this MCP); Claude Code
+clients also have the ``deriva-skills`` ``work-with-assets`` skill.
+Once a file is staged locally, this module's tools cover the
+metadata-curation half of the round trip.
 
 Every tool wraps DERIVA I/O in ``with deriva_call():`` and routes
 errors through ``_error_envelope`` (mutation tools also emit

--- a/src/deriva_ml_mcp_plugin/tools/execution/__init__.py
+++ b/src/deriva_ml_mcp_plugin/tools/execution/__init__.py
@@ -4,9 +4,12 @@
 read-side tools. The execution lifecycle (``create``, ``start``,
 ``commit``, ``abort``, ``update``, ``add_feature_values``,
 ``create_execution_dataset``, ``add_nested_execution``) is owned by
-the caller's local Python environment and lives in skills that
-generate user-side code -- mirroring the ``work-with-assets`` skill
-pattern in ``deriva-skills``.
+the caller's local Python environment (the ``with
+ml.create_execution(...) as exe:`` pattern). For the runnable how-to,
+call ``rag_search(query="execution lifecycle", doc_type="ml-docs")``
+(the ``user-guide/executions.md`` doc, retrievable over this MCP);
+Claude Code clients also have the ``deriva-skills``
+``execution-lifecycle`` skill.
 
 Per the stateless / bounded-resource rule (CLAUDE.md), executions
 originate in the user's environment because:

--- a/src/deriva_ml_mcp_plugin/tools/feature.py
+++ b/src/deriva_ml_mcp_plugin/tools/feature.py
@@ -416,6 +416,14 @@ def register(ctx: PluginContext) -> None:
         - ``by_execution`` -- filter to records from one execution.
           Requires ``selector_execution_rid``.
 
+        Exactly one selector strategy applies per call: ``selector`` is a
+        single value. Supply ``selector_workflow`` ONLY with
+        ``selector="by_workflow"`` and ``selector_execution_rid`` ONLY with
+        ``selector="by_execution"`` -- the two companion args are not
+        combinable with each other or with the time-based selectors, and a
+        companion arg passed against a non-matching selector is ignored.
+        Custom callable selectors are Python-API-only (not available here).
+
         See ``deriva_ml_getting_started`` (PAGINATION CONTRACT) for the two-step pagination flow.
 
         Args:


### PR DESCRIPTION
## Summary
Audit (`docs/audits/2026-06-03-skills-to-mcp-surface-audit.md`) found the MCP surface strong but with **cold trails**: prompts/docstrings repeatedly say "see the X skill" for how-to a skills-less chatbot (the primary target) can never reach. The how-to content already exists and is RAG-indexed (`user-guide/*.md`, `doc_type="ml-docs"`) — **the gap was routing, not content.**

Documentation-only changes to the getting-started prompt + tool docstrings:
- **C-G1**: new "NO SKILLS? USE THE DOCS" section — positions `rag_search(doc_type="ml-docs")` as the how-to source and names the retrievable user-guide pages.
- **C-G2**: every "see the X skill" pointer now also gives the reachable `rag_search` route + inline local-Python pattern; the aspirational `work-with-executions` pointer dropped. (prompts.py, asset.py, execution/__init__.py)
- **G1**: "PRESENTING & STORING RIDs" — render `[RID](cite_url)`; released=snapshot-pinned vs live; use `/id/` resolver (not `/chaise/`) when storing. Migrates cite_url guidance that previously lived only in the `deriva-ml-context` skill onto the MCP wire.
- **G2**: `deriva_ml_list_feature_values` docstring now states selector exclusivity.
- **G3**: warn that `ListMcpResourcesTool` lists only static resources, not the catalog URI templates.
- **G4**: "COMMON TASKS → where to look" intent→route table.

## Dependency
Pairs with deriva-ml's new `user-guide/assets.md` (the asset-I/O `rag_search` target). The rag_search pointers resolve once that page is indexed.

## Test Plan
- [x] 360 tests pass (incl. prompt-content + tool-registration assertions).
- [x] No `pyproject.toml`/`uv.lock` changes; getting-started is MCP-only (outside the `_CONCEPTS_GUIDE`↔`deriva-ml-context` SYNC contract), so no skill mirror needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)