### PR TITLE
fix(rag): persistent first-connect guard to stop re-indexing on every connect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,4 +144,4 @@ show_missing = true
 allow_dirty = false
 commit = true
 tag = true
-current_version = "0.6.1"
+current_version = "0.6.2"

--- a/src/deriva_ml_mcp_plugin/resources/rag.py
+++ b/src/deriva_ml_mcp_plugin/resources/rag.py
@@ -123,6 +123,93 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# First-connect guard (cold-start regression fix, 2026-06-04 bug report)
+# ---------------------------------------------------------------------------
+#
+# The ``on_catalog_connect`` hooks fire as background tasks (deriva-mcp-core's
+# ``_dispatch_catalog_connect`` schedules one ``asyncio.create_task`` per hook).
+# A single user's bootstrapping sequence fires several catalog-touching tool
+# calls (``get_catalog_info``, then two ``get_schema`` calls), each
+# independently triggering ``on_catalog_connect``. In ``stateless_http`` mode
+# core's per-``(host, catalog, user)`` connect dedup does not reliably hold
+# across them: it re-fires sequentially when a prior schema-fetch errored and
+# discarded the dedup key (which is exactly what happened while the
+# ``ExecutionStatus`` enum mismatch was crashing the execution hook), and it
+# re-fires concurrently when calls interleave at ``get_catalog()`` before any
+# adds the key. Without a guard the FULL hook set ran on EVERY connect: every
+# vocab and every per-user-trio row re-fetched and re-embedded. The ICD10_Eye
+# vocab (1209 terms) re-embedded each time; the passes fought the GIL with
+# ``rag_search``'s own query embedding -- 60-261s first-turn latency, 97% CPU.
+#
+# The fix (per the bug report) is a TWO-LAYER guard, matching the documented
+# "first catalog connect per server lifetime indexes all vocabs in bulk" intent
+# that the code previously failed to enforce:
+#
+#   1. A per-server-lifetime "already indexed" SET. Once a work unit has been
+#      indexed it is NOT re-indexed on any later connect until server restart.
+#      Cleared only by an explicit re-index tool (see _clear_* below) or restart.
+#   2. A per-work-unit ``asyncio.Lock`` with DOUBLE-CHECKED membership.
+#      Concurrent firings serialize on the lock; the winner runs the pass and
+#      records the unit in the set; waiters re-check the set after acquiring the
+#      lock and skip. The check + ``async with`` is race-free under asyncio
+#      cooperative scheduling -- no context switch between them.
+#
+# The guard lives on the HOOKS only, never on ``_index_vocabularies`` /
+# ``_resync_user_sources`` directly: those back the explicit
+# ``deriva_ml_reindex_vocabularies`` / ``deriva_ml_resync_indexes`` tools, which
+# are deliberate user requests that must always run. Those tools instead CLEAR
+# the relevant guard entries (``_clear_vocab_indexed`` / ``_clear_user_indexed``)
+# so a subsequent connect re-indexes too.
+#
+# A FAILED pass is not recorded in the set, so a transient catalog error stays
+# retryable on the next connect rather than stranding the catalog until restart.
+#
+# Work-unit keys:
+#   vocab pass         -> ``(host, catalog)``
+#   per-user-trio hook -> ``(user_id, host, catalog, table_token)``
+_indexed_vocab_catalogs: set[tuple[str, str]] = set()
+_indexed_user_catalogs: set[tuple[str, str, str, str]] = set()
+_vocab_connect_locks: dict[tuple[str, str], asyncio.Lock] = {}
+_user_connect_locks: dict[tuple[str, str, str, str], asyncio.Lock] = {}
+
+
+def _reset_index_state() -> None:
+    """Drop all first-connect guard state (sets + locks). Test-only isolation hook.
+
+    The guard registries are module-global and per-server-lifetime in
+    production; tests call this to start each scenario from a clean slate.
+    """
+    _indexed_vocab_catalogs.clear()
+    _indexed_user_catalogs.clear()
+    _vocab_connect_locks.clear()
+    _user_connect_locks.clear()
+
+
+def _clear_vocab_indexed(hostname: str, catalog_id: str) -> None:
+    """Forget that ``(hostname, catalog_id)`` vocabs were indexed this lifetime.
+
+    Called by ``deriva_ml_reindex_vocabularies`` so an explicit re-index request
+    is honored AND so the next ``on_catalog_connect`` re-runs the bulk pass
+    (otherwise the persistent guard would suppress it).
+    """
+    _indexed_vocab_catalogs.discard((hostname, catalog_id))
+
+
+def _clear_user_indexed(hostname: str, catalog_id: str) -> None:
+    """Forget every per-user-trio guard entry for ``(hostname, catalog_id)``.
+
+    Called by ``deriva_ml_resync_indexes`` so a manual resync re-runs and so the
+    calling user's next connect re-indexes. Clears entries for ALL users +
+    tables of this catalog (the set is keyed
+    ``(user_id, host, catalog, table_token)``); a resync is catalog-scoped and
+    inexpensive to widen, and a stale entry for another user would otherwise
+    silently suppress their re-index.
+    """
+    stale = {k for k in _indexed_user_catalogs if k[1] == hostname and k[2] == catalog_id}
+    _indexed_user_catalogs.difference_update(stale)
+
+
 _GITHUB_DOCS_NAME = "deriva-ml-docs"
 _GITHUB_DOCS_OWNER = "informatics-isi-edu"
 _GITHUB_DOCS_REPO = "deriva-ml"
@@ -848,57 +935,95 @@ def _make_hook(
         schema_hash: str,  # noqa: ARG001 -- hook signature requires it
         schema_json: dict,  # noqa: ARG001 -- hook signature requires it
     ) -> None:
-        try:
-            # fetch_fn wraps synchronous deriva-py HTTP I/O; run it in a
-            # worker thread so the event loop stays responsive while the
-            # catalog is being indexed.
-            raw_rows = await asyncio.to_thread(fetch_fn, hostname, catalog_id)
-            rows = _coerce_for_index(raw_rows)
-        except Exception:  # noqa: BLE001 -- fetch errors are domain-specific
-            logger.exception(
-                "deriva-ml RAG: failed to fetch %s rows for %s/%s",
-                table_name,
-                hostname,
-                catalog_id,
-            )
-            return
         store = get_rag_store()
         if store is None:
             logger.debug("rag store unavailable, skipping %s first-connect index", table_name)
             return
         # resolve_user_identity may issue a sync GET /authn/session in
         # stdio mode; offload so the loop is not blocked on first call.
+        # Resolved up front because it is part of the per-work-unit guard key
+        # (the index is per-user) and is cached after the first resolution.
         user_id = await asyncio.to_thread(resolve_user_identity, hostname)
-        for row in rows:
-            rid = row.get("rid")
-            if not rid:
-                # Defensive: a row without a RID can't get a stable
-                # per-RID source name; skip with a debug log rather
-                # than silently dropping it under an empty-RID source.
-                logger.debug(
-                    "skipping %s first-connect row with empty rid: %r",
-                    table_name,
-                    row,
-                )
-                continue
-            source = _row_source_name(hostname, catalog_id, user_id, table_token, rid)
+
+        # Two-layer first-connect guard (see the _indexed_user_catalogs comment
+        # block). Layer 1: per-server-lifetime "already indexed" set -- a later
+        # connect for the same unit skips entirely. Layer 2: per-key lock with
+        # a re-check, so concurrent firings collapse to one run.
+        key = (user_id, hostname, catalog_id, table_token)
+        if key in _indexed_user_catalogs:
+            return
+        lock = _user_connect_locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            if key in _indexed_user_catalogs:  # re-check after acquiring the lock
+                return
             try:
-                await _write_row_chunk(store, source, table_name, row, serializer)
-            except Exception:  # noqa: BLE001 -- one bad row should not poison the pass
-                logger.exception(
-                    "deriva-ml RAG: failed to first-connect index %s row %s",
+                # fetch_fn wraps synchronous deriva-py HTTP I/O; run it in a
+                # worker thread so the event loop stays responsive while the
+                # catalog is being indexed.
+                raw_rows = await asyncio.to_thread(fetch_fn, hostname, catalog_id)
+                rows = _coerce_for_index(raw_rows)
+            except ValueError as exc:
+                # A ValueError here is almost always a catalog row carrying a
+                # value deriva-ml's enums can't parse -- most commonly a legacy
+                # Execution.Status (e.g. "Completed") that predates the current
+                # ExecutionStatus set. find_executions() yields lookup_execution
+                # per row, so ONE such row aborts the whole fetch. This recurs on
+                # every connect for a stale catalog, so log a CONCISE, actionable
+                # single line (no traceback) rather than spamming a stack dump.
+                # Fix is catalog-data: map the legacy value to a current enum
+                # term. Not marked indexed -> retried once the data is corrected.
+                logger.warning(
+                    "deriva-ml RAG: skipping %s first-connect index for %s/%s -- a row "
+                    "holds a value deriva-ml cannot parse (likely a legacy "
+                    "Execution.Status / ExecutionStatus enum mismatch): %s. "
+                    "Fix the catalog row's value to a current enum term.",
                     table_name,
-                    rid,
+                    hostname,
+                    catalog_id,
+                    exc,
                 )
-                continue
-        logger.debug(
-            "first-connect indexed %d %s rows for user=%s host=%s catalog=%s",
-            len(rows),
-            table_name,
-            user_id,
-            hostname,
-            catalog_id,
-        )
+                return  # not marked indexed -> retried on next connect
+            except Exception:  # noqa: BLE001 -- fetch errors are domain-specific
+                logger.exception(
+                    "deriva-ml RAG: failed to fetch %s rows for %s/%s",
+                    table_name,
+                    hostname,
+                    catalog_id,
+                )
+                return  # not marked indexed -> retried on next connect
+            for row in rows:
+                rid = row.get("rid")
+                if not rid:
+                    # Defensive: a row without a RID can't get a stable
+                    # per-RID source name; skip with a debug log rather
+                    # than silently dropping it under an empty-RID source.
+                    logger.debug(
+                        "skipping %s first-connect row with empty rid: %r",
+                        table_name,
+                        row,
+                    )
+                    continue
+                source = _row_source_name(hostname, catalog_id, user_id, table_token, rid)
+                try:
+                    await _write_row_chunk(store, source, table_name, row, serializer)
+                except Exception:  # noqa: BLE001 -- one bad row should not poison the pass
+                    logger.exception(
+                        "deriva-ml RAG: failed to first-connect index %s row %s",
+                        table_name,
+                        rid,
+                    )
+                    continue
+            # Record only after a full, non-raising pass so a transient fetch
+            # error stays retryable on the next connect.
+            _indexed_user_catalogs.add(key)
+            logger.debug(
+                "first-connect indexed %d %s rows for user=%s host=%s catalog=%s",
+                len(rows),
+                table_name,
+                user_id,
+                hostname,
+                catalog_id,
+            )
 
     return hook
 
@@ -1071,14 +1196,29 @@ def _make_vocab_hook() -> Callable[[str, str, str, dict], Awaitable[None]]:
         schema_hash: str,  # noqa: ARG001 -- hook signature requires it
         schema_json: dict,  # noqa: ARG001 -- hook signature requires it
     ) -> None:
-        try:
-            await _index_vocabularies(hostname, catalog_id)
-        except Exception:  # noqa: BLE001 -- vocab discovery is best-effort
-            logger.exception(
-                "deriva-ml RAG: vocab index pass failed for %s/%s",
-                hostname,
-                catalog_id,
-            )
+        # Two-layer first-connect guard (see the _indexed_vocab_catalogs comment
+        # block). Vocab content is catalog-public (no per-user partition), so the
+        # work unit is just (host, catalog). This is the single most expensive
+        # cold-start pass -- the ICD10_Eye vocab alone is 1209 embedded terms --
+        # so suppressing redundant re-runs here removes most of the regression.
+        key = (hostname, catalog_id)
+        if key in _indexed_vocab_catalogs:
+            return
+        lock = _vocab_connect_locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            if key in _indexed_vocab_catalogs:  # re-check after acquiring the lock
+                return
+            try:
+                await _index_vocabularies(hostname, catalog_id)
+                # Record only after a successful pass so a transient failure
+                # stays retryable on the next connect.
+                _indexed_vocab_catalogs.add(key)
+            except Exception:  # noqa: BLE001 -- vocab discovery is best-effort
+                logger.exception(
+                    "deriva-ml RAG: vocab index pass failed for %s/%s",
+                    hostname,
+                    catalog_id,
+                )
 
     return hook
 

--- a/src/deriva_ml_mcp_plugin/tools/maintenance.py
+++ b/src/deriva_ml_mcp_plugin/tools/maintenance.py
@@ -113,9 +113,16 @@ def register(ctx: PluginContext) -> None:
                 # Imported lazily so module import time stays cheap and
                 # so test patches of ``rag._index_vocabularies`` reach
                 # this call site cleanly.
-                from deriva_ml_mcp_plugin.resources.rag import _index_vocabularies
+                from deriva_ml_mcp_plugin.resources.rag import (
+                    _clear_vocab_indexed,
+                    _index_vocabularies,
+                )
 
                 indexed = await _index_vocabularies(hostname, catalog_id, only_vocab=vocab)
+                # Drop the first-connect guard entry so the next
+                # on_catalog_connect re-runs the bulk pass too -- an explicit
+                # re-index implies the indexed content is stale.
+                _clear_vocab_indexed(hostname, catalog_id)
             return ReindexVocabulariesResponse(reindexed=indexed).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
@@ -207,9 +214,16 @@ def register(ctx: PluginContext) -> None:
                 # Lazy import per the established pattern -- keeps
                 # module import time cheap and lets tests patch
                 # rag._resync_user_sources at the use-site.
-                from deriva_ml_mcp_plugin.resources.rag import _resync_user_sources
+                from deriva_ml_mcp_plugin.resources.rag import (
+                    _clear_user_indexed,
+                    _resync_user_sources,
+                )
 
                 counts = await _resync_user_sources(hostname, catalog_id, target=target)
+                # Drop the per-user first-connect guard entries so the next
+                # on_catalog_connect re-runs the per-user-trio pass too -- an
+                # explicit resync implies the indexed view is stale.
+                _clear_user_indexed(hostname, catalog_id)
             return ResyncIndexesResponse(resynced=counts).model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(

--- a/tests/test_async_thread_wrap.py
+++ b/tests/test_async_thread_wrap.py
@@ -38,9 +38,7 @@ RESOURCES_ROOT = PLUGIN_ROOT / "resources"
 # every sync deriva-ml call inside ``with deriva_call():`` blocks.
 #
 # Resource handlers run on the same asyncio event loop as tool handlers
-# and have the same blocking-call hazard. ``resources/rag.py`` does not
-# use ``with deriva_call():`` (it manages its own retries) so it's not
-# in this list; the rule only fires inside that context manager.
+# and have the same blocking-call hazard.
 TOOL_MODULES: list[Path] = [
     TOOLS_ROOT / "asset.py",
     TOOLS_ROOT / "feature.py",
@@ -54,6 +52,18 @@ TOOL_MODULES: list[Path] = [
     # lifecycle moved to user-local Python per the stateless rule.
     # See docs/audit-2026-05-23.md.
     RESOURCES_ROOT / "ml.py",
+]
+
+# Modules checked with the STRICTER, context-free rule: every sync
+# deriva-ml call inside an ``async def`` must be thread-wrapped, whether
+# or not it sits inside a ``with deriva_call():`` block. ``resources/rag.py``
+# (the on_catalog_connect hooks + surgical re-index helpers) does NOT use
+# ``deriva_call()`` -- it manages its own retries -- so the deriva_call-scoped
+# rule above would never fire for it. The 2026-06-04 cold-start bug report
+# (Note 3) asks for rag.py coverage so a future unwrapped blocking call
+# (which would re-block the event loop during indexing) is caught structurally.
+CONTEXT_FREE_MODULES: list[Path] = [
+    RESOURCES_ROOT / "rag.py",
 ]
 
 # Names whose method calls indicate sync deriva-ml I/O. Any
@@ -266,7 +276,7 @@ def _node_within(node: ast.AST, ancestor: ast.AST) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _violations_in_module(path: Path) -> list[str]:
+def _violations_in_module(path: Path, *, require_deriva_call_context: bool = True) -> list[str]:
     """Return a list of violation strings for one tool module.
 
     Each violation string is a one-line summary identifying the file,
@@ -275,6 +285,14 @@ def _violations_in_module(path: Path) -> list[str]:
 
     Args:
         path: Absolute path to the tool module.
+        require_deriva_call_context: When True (default), only sync
+            deriva-ml calls inside a ``with deriva_call():`` block are
+            flagged -- the convention for the tool/resource modules that
+            manage I/O through that context manager. When False, EVERY
+            sync deriva-ml call inside an ``async def`` is flagged
+            regardless of context -- the stricter rule for modules
+            (e.g. ``resources/rag.py``) that don't use ``deriva_call()``
+            but still run on the event loop.
 
     Returns:
         Sorted list of violation strings (empty when clean).
@@ -295,18 +313,30 @@ def _violations_in_module(path: Path) -> list[str]:
             ):
                 threaded_nodes.append(node)
 
-        # Find every ``with deriva_call():`` block in this async func,
-        # including ``async with`` for completeness.
-        with_blocks: list[ast.With | ast.AsyncWith] = []
-        for node in ast.walk(async_func):
-            if isinstance(node, (ast.With, ast.AsyncWith)) and _is_with_deriva_call(node):
-                with_blocks.append(node)
+        if require_deriva_call_context:
+            # Scope the scan to ``with deriva_call():`` blocks.
+            scan_roots: list[ast.AST] = [
+                node
+                for node in ast.walk(async_func)
+                if isinstance(node, (ast.With, ast.AsyncWith)) and _is_with_deriva_call(node)
+            ]
+            context_note = " inside `with deriva_call():`"
+        else:
+            # Scan the whole async-func body -- no deriva_call() context
+            # required (rag.py convention). Exclude nested async defs'
+            # own bodies? No: _walk_async_funcs already yields each async
+            # def separately, and scanning the outer one's full subtree
+            # would double-flag inner-def calls. Use the func body nodes
+            # directly and let the per-async-def iteration cover nesting.
+            scan_roots = list(async_func.body)
+            context_note = ""
 
-        for with_block in with_blocks:
-            for call in _calls_in_subtree(with_block):
-                # Skip the ``deriva_call()`` context-manager call itself
-                # (it appears in ``with_block.items[*].context_expr``).
-                if any(call is item.context_expr for item in with_block.items):
+        for root in scan_roots:
+            for call in _calls_in_subtree(root):
+                # Skip a ``with deriva_call():`` context-manager call itself.
+                if isinstance(root, (ast.With, ast.AsyncWith)) and any(
+                    call is item.context_expr for item in root.items
+                ):
                     continue
                 # Skip ``asyncio.to_thread(...)`` calls themselves.
                 if _is_asyncio_to_thread(call.func):
@@ -317,15 +347,36 @@ def _violations_in_module(path: Path) -> list[str]:
                 # Allow calls inside a nested helper that's threaded.
                 if any(_node_within(call, helper) for helper in threaded_nodes):
                     continue
+                # In context-free mode, a call that lives inside a nested
+                # async def is that inner def's responsibility (it's
+                # yielded separately by _walk_async_funcs); skip here to
+                # avoid double-counting.
+                if not require_deriva_call_context and _in_nested_async_def(call, async_func):
+                    continue
 
                 snippet = ast.unparse(call)
                 violations.append(
                     f"{path}:{call.lineno}: in `async def {async_func.name}`: "
-                    f"unwrapped sync deriva-ml call `{snippet}` inside "
-                    f"`with deriva_call():` (must be `await asyncio.to_thread(...)`)"
+                    f"unwrapped sync deriva-ml call `{snippet}`{context_note} "
+                    f"(must be `await asyncio.to_thread(...)`)"
                 )
 
-    return sorted(violations)
+    return sorted(set(violations))
+
+
+def _in_nested_async_def(call: ast.Call, outer: ast.AsyncFunctionDef) -> bool:
+    """Return True iff ``call`` lives inside an async def nested within ``outer``.
+
+    Used by the context-free scan to avoid double-flagging: each async def
+    is checked in its own right by the outer loop, so a call belonging to a
+    nested async def should not also be attributed to its enclosing one.
+    """
+    for node in ast.walk(outer):
+        if node is outer:
+            continue
+        if isinstance(node, ast.AsyncFunctionDef) and any(c is call for c in ast.walk(node)):
+            return True
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -349,6 +400,26 @@ def test_async_tools_thread_wrap_sync_deriva_calls() -> None:
 
     if all_violations:
         msg = "\n".join(["Unwrapped sync deriva-ml calls found:", *all_violations])
+        raise AssertionError(msg)
+
+
+def test_context_free_modules_thread_wrap_all_sync_deriva_calls() -> None:
+    """Every sync deriva-ml call in a context-free module's async fns is thread-wrapped.
+
+    Covers ``resources/rag.py`` (on_catalog_connect hooks + surgical
+    re-index helpers), which does not use ``with deriva_call():`` and so
+    is invisible to the deriva_call-scoped check above. Per the 2026-06-04
+    cold-start bug report (Note 3): a future unwrapped blocking call here
+    would re-block the event loop during indexing, so the rule is enforced
+    structurally over the whole async-function body.
+    """
+    all_violations: list[str] = []
+    for module_path in CONTEXT_FREE_MODULES:
+        assert module_path.is_file(), f"module not found: {module_path}"
+        all_violations.extend(_violations_in_module(module_path, require_deriva_call_context=False))
+
+    if all_violations:
+        msg = "\n".join(["Unwrapped sync deriva-ml calls found (context-free):", *all_violations])
         raise AssertionError(msg)
 
 

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -259,3 +259,50 @@ async def test_resync_indexes_failure_returns_error_envelope_without_audit(
     assert "error" in payload
     assert "vector store down" in payload["error"]
     mock_audit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# First-connect guard clearing (2026-06-04 bug report, Note 2)
+# ---------------------------------------------------------------------------
+#
+# The persistent first-connect guard in resources/rag.py would otherwise
+# suppress re-indexing on the next on_catalog_connect even after an explicit
+# manual re-index. These tools must clear the relevant guard entries so the
+# manual request takes effect AND the next connect re-runs.
+
+
+async def test_reindex_vocabularies_clears_vocab_guard(vocab_ctx, capturing_mcp):
+    """deriva_ml_reindex_vocabularies drops the (host, catalog) vocab guard entry."""
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    rag_module._reset_index_state()
+    rag_module._indexed_vocab_catalogs.add(("h.example", "1"))
+
+    with patch.object(rag_module, "_index_vocabularies", return_value={"deriva-ml.X": 1}):
+        await capturing_mcp.tools["deriva_ml_reindex_vocabularies"](
+            hostname="h.example", catalog_id="1"
+        )
+
+    assert ("h.example", "1") not in rag_module._indexed_vocab_catalogs
+
+
+async def test_resync_indexes_clears_user_guard(vocab_ctx, capturing_mcp):
+    """deriva_ml_resync_indexes drops the per-user-trio guard entries for the catalog."""
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    rag_module._reset_index_state()
+    rag_module._indexed_user_catalogs.update(
+        {
+            ("userA", "h.example", "1", "dataset"),
+            ("userA", "h.example", "1", "workflow"),
+            ("userA", "h.example", "2", "dataset"),  # other catalog -- preserved
+        }
+    )
+
+    counts = {"dataset": 1, "workflow": 0, "execution": 0}
+    with patch.object(rag_module, "_resync_user_sources", return_value=counts):
+        await capturing_mcp.tools["deriva_ml_resync_indexes"](hostname="h.example", catalog_id="1")
+
+    remaining = rag_module._indexed_user_catalogs
+    assert not any(k[1] == "h.example" and k[2] == "1" for k in remaining)
+    assert ("userA", "h.example", "2", "dataset") in remaining  # untouched

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -38,6 +38,24 @@ def _run(coro):
     return asyncio.run(coro)
 
 
+@pytest.fixture(autouse=True)
+def _isolate_first_connect_guard():
+    """Reset the module-global first-connect guard state before every test.
+
+    The persistent guard (``_indexed_vocab_catalogs`` /
+    ``_indexed_user_catalogs`` + their locks) lives per-server-lifetime, i.e.
+    module-global. Without a reset, a hook-firing test leaks an "already
+    indexed" entry into the next test, which would then see its hook skip and
+    fail. Autouse so every test starts from a clean guard regardless of whether
+    it touches the hooks.
+    """
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    rag_module._reset_index_state()
+    yield
+    rag_module._reset_index_state()
+
+
 # Hook registration order in register_rag_sources(ctx):
 #   0 -> Dataset, 1 -> Workflow, 2 -> Execution, 3 -> Vocabularies.
 # Tests pull hooks via index rather than by name because the factory
@@ -899,6 +917,310 @@ def test_vocab_hook_swallows_index_exception() -> None:
     with patch.object(rag_module, "_index_vocabularies", new=fake):
         # Must not raise.
         _run(_hook_at(_VOCAB_HOOK_IDX)("h.example", "1", "hash", {}))
+
+
+# ---------------------------------------------------------------------------
+# 9b. First-connect guard -- catalog-connect re-firings must not re-index
+# ---------------------------------------------------------------------------
+#
+# Cold-start regression (2026-06-04): a single user's bootstrapping sequence
+# fires several catalog-touching tool calls (get_catalog_info, two get_schema
+# calls), each independently triggering on_catalog_connect. In stateless_http
+# mode core's per-(host, catalog, user) connect dedup does not reliably hold
+# across them (sequential re-fires when the prior schema-fetch errored and
+# discarded the key; concurrent re-fires when calls interleave). Without a
+# guard the full hook set ran on EVERY connect: every vocab + every per-user
+# row re-fetched and re-embedded. The ICD10_Eye vocab (1209 terms) re-embedded
+# each time; the passes fought the GIL with rag_search's own query embedding
+# -- ~60-261s first-turn latency, 97% CPU.
+#
+# The guard (per the 2026-06-04 bug report) has two layers:
+#   1. A per-server-lifetime "already indexed" set: once a work unit has been
+#      indexed it is NOT re-indexed on any later connect until server restart.
+#      This is the documented "first connect per server lifetime" intent.
+#   2. A per-key asyncio.Lock with double-checked membership: concurrent
+#      firings serialize on the lock; the winner indexes and records the unit
+#      in the set; waiters re-check the set after acquiring and skip.
+# Manual re-index tools (deriva_ml_reindex_vocabularies / resync_indexes) clear
+# the relevant set entries so an explicit re-index still runs.
+#
+# Work units:
+#   vocab pass         -> (host, catalog)
+#   per-user-trio hook -> (user_id, host, catalog, table_token)
+
+
+def _make_gate():
+    """Build an awaitable gate the test releases manually.
+
+    Returns (started_event, release_event, body) where ``body`` is an async
+    callable that signals it has started, then blocks until ``release`` is set.
+    Used to hold the first hook run open while a second concurrent run is
+    dispatched, so we can assert the second observes the in-progress lock.
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def body(*args, **kwargs):
+        started.set()
+        await release.wait()
+        return {}
+
+    return started, release, body
+
+
+def test_vocab_hook_skips_second_sequential_connect() -> None:
+    """A second SEQUENTIAL vocab-hook firing for the same catalog skips re-indexing.
+
+    This is the core of the persistent-guard fix: once a catalog's vocabs are
+    indexed this server lifetime, a later connect (the user re-opening the
+    chatbot, or the next bootstrapping tool call) must NOT re-run the pass.
+    """
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    fake_index = AsyncMock(return_value={})
+    with patch.object(rag_module, "_index_vocabularies", new=fake_index):
+        rag_module._reset_index_state()
+        hook = _hook_at(_VOCAB_HOOK_IDX)
+        _run(hook("h.example", "1", "hash", {}))
+        _run(hook("h.example", "1", "hash", {}))
+        _run(hook("h.example", "1", "hash", {}))
+
+    # Only the first of the three sequential firings ran the pass.
+    assert fake_index.await_count == 1
+
+
+def test_vocab_hook_skips_when_same_catalog_already_indexing() -> None:
+    """A second CONCURRENT vocab-hook firing for the same catalog runs the pass only once.
+
+    The first firing holds the per-catalog lock open mid-pass; while it is in
+    flight a second firing for the SAME (host, catalog) is dispatched. The
+    second serializes on the lock, and after acquiring it re-checks the
+    already-indexed set (now populated by the first) and returns WITHOUT calling
+    _index_vocabularies a second time.
+    """
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    started, release, body = _make_gate()
+    fake_index = AsyncMock(side_effect=body)
+
+    async def scenario() -> None:
+        hook = _hook_at(_VOCAB_HOOK_IDX)
+        first = asyncio.create_task(hook("h.example", "1", "hash", {}))
+        await started.wait()  # first run is now inside the lock, blocked mid-pass
+        # Second concurrent firing for the same catalog -- dispatched as a task
+        # because it will BLOCK on the lock the first run holds (wait-then-skip,
+        # not busy-return). Release the gate so the first finishes and records
+        # the unit; the second then acquires, re-checks the set, and skips.
+        second = asyncio.create_task(hook("h.example", "1", "hash", {}))
+        await asyncio.sleep(0)  # let the second task reach the lock acquire
+        release.set()
+        await asyncio.gather(first, second)
+
+    with patch.object(rag_module, "_index_vocabularies", new=fake_index):
+        rag_module._reset_index_state()  # isolate from other tests' state
+        _run(scenario())
+
+    # Only the first firing ran the index pass; the second skipped post-lock.
+    assert fake_index.await_count == 1
+
+
+def test_vocab_hook_does_not_skip_different_catalog() -> None:
+    """Firings for DIFFERENT catalogs both run (guard is per (host, catalog))."""
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    fake_index = AsyncMock(return_value={})
+    with patch.object(rag_module, "_index_vocabularies", new=fake_index):
+        rag_module._reset_index_state()
+        hook = _hook_at(_VOCAB_HOOK_IDX)
+        _run(hook("h.example", "1", "hash", {}))
+        _run(hook("h.example", "2", "hash", {}))
+
+    assert fake_index.await_count == 2
+
+
+def test_vocab_hook_failed_pass_not_marked_indexed() -> None:
+    """If the index pass raises, the catalog is NOT recorded as indexed.
+
+    A failed first-connect must be retryable on the next connect -- otherwise a
+    transient catalog error would permanently strand the catalog's vocab index
+    until server restart.
+    """
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    fake_index = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch.object(rag_module, "_index_vocabularies", new=fake_index):
+        rag_module._reset_index_state()
+        hook = _hook_at(_VOCAB_HOOK_IDX)
+        _run(hook("h.example", "1", "hash", {}))  # raises internally, swallowed
+        # Second connect must RETRY because the first did not complete.
+        fake_index.side_effect = None
+        fake_index.return_value = {}
+        _run(hook("h.example", "1", "hash", {}))
+
+    assert fake_index.await_count == 2
+
+
+def test_dataset_hook_skips_second_sequential_connect() -> None:
+    """A second SEQUENTIAL per-user-trio firing for the same unit skips re-indexing.
+
+    Persistent guard applied to the Dataset/Workflow/Execution first-connect
+    hooks: work unit is (user_id, host, catalog, table). Once indexed, a later
+    connect for the same unit must not re-walk the rows.
+    """
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    fetch_calls = 0
+
+    def fake_fetch(host, cat):
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return [{"rid": "1-DSAA", "name": "x"}]
+
+    async def fake_write(store, source, table_name, row, serializer):
+        return 1
+
+    with (
+        patch.object(rag_module, "_fetch_dataset_rows", side_effect=fake_fetch),
+        patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
+        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
+        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write),
+    ):
+        rag_module._reset_index_state()
+        hook = _hook_at(_DATASET_HOOK_IDX)
+        _run(hook("h.example", "1", "hash", {}))
+        _run(hook("h.example", "1", "hash", {}))
+
+    # The second firing skipped before fetching rows a second time.
+    assert fetch_calls == 1
+
+
+def test_dataset_hook_partitions_guard_per_user() -> None:
+    """The per-user-trio guard is keyed by user_id: a different user still indexes."""
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    fetch_calls = 0
+
+    def fake_fetch(host, cat):
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return [{"rid": "1-DSAA", "name": "x"}]
+
+    async def fake_write(store, source, table_name, row, serializer):
+        return 1
+
+    with (
+        patch.object(rag_module, "_fetch_dataset_rows", side_effect=fake_fetch),
+        patch.object(rag_module, "resolve_user_identity", side_effect=["userA", "userB"]),
+        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
+        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write),
+    ):
+        rag_module._reset_index_state()
+        hook = _hook_at(_DATASET_HOOK_IDX)
+        _run(hook("h.example", "1", "hash", {}))  # userA
+        _run(hook("h.example", "1", "hash", {}))  # userB -- distinct unit, runs
+
+    assert fetch_calls == 2
+
+
+def test_hook_logs_concise_message_for_legacy_status_valueerror(caplog) -> None:
+    """A ValueError from the fetch (legacy/unknown ExecutionStatus) logs concisely.
+
+    Per the 2026-06-04 bug report: an Execution row whose catalog Status is not
+    in deriva-ml's ExecutionStatus enum makes lookup_execution raise ValueError,
+    which aborts the whole fetch. The hook must catch it and log a clear,
+    actionable single line WITHOUT a full traceback (it recurs on every connect
+    for a stale catalog), and must not mark the unit indexed (retryable).
+    """
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    err = ValueError("'Completed' is not a valid ExecutionStatus")
+
+    def boom(host, cat):
+        raise err
+
+    with (
+        patch.object(rag_module, "_fetch_execution_rows", side_effect=boom),
+        patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
+        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
+        caplog.at_level("WARNING", logger="deriva_ml_mcp_plugin.resources.rag"),
+    ):
+        rag_module._reset_index_state()
+        # Must not raise.
+        _run(_hook_at(_EXECUTION_HOOK_IDX)("h.example", "1", "hash", {}))
+
+    # Find the record for this failure.
+    recs = [
+        r
+        for r in caplog.records
+        if "Completed" in r.getMessage() or "status" in r.getMessage().lower()
+    ]
+    assert recs, "expected a log record naming the legacy-status failure"
+    rec = recs[0]
+    # Concise: WARNING level, no traceback attached (logger.exception sets exc_info).
+    assert rec.levelname == "WARNING"
+    assert rec.exc_info is None, "legacy-status failure should NOT log a full traceback"
+    # Actionable: names the legacy status + the cause.
+    msg = rec.getMessage()
+    assert "Execution" in msg
+    assert "Completed" in msg or "ExecutionStatus" in msg
+
+    # Not marked indexed -> retryable on next connect.
+    assert (_USER_ID, "h.example", "1", _EXECUTION_TOKEN_FOR_TEST) not in (
+        rag_module._indexed_user_catalogs
+    )
+
+
+# Token used in the Execution hook's guard key (matches rag._EXECUTION_TOKEN).
+_EXECUTION_TOKEN_FOR_TEST = "execution"
+
+
+# ---------------------------------------------------------------------------
+# 9c. Guard-clearing helpers (manual re-index must re-run after persistent guard)
+# ---------------------------------------------------------------------------
+
+
+def test_clear_vocab_indexed_allows_reconnect_reindex() -> None:
+    """After _clear_vocab_indexed, a subsequent vocab-hook connect re-runs the pass."""
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    fake_index = AsyncMock(return_value={})
+    with patch.object(rag_module, "_index_vocabularies", new=fake_index):
+        rag_module._reset_index_state()
+        hook = _hook_at(_VOCAB_HOOK_IDX)
+        _run(hook("h.example", "1", "hash", {}))  # indexes, sets guard
+        _run(hook("h.example", "1", "hash", {}))  # skipped by guard
+        assert fake_index.await_count == 1
+        rag_module._clear_vocab_indexed("h.example", "1")  # explicit re-index path
+        _run(hook("h.example", "1", "hash", {}))  # guard cleared -> runs again
+
+    assert fake_index.await_count == 2
+
+
+def test_clear_user_indexed_clears_all_users_and_tables_for_catalog() -> None:
+    """_clear_user_indexed drops every per-user-trio entry for the catalog."""
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    rag_module._reset_index_state()
+    # Seed entries for two users, two tables, plus an unrelated catalog.
+    rag_module._indexed_user_catalogs.update(
+        {
+            ("userA", "h.example", "1", "dataset"),
+            ("userA", "h.example", "1", "workflow"),
+            ("userB", "h.example", "1", "execution"),
+            ("userA", "h.example", "2", "dataset"),  # different catalog -- keep
+            ("userA", "other", "1", "dataset"),  # different host -- keep
+        }
+    )
+    rag_module._clear_user_indexed("h.example", "1")
+
+    remaining = rag_module._indexed_user_catalogs
+    assert ("userA", "h.example", "2", "dataset") in remaining
+    assert ("userA", "other", "1", "dataset") in remaining
+    assert not any(k[1] == "h.example" and k[2] == "1" for k in remaining)
+
+
+# (Tool-level guard-clearing tests live in test_maintenance.py, alongside the
+# vocab_ctx / capturing_mcp fixtures that drive the maintenance tools.)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`resources/rag.py`'s `on_catalog_connect` hooks re-indexed **all** vocabularies and per-user Dataset/Workflow/Execution rows on **every** catalog connect. A single user's bootstrapping sequence fires several catalog-touching tool calls (`get_catalog_info` + two `get_schema`), each independently triggering `on_catalog_connect`. In `stateless_http` mode core's per-connect dedup does not reliably hold across them (re-fires sequentially when a prior schema-fetch errored and discarded the dedup key — which is exactly what the `ExecutionStatus` enum crash was causing — and concurrently when calls interleave).

Result: the full hook set ran on every connect. The `ICD10_Eye` vocab (1209 terms) re-embedded each time; the passes fought the GIL with `rag_search`'s own query embedding. **60–261s first-turn latency, 97% CPU.**

## Fix — implements the 2026-06-04 bug report in full

- **Bugs 1–3 (persistent guard):** replace the concurrency-only lock with a two-layer guard — a per-server-lifetime "already indexed" set (vocab keyed by `(host, catalog)`; per-user-trio keyed by `(user_id, host, catalog, table)`) plus a per-key `asyncio.Lock` with double-checked membership. A later connect for an indexed unit skips entirely; concurrent firings serialize and collapse to one run. A **failed** pass is not recorded, so transient errors stay retryable. Enforces the long-documented "first connect per server lifetime" intent the code never actually enforced.
- **Note 2 (guard clearing):** `deriva_ml_reindex_vocabularies` / `deriva_ml_resync_indexes` now clear the relevant guard entries so an explicit re-index runs **and** the next connect re-runs.
- **Additional bug (legacy status):** the execution fetch path catches `ValueError` (legacy/unknown `ExecutionStatus`, e.g. a pre-reconciliation `"Completed"` row) and logs a concise, actionable single line instead of a full traceback on every connect; the unit is left un-indexed so it retries once the catalog data is fixed.
- **Note 3 (test coverage):** `test_async_thread_wrap.py` gains a context-free check covering `resources/rag.py` (which doesn't use `deriva_call()`), catching any future unwrapped blocking call in the hooks / re-index helpers.

## Tests

372 passed (+8 net). New coverage: sequential-skip, concurrent collapse, failed-pass retry, per-user partitioning, guard-clearing from the manual tools, and the concise legacy-status log. An autouse fixture resets the module-global guard state between tests. `ruff check` + `ruff format` clean.

## Notes

- Includes the `0.6.1 → 0.6.2` version bump commit + local `v0.6.2` tag (tag pushed on merge).
- The companion catalog-data repair (mapping legacy `Completed`/`Initializing`/`Pending` Execution statuses on `www.eye-ai.org` to valid enum terms, and pruning the stale vocab terms) was applied directly to the catalog and is **not** part of this code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)