### PR TITLE
Read-through RAG indexing: cut per-connection startup overhead

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ src/deriva_ml_mcp_plugin/
 └── resources/           # MCP resources + per-user RAG
     ├── ml.py            #   9 read-only resources under deriva://catalog/{h}/{c}/ml/...
     └── rag.py           #   1 GitHub doc source +
-                         #   3 per-user on_catalog_connect hooks (Dataset/Workflow/Execution)
+                         #   read-through per-user-per-RID writers (Dataset/Workflow/Execution,
+                         #   warmed on list/get/find + surgically on mutate; no on-connect pass)
                          # + 1 catalog-public on_catalog_connect hook (vocabularies)
 ```
 
@@ -55,9 +56,10 @@ into a focused-submodule package.
 `ctx.rag_dataset_indexer(...)` -- that API produces a single global
 enriched source shared across users (`enriched:{host}:{cat}:{schema}:{table}`),
 which leaks data for any catalog table where rows have user-specific
-ACLs. Instead, the plugin uses `ctx.on_catalog_connect(...)` with
-direct `store.delete_source + store.add` writes so each user's chunks
-land under per-RID source names of the shape
+ACLs. Instead, the plugin writes these rows via direct
+`store.delete_source + store.add` calls (from the read-through and
+mutate paths, not an on-connect hook) so each user's chunks land under
+per-RID source names of the shape
 `data:{host}:{cat}:{user_id}:{table}:{rid}` (v1.3) and ACL is applied
 at fetch time using the calling user's credential. The `data:` prefix
 keeps upstream's `rag_search` user-id filter in play (it accepts both
@@ -68,31 +70,39 @@ ban; `test_data_sources_use_per_rid_naming` pins the v1.3 source-name
 shape; future commits accidentally calling the unsafe API or
 regressing the source-name shape will fail CI.
 
-**Surgical per-RID re-index (v1.3).** Each mutating tool that affects
-a Dataset / Workflow / Execution row calls `_reindex_<entity>` (a
-lazy import inside the tool body, mirroring the v1.1 vocab indexer
-pattern) immediately after the catalog mutation succeeds. The
-re-index is best-effort: any failure is logged but does NOT propagate
-to the tool's success path (the catalog mutation already succeeded).
-The audit event for the catalog mutation always fires before the
-re-index call so audit captures the success regardless of cache
-state. Result: a freshly created or modified row is searchable via
-`rag_search` on the very next call from the same user.
+**Read-through (index-on-find) indexing (v1.5).** Dataset / Workflow /
+Execution rows are NO LONGER bulk-indexed on connect (the three
+first-connect passes were removed in v1.5 because they re-fetched and
+re-embedded every visible row on every catalog connect). A row's chunk
+is warmed lazily instead: the list/get/find tools call
+`_index_rows_on_find(...)` after a read to schedule a best-effort
+re-index for each row just seen (in the order the read returned them --
+there is NO newest-first sort), and each mutating tool calls
+`_reindex_<entity>` surgically right after its catalog mutation
+succeeds. Both paths write per-RID sources of the shape
+`data:{host}:{cat}:{user_id}:{table}:{rid}`. The re-index is
+best-effort: any failure is logged but does NOT propagate to the
+tool's success path (the catalog mutation already succeeded). The
+audit event always fires before the re-index call so audit captures
+the success regardless of cache state. Result: a row becomes
+`rag_search`-able once it's been listed/fetched (which warms it) or
+the moment the calling user creates/mutates it.
 
-**Cross-user freshness gap (v1.4 — known limitation).** Per-user
-surgical re-index covers the calling user's OWN mutations. It does
-NOT propagate across users: when user A mutates a dataset visible
-to user B, B's per-user sources remain stale until B reconnects.
-Same gap applies to mutations from non-MCP clients (Chaise UI,
-ERMrest direct). v1.4 ships a manual bridge: the
-`deriva_ml_resync_indexes(hostname, catalog_id, target=None)` tool
-in `tools/maintenance.py` re-runs `_reindex_*` for the calling
-user's per-user sources -- either all (target=None) or one
-(target="dataset:1-AAAA"). The `deriva_ml_getting_started` prompt
-documents the verify-with-`get_*` recovery pattern for shared-visible
-rows. Automatic cross-user fan-out is deferred per the design
-discussion in #9 -- the load profile is deployment-specific and
-no demand signal yet.
+**Cross-user freshness gap (v1.4 — known limitation).** The
+read-through warm and surgical re-index cover only the rows the calling
+user has read or mutated under their OWN credential. They do NOT
+propagate across users: when user A mutates a dataset visible to user
+B, B's per-user sources stay stale until B next lists/fetches that row
+(or resyncs). Same gap applies to mutations from non-MCP clients
+(Chaise UI, ERMrest direct). The manual bridge is
+`deriva_ml_resync_indexes(hostname, catalog_id, target=None)` in
+`tools/maintenance.py` -- the "warm everything for this catalog now"
+button, re-running `_reindex_*` over every visible row for the calling
+user (target=None) or one (target="dataset:1-AAAA"). The
+`deriva_ml_getting_started` prompt documents the verify-with-`get_*`
+recovery pattern for shared-visible rows. Automatic cross-user fan-out
+is deferred per the design discussion in #9 -- the load profile is
+deployment-specific and no demand signal yet.
 
 Vocabularies are the documented exception: vocab content is catalog-
 public (no per-user ACL), so the plugin writes vocab terms directly

--- a/docs/superpowers/plans/2026-06-04-read-through-rag-indexing.md
+++ b/docs/superpowers/plans/2026-06-04-read-through-rag-indexing.md
@@ -1,0 +1,938 @@
+# Read-Through RAG Indexing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut per-connection RAG startup overhead by replacing the three per-user bulk on-connect indexers (Dataset/Workflow/Execution) with read-through (index-on-find) indexing, while keeping vocabulary always-indexed on connect.
+
+**Architecture:** Remove only the `_make_hook` on-connect bulk-pass wiring. Add a fire-and-forget "index-on-find" helper that the dataset/workflow/execution list+get tools call after building their response, warming each returned row's per-user RAG source newest-first. Add client-side `dataset_type`/`workflow_type` filters to the dataset/workflow list helpers for a consistent structured-filter surface. The existing surgical `_reindex_*` writers, the `deriva_ml_resync_indexes` warm-button, and all vocabulary machinery stay.
+
+**Tech Stack:** Python 3 / asyncio, deriva-ml, deriva-mcp-core plugin API, Pydantic response models, pytest, `uv` for all tooling.
+
+**Repo:** `deriva-ml-mcp-plugin` (sibling of this worktree). All paths below are relative to that repo root. Work on branch `feat/read-through-rag-indexing` (already created; the design spec is committed there).
+
+**Reference spec:** `docs/superpowers/specs/2026-06-04-drop-per-user-row-indexing-design.md`
+
+**Tooling reminders:**
+- Always `uv run <cmd>` — never call `pytest`/`ruff` directly.
+- Run tests with `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest ...`.
+- Lint/format touched files: `uv run ruff check src tests` and `uv run ruff format src tests`.
+- House style: `from __future__ import annotations`, unquoted annotations, Google-style docstrings with `Example:`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/deriva_ml_mcp_plugin/resources/rag.py` | RAG indexing wiring + helpers | Remove 3 `_make_hook` on-connect registrations; add `_index_rows_on_find` fire-and-forget helper; update module docstring + `register_rag_sources` docstring |
+| `src/deriva_ml_mcp_plugin/tools/dataset/read.py` | Dataset list/get tools + impls | Add `dataset_type` filter to `_list_datasets_impl`; surface `dataset_type` param on `deriva_ml_list_datasets`; call index-on-find in list + get |
+| `src/deriva_ml_mcp_plugin/tools/workflow.py` | Workflow list/get tools + impls | Add `workflow_type` filter to `_list_workflows_impl`; surface param on `deriva_ml_list_workflows`; call index-on-find in list + get |
+| `src/deriva_ml_mcp_plugin/tools/execution/read.py` | Execution list/get tools + impls | Call index-on-find in `deriva_ml_list_executions` + `deriva_ml_get_execution` (filters already exist) |
+| `tests/test_rag.py` | RAG helper unit tests | Drop the 3 bulk-hook tests; add `_index_rows_on_find` tests |
+| `tests/test_plugin.py` | Plugin wiring tests | `four_catalog_connect_hooks` → one-hook; drop per-RID-naming bulk test; fix vocab-hook index `[3]`→`[0]` |
+| `tests/test_dataset_read.py` / `tests/test_workflow*.py` / `tests/test_execution*.py` | Read-tool tests | Add type-filter tests + index-on-find scheduling tests |
+
+The index-on-find helper lives in `rag.py` (next to the `_reindex_*` writers it reuses) and is called from the read tools via lazy import — same cycle-avoidance idiom the mutation tools already use for `_reindex_dataset`.
+
+---
+
+## Task 1: Add the `_index_rows_on_find` fire-and-forget helper
+
+**Files:**
+- Modify: `src/deriva_ml_mcp_plugin/resources/rag.py`
+- Test: `tests/test_rag.py`
+
+This helper takes rows already in hand (from a list/get response), sorts them newest-first, and schedules a background per-RID reindex for each. It must never block or raise into the caller. It mirrors the established fire-and-forget idiom in `deriva-mcp-core/src/deriva_mcp_core/tools/catalog.py:158-186` (`create_task` + module-level task set + `add_done_callback`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_rag.py`:
+
+```python
+def test_index_rows_on_find_schedules_reindex_per_rid() -> None:
+    """``_index_rows_on_find`` fires one reindex coroutine per row, newest-first."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    # Rows as the list impls produce them (RID + an RCT for sort order).
+    rows = [
+        {"rid": "1-OLD", "rct": "2026-01-01T00:00:00+00:00"},
+        {"rid": "1-NEW", "rct": "2026-06-01T00:00:00+00:00"},
+    ]
+    calls: list[str] = []
+
+    async def fake_reindex(hostname, catalog_id, rid):
+        calls.append(rid)
+        return 1
+
+    async def run() -> None:
+        with patch.object(rag_module, "_reindex_dataset", new=AsyncMock(side_effect=fake_reindex)):
+            rag_module._index_rows_on_find(
+                "h", "1", rag_module._DATASET_TOKEN, rows, rct_key="rct"
+            )
+            # Let the scheduled background tasks run to completion.
+            await asyncio.gather(*rag_module._on_find_tasks)
+
+    asyncio.run(run())
+
+    # Both RIDs indexed, newest-first (1-NEW before 1-OLD).
+    assert calls == ["1-NEW", "1-OLD"]
+
+
+def test_index_rows_on_find_swallows_reindex_errors() -> None:
+    """A failing reindex never propagates out of the background task."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    rows = [{"rid": "1-AAAA", "rct": "2026-01-01T00:00:00+00:00"}]
+
+    async def run() -> None:
+        boom = AsyncMock(side_effect=RuntimeError("rag boom"))
+        with patch.object(rag_module, "_reindex_dataset", new=boom):
+            rag_module._index_rows_on_find("h", "1", rag_module._DATASET_TOKEN, rows, rct_key="rct")
+            # gather must not raise even though the reindex raised.
+            await asyncio.gather(*rag_module._on_find_tasks, return_exceptions=True)
+
+    asyncio.run(run())  # no exception escapes
+
+
+def test_index_rows_on_find_no_running_loop_is_noop() -> None:
+    """Called with no running event loop, the helper is a silent no-op (import-time safety)."""
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    # Not inside asyncio.run -> no running loop. Must not raise.
+    rag_module._index_rows_on_find(
+        "h", "1", rag_module._DATASET_TOKEN, [{"rid": "1-AAAA"}], rct_key="rct"
+    )
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_rag.py -k index_rows_on_find -v`
+Expected: FAIL with `AttributeError: module ... has no attribute '_index_rows_on_find'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `src/deriva_ml_mcp_plugin/resources/rag.py`, add near the `_reindex_*` helpers (after `_reindex_execution`). First add a module-level task set next to the other module state (near the top, after the constants):
+
+```python
+# Strong references to in-flight index-on-find background tasks. Without
+# this set the event loop may garbage-collect a pending task before it
+# runs (asyncio holds only a weak reference). Mirrors the
+# ``_connect_tasks`` pattern in deriva-mcp-core/tools/catalog.py.
+_on_find_tasks: set[asyncio.Task] = set()
+
+# Maps a per-user-trio table token to the surgical re-index coroutine
+# that warms one row of that table. Used by ``_index_rows_on_find``.
+_REINDEX_BY_TOKEN: dict[str, Callable[[str, str, str], Awaitable[int]]] = {}
+```
+
+Then add the helper (the `_REINDEX_BY_TOKEN` map is populated after the
+`_reindex_*` functions are defined — add the three assignments directly
+below `_reindex_execution`):
+
+```python
+_REINDEX_BY_TOKEN[_DATASET_TOKEN] = _reindex_dataset
+_REINDEX_BY_TOKEN[_WORKFLOW_TOKEN] = _reindex_workflow
+_REINDEX_BY_TOKEN[_EXECUTION_TOKEN] = _reindex_execution
+
+
+def _index_rows_on_find(
+    hostname: str,
+    catalog_id: str,
+    table_token: str,
+    rows: list[dict[str, Any]],
+    *,
+    rct_key: str = "rct",
+) -> None:
+    """Warm the calling user's per-RID RAG sources for rows just read.
+
+    Read-through (index-on-find) indexing: a list/get tool that just
+    fetched ``rows`` calls this to schedule a best-effort background
+    re-index of each row, so a later ``rag_search`` finds them. Rows are
+    warmed **newest-first** (descending ``rct_key``) so the most recently
+    created entities become searchable first.
+
+    Fire-and-forget: schedules one background task per row and returns
+    immediately. Never blocks the caller's response and never raises --
+    a missing event loop (import-time / sync test) is a silent no-op, and
+    each per-row reindex swallows its own errors (see ``_reindex_*``).
+
+    Args:
+        hostname: Deriva hostname.
+        catalog_id: Catalog ID or alias.
+        table_token: One of ``_DATASET_TOKEN`` / ``_WORKFLOW_TOKEN`` /
+            ``_EXECUTION_TOKEN``. Selects the per-row reindex coroutine.
+        rows: Summary-shape row dicts (must carry ``"rid"``). Rows
+            without a RID are skipped.
+        rct_key: Key holding each row's record-creation timestamp, used
+            only to order the warm newest-first. Rows missing the key
+            sort last (treated as oldest).
+
+    Returns:
+        None.
+
+    Example:
+        >>> _index_rows_on_find(  # doctest: +SKIP
+        ...     "host", "1", _DATASET_TOKEN,
+        ...     [{"rid": "1-AAAA", "rct": "2026-06-01T00:00:00+00:00"}],
+        ... )
+    """
+    reindex_fn = _REINDEX_BY_TOKEN.get(table_token)
+    if reindex_fn is None:
+        return
+    # Newest-first: rows with a later rct warm sooner. Missing/empty rct
+    # sorts last (empty string < any real ISO timestamp).
+    ordered = sorted(rows, key=lambda r: r.get(rct_key) or "", reverse=True)
+
+    async def _do() -> None:
+        for row in ordered:
+            rid = row.get("rid")
+            if not rid:
+                continue
+            try:
+                await reindex_fn(hostname, catalog_id, rid)
+            except Exception:  # noqa: BLE001 -- best-effort warm
+                logger.debug(
+                    "index-on-find reindex failed for %s %s in %s/%s",
+                    table_token,
+                    rid,
+                    hostname,
+                    catalog_id,
+                    exc_info=True,
+                )
+
+    try:
+        task = asyncio.get_running_loop().create_task(_do())
+        _on_find_tasks.add(task)
+        task.add_done_callback(_on_find_tasks.discard)
+    except RuntimeError:
+        # No running event loop (import-time, sync test) -- silent no-op.
+        pass
+```
+
+Verify `Callable` and `Awaitable` are already imported in `rag.py` (they are — used by `_make_vocab_hook`'s return annotation). `Any` is imported. No new imports needed.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_rag.py -k index_rows_on_find -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Lint + format**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run ruff check src/deriva_ml_mcp_plugin/resources/rag.py tests/test_rag.py && uv run ruff format src/deriva_ml_mcp_plugin/resources/rag.py tests/test_rag.py`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin
+git add src/deriva_ml_mcp_plugin/resources/rag.py tests/test_rag.py
+git commit -m "feat(rag): add _index_rows_on_find read-through warm helper
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Remove the three on-connect bulk indexers
+
+**Files:**
+- Modify: `src/deriva_ml_mcp_plugin/resources/rag.py`
+- Test: `tests/test_plugin.py`, `tests/test_rag.py`
+
+Delete only the `_make_hook` factory and its three `ctx.on_catalog_connect(...)` registrations. The `_fetch_*_rows` fetchers, serializers, `_reindex_*`, and `_resync_*` all stay (the kept `deriva_ml_resync_indexes` path uses them).
+
+- [ ] **Step 1: Update the wiring test to expect one hook**
+
+In `tests/test_plugin.py`, change `test_register_wires_four_catalog_connect_hooks`:
+
+```python
+def test_register_wires_one_catalog_connect_hook(ctx):
+    """``register(ctx)`` wires exactly the vocab catalog-connect hook.
+
+    Read-through indexing removed the three per-user bulk row indexers
+    (Dataset/Workflow/Execution). Only the catalog-public vocab indexer
+    fires on connect now. Hook identity is covered in test_rag.py; this
+    pins the count so re-adding a bulk hook is caught at the plugin level.
+    """
+    register(ctx)
+    assert len(ctx._catalog_connect_hooks) == 1
+```
+
+In the same file, update `test_vocab_hook_writes_to_vocab_prefix_not_data_prefix`: change `vocab_hook = ctx._catalog_connect_hooks[3]` to `ctx._catalog_connect_hooks[0]`.
+
+Delete `test_data_sources_use_per_rid_naming` entirely (it asserts the bulk hooks write per-RID sources on connect; those hooks no longer exist — the per-RID naming is still covered by the `_reindex_*` tests in test_rag.py).
+
+- [ ] **Step 2: Run to verify the new/changed tests fail**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_plugin.py -k "one_catalog_connect_hook or vocab_hook_writes" -v`
+Expected: `test_register_wires_one_catalog_connect_hook` FAILS (`assert 4 == 1`); `vocab_hook_writes` FAILS (`IndexError`/wrong hook at `[0]`) — both because the bulk hooks are still registered.
+
+- [ ] **Step 3: Remove the bulk-hook registrations**
+
+In `src/deriva_ml_mcp_plugin/resources/rag.py`, in `register_rag_sources`, delete these three blocks (the Dataset/Workflow/Execution registrations), leaving the two `rag_github_source` calls and the vocab hook:
+
+```python
+    ctx.on_catalog_connect(
+        _make_hook(_fetch_dataset_rows, _DATASET_TABLE, _DATASET_TOKEN, _DatasetSerializer())
+    )
+    ctx.on_catalog_connect(
+        _make_hook(_fetch_workflow_rows, _WORKFLOW_TABLE, _WORKFLOW_TOKEN, _WorkflowSerializer())
+    )
+    ctx.on_catalog_connect(
+        _make_hook(
+            _fetch_execution_rows, _EXECUTION_TABLE, _EXECUTION_TOKEN, _ExecutionSerializer()
+        )
+    )
+```
+
+After deletion the only remaining `ctx.on_catalog_connect(...)` call is `ctx.on_catalog_connect(_make_vocab_hook())`.
+
+- [ ] **Step 4: Delete the `_make_hook` factory**
+
+In the same file, delete the entire `def _make_hook(...)` function (the per-user bulk-pass factory, roughly the block whose `hook` ignores `schema_hash`/`schema_json` and loops `_write_row_chunk` over fetched rows). Do NOT delete `_make_vocab_hook`, `_fetch_*_rows`, the serializers, `_reindex_*`, `_resync_*`, `_row_source_name`, `_write_row_chunk`, or `_coerce_for_index`.
+
+- [ ] **Step 5: Update the module + `register_rag_sources` docstrings**
+
+In `rag.py`, edit the module docstring: the numbered list item describing "Three per-user-per-RID `on_catalog_connect` hooks" should now describe them as **read-through (index-on-find)** writers warmed by the list/get tools, not on-connect hooks. Edit `register_rag_sources`'s docstring so the "four catalog-connect hooks" wording becomes "the GitHub doc sources and the vocabulary catalog-connect hook" (one hook). Keep all factual references to the `data:` per-RID source shape — that shape is unchanged.
+
+- [ ] **Step 6: Drop the now-dead bulk-hook tests in test_rag.py**
+
+Delete from `tests/test_rag.py` the tests that fired `_make_hook` on-connect bulk behavior:
+`test_dataset_hook_writes_one_per_rid_source_per_row`,
+`test_workflow_hook_writes_one_per_rid_source_per_row`,
+`test_execution_hook_writes_one_per_rid_source_per_row`,
+`test_dataset_hook_swallows_fetch_exception`,
+`test_workflow_hook_isolates_per_row_write_failures`,
+`test_dataset_hook_skips_rows_without_rid`,
+`test_dataset_hook_partitions_per_user`.
+Keep the serializer tests, `_row_source_name` test, `_write_row_chunk` test, all `_reindex_*` tests, all vocab tests, and the new `_index_rows_on_find` tests from Task 1.
+
+- [ ] **Step 7: Run the affected tests**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_plugin.py tests/test_rag.py -v`
+Expected: PASS. No reference to a deleted `_make_hook`/hook test remains.
+
+- [ ] **Step 8: Grep for stragglers**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && grep -rn "_make_hook\b" src tests`
+Expected: no matches (only `_make_vocab_hook` should exist, which won't match `_make_hook\b` followed by word boundary — verify the grep returns nothing for the bare `_make_hook`).
+
+- [ ] **Step 9: Lint + format + commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin
+uv run ruff check src tests && uv run ruff format src/deriva_ml_mcp_plugin/resources/rag.py tests/test_rag.py tests/test_plugin.py
+git add src/deriva_ml_mcp_plugin/resources/rag.py tests/test_rag.py tests/test_plugin.py
+git commit -m "refactor(rag): drop on-connect bulk row indexers (keep vocab hook)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add `dataset_type` filter to the dataset list path
+
+**Files:**
+- Modify: `src/deriva_ml_mcp_plugin/tools/dataset/read.py`
+- Test: `tests/test_dataset_read.py` (create if absent; otherwise add to the existing dataset-read test module)
+
+`DatasetSummary.dataset_types` is a **list** — the filter is a membership test, applied to the fetched rows before pagination.
+
+- [ ] **Step 1: Write the failing test**
+
+First confirm the test module name: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && ls tests | grep -i dataset`. Add to the dataset-read test file (use `tests/test_dataset_read.py`; create it with the standard imports if it does not exist). The test drives `_list_datasets_impl` with a fake `ml`:
+
+```python
+def test_list_datasets_impl_filters_by_dataset_type() -> None:
+    """``dataset_type=`` keeps only datasets whose type list contains it."""
+    from types import SimpleNamespace
+
+    from deriva_ml_mcp_plugin.tools.dataset.read import _list_datasets_impl
+
+    def _ds(rid, types):
+        return SimpleNamespace(
+            dataset_rid=rid,
+            description="d",
+            dataset_types=types,
+            current_version=None,
+        )
+
+    fake_ml = SimpleNamespace(
+        find_datasets=lambda deleted, sort: [
+            _ds("1-TRN", ["Training"]),
+            _ds("1-TST", ["Testing"]),
+            _ds("1-BTH", ["Training", "Validation"]),
+        ]
+    )
+
+    resp = _list_datasets_impl(
+        fake_ml, after_rid=None, limit=100, dataset_type="Training"
+    )
+    rids = [d.rid for d in resp.datasets]
+    assert rids == ["1-BTH", "1-TRN"]  # RID-ascending of the two Training matches
+
+
+def test_list_datasets_impl_dataset_type_none_returns_all() -> None:
+    """No filter -> unchanged behavior (all datasets)."""
+    from types import SimpleNamespace
+
+    from deriva_ml_mcp_plugin.tools.dataset.read import _list_datasets_impl
+
+    def _ds(rid, types):
+        return SimpleNamespace(
+            dataset_rid=rid, description="d", dataset_types=types, current_version=None
+        )
+
+    fake_ml = SimpleNamespace(
+        find_datasets=lambda deleted, sort: [_ds("1-A", ["Training"]), _ds("1-B", ["Testing"])]
+    )
+    resp = _list_datasets_impl(fake_ml, after_rid=None, limit=100, dataset_type=None)
+    assert {d.rid for d in resp.datasets} == {"1-A", "1-B"}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_dataset_read.py -k dataset_type -v`
+Expected: FAIL with `TypeError: _list_datasets_impl() got an unexpected keyword argument 'dataset_type'`.
+
+- [ ] **Step 3: Implement the filter**
+
+In `src/deriva_ml_mcp_plugin/tools/dataset/read.py`, add a `dataset_type` parameter to `_list_datasets_impl` and apply the membership filter to the fetched rows **before** `_paginate`:
+
+```python
+def _list_datasets_impl(
+    ml: Any,
+    *,
+    after_rid: str | None,
+    limit: int,
+    include_deleted: bool = False,
+    sort: bool = False,
+    dataset_type: str | None = None,
+) -> DatasetListResponse:
+```
+
+Add to the `Args:` docstring:
+
+```
+        dataset_type: Optional ``Dataset_Type`` vocabulary term. When
+            set, keep only datasets whose ``dataset_types`` list contains
+            this term (membership test, applied before pagination so
+            ``limit`` counts filtered rows). When ``None`` (default), no
+            type filtering.
+```
+
+In the body, after building `datasets` (the sorted/raw list) and before `_paginate(...)`, insert:
+
+```python
+    if dataset_type is not None:
+        datasets = [d for d in datasets if dataset_type in (d.dataset_types or [])]
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_dataset_read.py -k dataset_type -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Lint + format + commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin
+uv run ruff check src/deriva_ml_mcp_plugin/tools/dataset/read.py tests/test_dataset_read.py && uv run ruff format src/deriva_ml_mcp_plugin/tools/dataset/read.py tests/test_dataset_read.py
+git add src/deriva_ml_mcp_plugin/tools/dataset/read.py tests/test_dataset_read.py
+git commit -m "feat(dataset): client-side dataset_type filter in _list_datasets_impl
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Surface `dataset_type` on the `deriva_ml_list_datasets` tool
+
+**Files:**
+- Modify: `src/deriva_ml_mcp_plugin/tools/dataset/read.py`
+- Test: `tests/test_dataset_read.py`
+
+- [ ] **Step 1: Write the failing test**
+
+This test calls the registered tool through the capturing-MCP fixture. Match the existing fixture pattern in the dataset-read tests (look at how a sibling test obtains `capturing_mcp` / a `ctx`). The assertion: passing `dataset_type` forwards it into `_list_datasets_impl`.
+
+```python
+def test_list_datasets_tool_forwards_dataset_type(dataset_ctx, capturing_mcp, mock_ml) -> None:
+    """``deriva_ml_list_datasets(dataset_type=...)`` forwards the filter to the impl."""
+    from unittest.mock import patch
+
+    register(dataset_ctx)  # however the existing tests register; mirror them
+    seen = {}
+
+    real_impl = _list_datasets_impl
+
+    def spy(ml, **kwargs):
+        seen.update(kwargs)
+        # Return an empty page so the tool completes.
+        return DatasetListResponse(datasets=[], count=0, truncated=False, next_after_rid=None)
+
+    with patch("deriva_ml_mcp_plugin.tools.dataset.read._list_datasets_impl", side_effect=spy):
+        import asyncio
+
+        asyncio.run(
+            capturing_mcp.tools["deriva_ml_list_datasets"](
+                hostname="h", catalog_id="1", dataset_type="Training"
+            )
+        )
+    assert seen.get("dataset_type") == "Training"
+```
+
+> Note for the implementer: adapt `dataset_ctx`/`capturing_mcp`/`mock_ml`/`register` to the exact fixtures already used by the other tests in this file. If the file registers tools differently, copy that setup verbatim — do not invent a new harness.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_dataset_read.py -k forwards_dataset_type -v`
+Expected: FAIL — the tool rejects the unknown `dataset_type` kwarg (`TypeError`) or never forwards it.
+
+- [ ] **Step 3: Add the param to the tool**
+
+In `deriva_ml_list_datasets`, add `dataset_type: str | None = None` to the signature (after `sort`), document it in `Args:`, and forward it in the `_list_datasets_impl` call:
+
+```python
+                payload = await asyncio.to_thread(
+                    _list_datasets_impl,
+                    ml,
+                    after_rid=after_rid,
+                    limit=capped,
+                    include_deleted=include_deleted,
+                    sort=sort,
+                    dataset_type=dataset_type,
+                )
+```
+
+Add to the tool docstring `Args:`:
+
+```
+            dataset_type: Optional ``Dataset_Type`` term. When set, only
+                datasets tagged with this type are returned (structured
+                filter -- prefer this over fuzzy ``rag_search`` when the
+                user names a type). Combine with a later ``rag_search``
+                for "Training datasets matching <description text>".
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_dataset_read.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + format + commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin
+uv run ruff check src/deriva_ml_mcp_plugin/tools/dataset/read.py tests/test_dataset_read.py && uv run ruff format src/deriva_ml_mcp_plugin/tools/dataset/read.py tests/test_dataset_read.py
+git add src/deriva_ml_mcp_plugin/tools/dataset/read.py tests/test_dataset_read.py
+git commit -m "feat(dataset): expose dataset_type filter on deriva_ml_list_datasets
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Add `workflow_type` filter to the workflow list path + tool
+
+**Files:**
+- Modify: `src/deriva_ml_mcp_plugin/tools/workflow.py`
+- Test: `tests/test_workflow.py` (use the existing workflow test module)
+
+`WorkflowSummary.workflow_type` is also a **list** — same membership-test pattern as Task 3, done in one task for impl + tool since the workflow file holds both.
+
+- [ ] **Step 1: Write the failing tests**
+
+Confirm the module: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && ls tests | grep -i workflow`. Add:
+
+```python
+def test_list_workflows_impl_filters_by_workflow_type() -> None:
+    """``workflow_type=`` keeps only workflows whose type list contains it."""
+    from types import SimpleNamespace
+
+    from deriva_ml_mcp_plugin.tools.workflow import _list_workflows_impl
+
+    def _wf(rid, types):
+        return SimpleNamespace(
+            workflow_rid=rid, name="w", url="u", checksum="c", version="1",
+            workflow_type=types, description="d",
+        )
+
+    fake_ml = SimpleNamespace(
+        find_workflows=lambda sort: [
+            _wf("1-TRN", ["Model_Training"]),
+            _wf("1-INF", ["Inference"]),
+        ]
+    )
+    resp = _list_workflows_impl(
+        fake_ml, after_rid=None, limit=100, workflow_type="Model_Training"
+    )
+    assert [w.rid for w in resp.workflows] == ["1-TRN"]
+```
+
+> If `_summarize_workflow` calls `_resolve_workflow_rid(wf)` and that needs more than `workflow_rid` on the fake, set `workflow_rid` directly on the `SimpleNamespace` (as above) so the resolver's happy path returns it. If the resolver still fails on a bare namespace, patch `_resolve_workflow_rid` to return the row's `workflow_rid` for this test.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_workflow.py -k workflow_type -v`
+Expected: FAIL with `TypeError: _list_workflows_impl() got an unexpected keyword argument 'workflow_type'`.
+
+- [ ] **Step 3: Implement the impl filter**
+
+In `src/deriva_ml_mcp_plugin/tools/workflow.py`, add `workflow_type: str | None = None` to `_list_workflows_impl`, document it, and filter after the rows are fetched/sorted and before `_paginate`:
+
+```python
+    if workflow_type is not None:
+        workflows = [w for w in workflows if workflow_type in (w.workflow_type or [])]
+```
+
+(Use whatever the local variable holding the post-sort list is named — mirror the dataset impl. If the impl summarizes inside the paginate call, filter on the raw objects' `.workflow_type` before summarizing.)
+
+- [ ] **Step 4: Add the param to the tool**
+
+In `deriva_ml_list_workflows`, add `workflow_type: str | None = None` to the signature, document it in `Args:` (mirror the dataset wording — "structured filter, prefer over fuzzy rag_search"), and forward it into the `_list_workflows_impl` call.
+
+- [ ] **Step 5: Add the tool-forwarding test**
+
+Mirror Task 4 Step 1's spy test for `deriva_ml_list_workflows` + `workflow_type`, using the workflow test file's fixtures.
+
+- [ ] **Step 6: Run to verify all pass**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_workflow.py -k workflow_type -v`
+Expected: PASS.
+
+- [ ] **Step 7: Lint + format + commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin
+uv run ruff check src/deriva_ml_mcp_plugin/tools/workflow.py tests/test_workflow.py && uv run ruff format src/deriva_ml_mcp_plugin/tools/workflow.py tests/test_workflow.py
+git add src/deriva_ml_mcp_plugin/tools/workflow.py tests/test_workflow.py
+git commit -m "feat(workflow): client-side workflow_type filter on list path + tool
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Wire index-on-find into the dataset read tools
+
+**Files:**
+- Modify: `src/deriva_ml_mcp_plugin/tools/dataset/read.py`
+- Test: `tests/test_dataset_read.py`
+
+After `deriva_ml_list_datasets` builds `payload` and after `deriva_ml_get_dataset` builds its detail, schedule the read-through warm. Use the lazy-import idiom (avoid the rag↔tools cycle). The warm uses the rows already in `payload`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_list_datasets_tool_schedules_index_on_find(dataset_ctx, capturing_mcp, mock_ml) -> None:
+    """``deriva_ml_list_datasets`` warms the returned rows via _index_rows_on_find."""
+    from unittest.mock import patch
+
+    register(dataset_ctx)  # mirror existing registration
+    captured = {}
+
+    def fake_warm(hostname, catalog_id, token, rows, **kwargs):
+        captured["token"] = token
+        captured["rids"] = [r.get("rid") for r in rows]
+
+    with patch(
+        "deriva_ml_mcp_plugin.resources.rag._index_rows_on_find", side_effect=fake_warm
+    ):
+        import asyncio
+
+        # mock_ml.find_datasets should yield at least one dataset with a RID.
+        asyncio.run(
+            capturing_mcp.tools["deriva_ml_list_datasets"](hostname="h", catalog_id="1")
+        )
+
+    from deriva_ml_mcp_plugin.resources.rag import _DATASET_TOKEN
+
+    assert captured.get("token") == _DATASET_TOKEN
+    assert captured.get("rids")  # at least one RID warmed
+```
+
+> Adapt `mock_ml` so `find_datasets` returns datasets with RIDs (mirror what the existing list-datasets happy-path test uses). The warm receives **dicts** (`payload.datasets` model-dumped) — see Step 3 for how the tool produces them.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_dataset_read.py -k schedules_index_on_find -v`
+Expected: FAIL — `_index_rows_on_find` is never called (`captured` empty).
+
+- [ ] **Step 3: Call the warm in the list tool**
+
+In `deriva_ml_list_datasets`, after `payload` is built and **before** `return payload.model_dump_json(...)` (and only on the non-preflight path), add:
+
+```python
+                # Read-through indexing: warm the per-user RAG sources for
+                # the rows we just returned so a later rag_search finds
+                # them (newest-first). Fire-and-forget; never blocks or
+                # fails the read. Lazy import avoids the rag<->tools cycle.
+                try:
+                    from deriva_ml_mcp_plugin.resources.rag import (
+                        _DATASET_TOKEN,
+                        _index_rows_on_find,
+                    )
+
+                    _index_rows_on_find(
+                        hostname,
+                        catalog_id,
+                        _DATASET_TOKEN,
+                        [d.model_dump(mode="json") for d in payload.datasets],
+                    )
+                except Exception:  # noqa: BLE001 -- warm is best-effort
+                    logger.debug("index-on-find scheduling failed for list_datasets", exc_info=True)
+            return payload.model_dump_json(by_alias=True)
+```
+
+`dataset/read.py` does **not** define a module logger (verified). Add it once near the top of the file, after the imports:
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+(If `import logging` already exists, add only the `logger = ...` line. `workflow.py` already defines a module-level `logger`, so Task 7 needs no logger addition. `execution/read.py` does **not** have a module-level `logger` — Task 8 adds one, see its Step 3 note.)
+
+> `DatasetSummary` carries no `rct` field, so the newest-first sort falls back to "no rct → all equal → stable order." That is acceptable: the list is already returned RID-ascending (or RCT-desc when `sort=True`), and warm order within a single page is a minor optimization. The rct-based ordering matters most for the resync/bulk path; for a single page the in-hand order is fine. (No extra work — the helper tolerates missing `rct`.)
+
+- [ ] **Step 4: Wire the get tool**
+
+In `deriva_ml_get_dataset`, after the detail payload is built and before returning, add the same warm for the single row:
+
+```python
+                try:
+                    from deriva_ml_mcp_plugin.resources.rag import (
+                        _DATASET_TOKEN,
+                        _index_rows_on_find,
+                    )
+
+                    _index_rows_on_find(
+                        hostname, catalog_id, _DATASET_TOKEN, [{"rid": dataset_rid}]
+                    )
+                except Exception:  # noqa: BLE001 -- warm is best-effort
+                    logger.debug("index-on-find scheduling failed for get_dataset", exc_info=True)
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_dataset_read.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + format + commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin
+uv run ruff check src/deriva_ml_mcp_plugin/tools/dataset/read.py tests/test_dataset_read.py && uv run ruff format src/deriva_ml_mcp_plugin/tools/dataset/read.py tests/test_dataset_read.py
+git add src/deriva_ml_mcp_plugin/tools/dataset/read.py tests/test_dataset_read.py
+git commit -m "feat(dataset): index-on-find warm in list/get dataset tools
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Wire index-on-find into the workflow read tools
+
+**Files:**
+- Modify: `src/deriva_ml_mcp_plugin/tools/workflow.py`
+- Test: `tests/test_workflow.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Mirror Task 6 Step 1 for `deriva_ml_list_workflows`, asserting `_index_rows_on_find` is called with `_WORKFLOW_TOKEN` and the returned RIDs.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_workflow.py -k schedules_index_on_find -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Call the warm in `deriva_ml_list_workflows`**
+
+After `payload` is built, before returning:
+
+```python
+                try:
+                    from deriva_ml_mcp_plugin.resources.rag import (
+                        _WORKFLOW_TOKEN,
+                        _index_rows_on_find,
+                    )
+
+                    _index_rows_on_find(
+                        hostname,
+                        catalog_id,
+                        _WORKFLOW_TOKEN,
+                        [w.model_dump(mode="json") for w in payload.workflows],
+                    )
+                except Exception:  # noqa: BLE001 -- warm is best-effort
+                    logger.debug("index-on-find scheduling failed for list_workflows", exc_info=True)
+```
+
+- [ ] **Step 4: Wire the workflow get tool (if present)**
+
+Find the single-workflow read tool: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && grep -n "deriva_ml_get_workflow\|_get_workflow_impl" src/deriva_ml_mcp_plugin/tools/workflow.py`. If a `deriva_ml_get_workflow` tool exists, add the single-row warm (mirror Task 6 Step 4 with `_WORKFLOW_TOKEN` and `[{"rid": workflow_rid}]`). If no get-workflow tool exists, skip this step (note it in the commit).
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_workflow.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + format + commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin
+uv run ruff check src/deriva_ml_mcp_plugin/tools/workflow.py tests/test_workflow.py && uv run ruff format src/deriva_ml_mcp_plugin/tools/workflow.py tests/test_workflow.py
+git add src/deriva_ml_mcp_plugin/tools/workflow.py tests/test_workflow.py
+git commit -m "feat(workflow): index-on-find warm in list/get workflow tools
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Wire index-on-find into the execution read tools
+
+**Files:**
+- Modify: `src/deriva_ml_mcp_plugin/tools/execution/read.py`
+- Test: `tests/test_execution.py` (the existing execution test module)
+
+Note: `ExecutionSummary` carries **no** creation-timestamp field (its fields are `rid`, `workflow_rid`, etc. — verified in `_response_models.py`). So the warm cannot sort executions newest-first from the summary; it warms them in the page order the tool already returns (which is RCT-desc when the caller passes `sort=True`, RID-asc otherwise). Pass no `rct_key` override — the helper's missing-key fallback ("all equal → stable order") is exactly right here. Newest-first warm ordering is realized at the page level via `sort=True`, not inside the warm.
+
+- [ ] **Step 1: Write the failing test**
+
+Mirror Task 6 Step 1 for `deriva_ml_list_executions`, asserting `_index_rows_on_find` is called with `_EXECUTION_TOKEN` and the returned RIDs. Also add one for `deriva_ml_get_execution` asserting a single-row warm. Use the fixtures already in `tests/test_execution.py`.
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_execution.py -k schedules_index_on_find -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Call the warm in `deriva_ml_list_executions`**
+
+`execution/read.py` has no module-level `logger` (only a function-local `import logging` at ~line 648). Add a module logger near the top after the imports:
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+(If `import logging` is already at module scope, add only the `logger = ...` line.)
+
+Then, after `payload` is built, before returning:
+
+```python
+                try:
+                    from deriva_ml_mcp_plugin.resources.rag import (
+                        _EXECUTION_TOKEN,
+                        _index_rows_on_find,
+                    )
+
+                    _index_rows_on_find(
+                        hostname,
+                        catalog_id,
+                        _EXECUTION_TOKEN,
+                        [e.model_dump(mode="json") for e in payload.executions],
+                        # No rct_key: ExecutionSummary has no timestamp field;
+                        # warm in the tool's returned page order.
+                    )
+                except Exception:  # noqa: BLE001 -- warm is best-effort
+                    logger.debug("index-on-find scheduling failed for list_executions", exc_info=True)
+```
+
+- [ ] **Step 4: Call the warm in `deriva_ml_get_execution`**
+
+After the single execution is fetched/summarized, before returning, add the single-row warm (`[{"rid": execution_rid}]`, `_EXECUTION_TOKEN`).
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_execution.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + format + commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin
+uv run ruff check src/deriva_ml_mcp_plugin/tools/execution/read.py tests/test_execution.py && uv run ruff format src/deriva_ml_mcp_plugin/tools/execution/read.py tests/test_execution.py
+git add src/deriva_ml_mcp_plugin/tools/execution/read.py tests/test_execution.py
+git commit -m "feat(execution): index-on-find warm in list/get execution tools
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Full suite + lint gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest -q`
+Expected: all pass. If anything in `test_integration*.py` asserts that a Dataset/Workflow/Execution row is a `rag_search` hit *purely from on-connect bulk indexing*, update it to first call the corresponding `deriva_ml_list_*` tool (which now warms the index) before asserting the search hit — this matches the read-through model. Do NOT weaken assertions that exercise the kept `deriva_ml_resync_indexes` path.
+
+- [ ] **Step 2: Lint + format the whole tree**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run ruff check src tests && uv run ruff format --check src tests`
+Expected: clean. Fix any residue and re-run.
+
+- [ ] **Step 3: Grep for dangling references to removed wiring**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && grep -rn "four_catalog_connect\|four catalog-connect\|_catalog_connect_hooks\[3\]\|_make_hook\b" src tests docs`
+Expected: no matches except intentional history in the design spec. Fix any stragglers in code/tests.
+
+- [ ] **Step 4: Commit any cleanup**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin
+git add -A
+git commit -m "test: align integration tests with read-through indexing
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" || echo "nothing to commit"
+```
+
+---
+
+## Task 10: Update CLAUDE.md + module docs to describe read-through indexing
+
+**Files:**
+- Modify: `src/deriva_ml_mcp_plugin/resources/rag.py` (module docstring — if not already fully updated in Task 2)
+- Modify: `CLAUDE.md` (repo root — the RAG/indexing description, if present)
+
+- [ ] **Step 1: Check CLAUDE.md for indexing claims**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && grep -n "on_catalog_connect\|on connect\|bulk\|per-user\|index\|rag" CLAUDE.md`
+Identify any sentence stating the plugin bulk-indexes Dataset/Workflow/Execution rows on connect.
+
+- [ ] **Step 2: Update the wording**
+
+Edit those sentences to state: schema (core) + vocabulary index on connect; Dataset/Workflow/Execution rows index **read-through** (on create/mutate and on list/get/find), warmed newest-first; `deriva_ml_resync_indexes` remains the manual warm-everything button. Keep it to a few sentences — match CLAUDE.md's existing density.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin
+git add CLAUDE.md src/deriva_ml_mcp_plugin/resources/rag.py
+git commit -m "docs: describe read-through RAG indexing model
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Follow-on (separate repo, NOT part of this plan)
+
+`deriva-skills` — update `skills/semantic-awareness/SKILL.md` and `references/find-before-you-create.md` to (1) route structured finds (type/status/RID/URL) to deterministic `find_*`/`list_*` instead of `rag_search`; (2) describe the warm-before-rank ordering (list/find warms the index, then `rag_search` ranks); (3) note vocab terms are always warm while data rows warm on first browse; (4) route workflow dedup to `find_workflow_by_url`. Tracked as its own change in the `deriva-skills` repo.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** drop bulk hooks (Task 2 ✓), keep vocab on connect (untouched ✓), index-on-find helper + newest-first (Task 1 ✓), wire list+get for all three entities (Tasks 6/7/8 ✓), `dataset_type`/`workflow_type` filters (Tasks 3/4/5 ✓), keep `deriva_ml_resync_indexes` + machinery (Task 2 keeps `_fetch_*_rows`/`_resync_*` ✓), keep serializers/`_reindex_*` (Task 2 ✓), docs (Task 10 ✓), skill follow-on flagged out-of-scope ✓.
+- **Type consistency:** `_index_rows_on_find(hostname, catalog_id, table_token, rows, *, rct_key)` used identically in Tasks 1/6/7/8; token constants `_DATASET_TOKEN`/`_WORKFLOW_TOKEN`/`_EXECUTION_TOKEN` referenced consistently; `_REINDEX_BY_TOKEN` maps them to the existing `_reindex_*` coroutines.
+- **Known adaptation points (flagged inline, not placeholders):** exact test-fixture names (`dataset_ctx`/`capturing_mcp`/`mock_ml`) and the execution summary's RCT field name must be read from the existing test files / source at implementation time — each such step says so explicitly and gives the grep to find it.

--- a/docs/superpowers/plans/2026-06-04-read-through-rag-indexing.md
+++ b/docs/superpowers/plans/2026-06-04-read-through-rag-indexing.md
@@ -4,7 +4,7 @@
 
 **Goal:** Cut per-connection RAG startup overhead by replacing the three per-user bulk on-connect indexers (Dataset/Workflow/Execution) with read-through (index-on-find) indexing, while keeping vocabulary always-indexed on connect.
 
-**Architecture:** Remove only the `_make_hook` on-connect bulk-pass wiring. Add a fire-and-forget "index-on-find" helper that the dataset/workflow/execution list+get tools call after building their response, warming each returned row's per-user RAG source newest-first. Add client-side `dataset_type`/`workflow_type` filters to the dataset/workflow list helpers for a consistent structured-filter surface. The existing surgical `_reindex_*` writers, the `deriva_ml_resync_indexes` warm-button, and all vocabulary machinery stay.
+**Architecture:** Remove only the `_make_hook` on-connect bulk-pass wiring. Add a fire-and-forget "index-on-find" helper that the dataset/workflow/execution list+get tools call after building their response, warming each returned row's per-user RAG source (in the order the read returned them — see the post-Task-6 simplification that dropped the inert newest-first sort). Add client-side `dataset_type`/`workflow_type` filters to the dataset/workflow list helpers for a consistent structured-filter surface. The existing surgical `_reindex_*` writers, the `deriva_ml_resync_indexes` warm-button, and all vocabulary machinery stay.
 
 **Tech Stack:** Python 3 / asyncio, deriva-ml, deriva-mcp-core plugin API, Pydantic response models, pytest, `uv` for all tooling.
 
@@ -803,7 +803,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 - Modify: `src/deriva_ml_mcp_plugin/tools/execution/read.py`
 - Test: `tests/test_execution.py` (the existing execution test module)
 
-Note: `ExecutionSummary` carries **no** creation-timestamp field (its fields are `rid`, `workflow_rid`, etc. — verified in `_response_models.py`). So the warm cannot sort executions newest-first from the summary; it warms them in the page order the tool already returns (which is RCT-desc when the caller passes `sort=True`, RID-asc otherwise). Pass no `rct_key` override — the helper's missing-key fallback ("all equal → stable order") is exactly right here. Newest-first warm ordering is realized at the page level via `sort=True`, not inside the warm.
+Note: the warm indexes rows in the order the read returned them (the `_index_rows_on_find` helper does NOT re-sort — the newest-first heuristic was dropped after Task 6 review as inert dead plumbing). So executions warm in whatever order the tool returned (RCT-desc when the caller passes `sort=True`, RID-asc otherwise). The call passes no ordering argument — just `(hostname, catalog_id, _EXECUTION_TOKEN, rows)`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -838,8 +838,6 @@ Then, after `payload` is built, before returning:
                         catalog_id,
                         _EXECUTION_TOKEN,
                         [e.model_dump(mode="json") for e in payload.executions],
-                        # No rct_key: ExecutionSummary has no timestamp field;
-                        # warm in the tool's returned page order.
                     )
                 except Exception:  # noqa: BLE001 -- warm is best-effort
                     logger.debug("index-on-find scheduling failed for list_executions", exc_info=True)
@@ -898,10 +896,12 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" || echo "n
 
 ---
 
-## Task 10: Update CLAUDE.md + module docs to describe read-through indexing
+## Task 10: Update CLAUDE.md + module docs + user-facing prompt to describe read-through indexing
 
 **Files:**
 - Modify: `src/deriva_ml_mcp_plugin/resources/rag.py` (module docstring — if not already fully updated in Task 2)
+- Modify: `src/deriva_ml_mcp_plugin/plugin.py` (the `register` docstring around line 42 — describes the on_catalog_connect hooks)
+- Modify: `src/deriva_ml_mcp_plugin/prompts.py` (the RAG/indexing description around lines 974-983 — **user-visible**, ships to the LLM)
 - Modify: `CLAUDE.md` (repo root — the RAG/indexing description, if present)
 
 - [ ] **Step 1: Check CLAUDE.md for indexing claims**
@@ -909,15 +909,30 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" || echo "n
 Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && grep -n "on_catalog_connect\|on connect\|bulk\|per-user\|index\|rag" CLAUDE.md`
 Identify any sentence stating the plugin bulk-indexes Dataset/Workflow/Execution rows on connect.
 
-- [ ] **Step 2: Update the wording**
+- [ ] **Step 2: Update CLAUDE.md wording**
 
 Edit those sentences to state: schema (core) + vocabulary index on connect; Dataset/Workflow/Execution rows index **read-through** (on create/mutate and on list/get/find), warmed newest-first; `deriva_ml_resync_indexes` remains the manual warm-everything button. Keep it to a few sentences — match CLAUDE.md's existing density.
+
+- [ ] **Step 3: Fix the stale `plugin.py` register docstring**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && grep -n "on_catalog_connect\|first connect\|first-connect\|three.*hook\|Dataset, Workflow" src/deriva_ml_mcp_plugin/plugin.py`
+Around line 42 the `register` docstring says something like "three on_catalog_connect hooks for Dataset, Workflow, and Execution rows." Update it to: one vocab on_catalog_connect hook; Dataset/Workflow/Execution rows are indexed read-through (on list/get/find via `_index_rows_on_find` + surgically on create/mutate via `_reindex_*`), not on connect.
+
+- [ ] **Step 4: Fix the stale, user-visible `prompts.py` RAG description**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && grep -n "first connect\|first-connect\|on connect\|Fresh on\|surgically refreshed\|RAG\|rag_search\|indexed" src/deriva_ml_mcp_plugin/prompts.py`
+Around lines 974-983 the prompt text describes Workflows/datasets/executions as "Fresh on first connect AND surgically refreshed…" and an execution-creation note pointing to "next first-connect." This text SHIPS TO THE LLM, so it must be accurate. Update it to describe read-through indexing: these rows become rag_search-able once they've been listed/fetched (which warms the index) or surgically on create/mutate; `deriva_ml_resync_indexes` warms everything on demand. Do NOT describe an on-connect bulk pass. Keep the wording concise and in the prompt's existing voice.
+
+- [ ] **Step 5: Verify no stale first-connect/bulk claims remain**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && grep -rn "first connect\|first-connect\|bulk path\|bulk index\|on_catalog_connect.*Dataset\|three.*on_catalog_connect" src/deriva_ml_mcp_plugin`
+Expected: no remaining claim that Dataset/Workflow/Execution rows are bulk-indexed on connect. (The vocab hook IS on connect — that's correct and may still be described as such.)
 
 - [ ] **Step 3: Commit**
 
 ```bash
 cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin
-git add CLAUDE.md src/deriva_ml_mcp_plugin/resources/rag.py
+git add CLAUDE.md src/deriva_ml_mcp_plugin/resources/rag.py src/deriva_ml_mcp_plugin/plugin.py src/deriva_ml_mcp_plugin/prompts.py
 git commit -m "docs: describe read-through RAG indexing model
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
@@ -933,6 +948,6 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 ## Self-Review Notes
 
-- **Spec coverage:** drop bulk hooks (Task 2 ✓), keep vocab on connect (untouched ✓), index-on-find helper + newest-first (Task 1 ✓), wire list+get for all three entities (Tasks 6/7/8 ✓), `dataset_type`/`workflow_type` filters (Tasks 3/4/5 ✓), keep `deriva_ml_resync_indexes` + machinery (Task 2 keeps `_fetch_*_rows`/`_resync_*` ✓), keep serializers/`_reindex_*` (Task 2 ✓), docs (Task 10 ✓), skill follow-on flagged out-of-scope ✓.
-- **Type consistency:** `_index_rows_on_find(hostname, catalog_id, table_token, rows, *, rct_key)` used identically in Tasks 1/6/7/8; token constants `_DATASET_TOKEN`/`_WORKFLOW_TOKEN`/`_EXECUTION_TOKEN` referenced consistently; `_REINDEX_BY_TOKEN` maps them to the existing `_reindex_*` coroutines.
+- **Spec coverage:** drop bulk hooks (Task 2 ✓), keep vocab on connect (untouched ✓), index-on-find helper (Task 1 ✓; the newest-first sort was added then removed as inert — warm follows the read's returned order), wire list+get for all three entities (Tasks 6/7/8 ✓), `dataset_type`/`workflow_type` filters (Tasks 3/4/5 ✓), keep `deriva_ml_resync_indexes` + machinery (Task 2 keeps `_fetch_*_rows`/`_resync_*` ✓), keep serializers/`_reindex_*` (Task 2 ✓), docs (Task 10 ✓), skill follow-on flagged out-of-scope ✓.
+- **Type consistency:** `_index_rows_on_find(hostname, catalog_id, table_token, rows)` used identically in Tasks 1/6/7/8 (no `rct_key` — dropped post-Task-6); token constants `_DATASET_TOKEN`/`_WORKFLOW_TOKEN`/`_EXECUTION_TOKEN` referenced consistently; `_REINDEX_BY_TOKEN` maps them to the existing `_reindex_*` coroutines.
 - **Known adaptation points (flagged inline, not placeholders):** exact test-fixture names (`dataset_ctx`/`capturing_mcp`/`mock_ml`) and the execution summary's RCT field name must be read from the existing test files / source at implementation time — each such step says so explicitly and gives the grep to find it.

--- a/docs/superpowers/specs/2026-06-04-drop-per-user-row-indexing-design.md
+++ b/docs/superpowers/specs/2026-06-04-drop-per-user-row-indexing-design.md
@@ -1,0 +1,286 @@
+# Read-through RAG indexing: cut connect-time bulk passes
+
+**Date:** 2026-06-04
+**Repo:** `deriva-ml-mcp-plugin`
+**Status:** Approved (design)
+
+## Problem
+
+Catalog connect has too much startup overhead. On every first connect
+per (user, catalog), `register_rag_sources`
+([resources/rag.py](../../../src/deriva_ml_mcp_plugin/resources/rag.py))
+runs **three per-user bulk indexers** — Dataset, Workflow, Execution —
+each of which fetches up to `_MAX_LIMIT` rows under the caller's
+credential and embeds every row into the vector store. That fetch+embed
+work is the dominant connect-time cost.
+
+Two goals must survive the fix:
+
+1. **Avoid duplicate creation** of datasets, vocabulary terms,
+   workflows, and executions — the `semantic-awareness`
+   find-before-you-create guardrail, which runs `rag_search` *before* a
+   create.
+2. **Find by description** — datasets, workflows, executions, tables
+   must be discoverable from free-text, not just exact metadata.
+
+The naive fix (delete the data-row indexers) breaks both goals for
+workflows and executions. The constraint is real: anything fuzzy-
+searchable by `rag_search` must be in the index, but bulk-indexing it on
+connect is what costs.
+
+## Decision
+
+Replace **connect-time bulk indexing** with **read-through (index-on-
+find) indexing**, and keep vocabulary always-indexed on connect.
+
+- **Schema** — already indexed by `deriva-mcp-core` on connect
+  (`schema:` prefix, catalog-public, TTL-gated). Untouched; free.
+- **Vocabulary** — stays bulk-indexed on connect via this plugin's
+  existing vocab hook (`vocab:` prefix, catalog-public, cheap). This is
+  "vocabulary is always indexed": the term-dedup guardrail is never
+  cold.
+- **Dataset / Workflow / Execution** — **no bulk pass on connect.**
+  Instead each row is indexed (per-user, `data:` prefix) at two moments:
+  - **on create / mutate** — via the existing surgical `_reindex_*`
+    helpers already wired into the mutation tools (unchanged); and
+  - **on find / list / get** — NEW: the shared read path indexes each
+    row it returns, fire-and-forget, so reads warm the index.
+
+The index-on-find hook lands at the **`_list_*_impl` / `_get_*_impl`
+layer** (`tools/dataset/read.py`, `tools/workflow.py`,
+`tools/execution/read.py`). Both the `deriva_ml_*` MCP tools and the
+`deriva://.../deriva-ml/...` resources call through these impls
+([resources/ml.py:82-90](../../../src/deriva_ml_mcp_plugin/resources/ml.py)),
+so hooking the impl layer gives auto-indexing to tools and resources
+with one implementation per entity.
+
+### Why this satisfies every goal
+
+- **Startup:** connect does schema (core) + vocab only. The three
+  per-user bulk fetch+embed passes are gone. This is the win.
+- **Find by description (incl. workflows + executions):** all three
+  entity types remain in `catalog-data` RAG, so `rag_search` ranks them
+  by free-text exactly as today. The index is populated by the reads a
+  session already performs (a `list`/`get`/resource-fetch warms the rows
+  before any `rag_search` would want them).
+- **Dedup guardrail:** intact for all four entity types — vocab terms
+  (always on connect) plus datasets/workflows/executions (warmed by the
+  list/find that `semantic-awareness` already does as step 1). Workflows
+  additionally retain the deterministic `find_workflow_by_url`.
+- **Cold-start gap closes naturally:** pre-existing rows enter a user's
+  index the first time that user lists/browses them — no separate
+  warm-up step, no bulk connect cost.
+
+## Mechanism details
+
+### Index-on-find hook
+
+A small helper in `resources/rag.py`, e.g.
+`_index_rows_background(hostname, catalog_id, table_token, rows,
+serializer)`, that:
+
+- resolves the user identity once,
+- for each row, schedules `_write_row_chunk` under the per-RID `data:`
+  source name,
+- runs as a fire-and-forget background task (`asyncio.create_task` or
+  equivalent) so it **never blocks or fails the read's response**,
+- swallows all errors (best-effort, logged at debug), mirroring the
+  existing `_reindex_*` contract.
+
+Each `_list_*_impl` / `_get_*_impl`, after building its summary rows,
+calls this helper with the rows it is already returning. No extra
+catalog fetch — it reuses the rows in hand.
+
+Idempotency: `_write_row_chunk` already does `delete_source` +
+`add`, so re-indexing an unchanged row is a cheap no-op-equivalent.
+Re-warming the same rows on every list is acceptable; if profiling shows
+it matters, add a short per-process (host,cat,user,rid) seen-set to skip
+recently-indexed RIDs — deferred until measured.
+
+### Newest-first background warm order
+
+The index fills incrementally in the background: `store.add` offloads
+the ONNX embedding via `asyncio.to_thread`
+([core store.py](../../../../deriva-mcp-core/src/deriva_mcp_core/rag/store.py))
+and the writer adds in batches, so each row becomes `rag_search`-able as
+soon as *its* write lands — not after the whole set finishes. Because
+the warm is a stream of per-row writes, **feed order decides what
+becomes searchable first.**
+
+The index-on-find path therefore warms **newest-first** (record-creation
+time descending). `_list_executions_impl` already exposes this via its
+`sort=True` mode (forwards to `find_executions(sort=True)`); the
+dataset/workflow impls get the equivalent. Rationale: find-before-create
+and "find that recent run" queries target recent entities, so newest-
+first makes the most-likely-queried rows searchable within the first
+batch while the older backlog trickles in behind.
+
+Decoupling rule: the read tool's **returned page** keeps its caller-
+requested order and cursor-pagination semantics (default `sort=False`,
+RID-ascending — the stable-cursor contract). The **background index
+write** sorts newest-first independently of what the caller sees. The
+two never interfere: the user's list output is byte-identical to today;
+only the embed order changes.
+
+### What is removed
+
+`resources/rag.py`:
+- The three `ctx.on_catalog_connect(_make_hook(...))` registrations for
+  Dataset / Workflow / Execution.
+- The `_make_hook` **bulk-pass factory** (the on-connect bulk indexer).
+  This is the only thing whose removal is the actual startup win.
+
+Note the `_fetch_*_rows` fetchers are **NOT** removed — they are still
+used by the kept `deriva_ml_resync_indexes` path (`_resync_one_table`
+enumerates a table via its `_fetch_*_rows` fetcher). Only the
+`_make_hook` on-connect wiring goes.
+
+`tools/maintenance.py`:
+- (nothing removed) — `deriva_ml_resync_indexes` is **kept** as an
+  explicit "warm all of my datasets/workflows/executions for this
+  catalog now" button. Index-on-find makes it non-essential for steady-
+  state use, but it stays as the deterministic operator warm-up after a
+  restart (and as the manual bridge for `add_term`-style mutations that
+  fire no lifecycle hook). Its `_resync_user_sources` /
+  `_resync_one_table` machinery in `rag.py` therefore also **stays**.
+
+### What stays (unchanged)
+
+- The surgical `_reindex_dataset/workflow/execution`,
+  `_delete_dataset_source`, `_row_source_name`, `_write_row_chunk`,
+  and the per-table serializers (`_DatasetSerializer`,
+  `_WorkflowSerializer`, `_ExecutionSerializer`) — now the *primary*
+  index writers, reused by both the create/mutate path and the new
+  index-on-find path.
+- The mutation-tool reindex call sites in `tools/dataset/mutate.py`
+  (×5) and `tools/workflow.py` (×2).
+- All vocab machinery + `deriva_ml_reindex_vocabularies` + both
+  `rag_github_source` declarations.
+- Core's schema indexing.
+
+## Retrieval modes: structured vs. fuzzy vs. hybrid
+
+A "find" specified by structured attributes (type, status, RID, URL)
+does **not** need the fuzzy index — the catalog answers it
+deterministically. RAG is only for the free-text/description residue.
+The skill routes by query shape:
+
+1. **Structured** — "find Training datasets", "Failed executions",
+   "the workflow at this URL". → deterministic `find_*` / `list_*` with
+   a type/status/RID/URL filter. Exact; no embedding consulted. (Also
+   warms the index newest-first as a side effect — see index-on-find.)
+2. **Free-text** — "the run about retinopathy screening". → `rag_search`
+   for fuzzy ranking over the indexed description/name.
+3. **Hybrid** — "all Training datasets matching <description text>". →
+   structured filter narrows the candidate set, then fuzzy ranks within
+   it. First-class mode: the structured filter MUST exist for the
+   narrow-then-rank flow to work.
+
+We still index all three entity types (so free-text and the fuzzy half
+of hybrid work); routing just avoids paying for fuzzy when the query is
+fully structured.
+
+### Consistency fix: type filters on datasets and workflows (required)
+
+Type-based lookup ("find Training datasets") will be common, and the
+hybrid mode depends on a structured type filter existing. Today the
+library is uneven:
+
+- `find_executions(workflow_type=, status=, workflow_rid=, dataset=)` —
+  structured filters already exist; executions read path exposes them.
+- `find_datasets(deleted=, sort=)` — **no `dataset_type` filter.**
+- `find_workflows(sort=)` — **no `workflow_type` filter.**
+
+Add **client-side** type filtering to the plugin read helpers (no
+library change needed):
+
+- `_list_datasets_impl(..., dataset_type: str | None = None)` — filter
+  the rows `find_datasets()` already returns. `DatasetSummary` already
+  carries `dataset_types` (a **list** — a dataset may have several), so
+  the filter is a **membership test** (`dataset_type in
+  row.dataset_types`), done in-memory before pagination. No extra
+  catalog fetch.
+- `_list_workflows_impl(..., workflow_type: str | None = None)` —
+  same pattern; `WorkflowSummary.workflow_type` is likewise a **list**,
+  so the filter is the same membership test (`workflow_type in
+  row.workflow_type`).
+
+Surface the new param on the corresponding `deriva_ml_list_datasets` /
+`deriva_ml_list_workflows` tools (and the list resources). This gives
+all three ML entities a **consistent** structured-filter surface and
+makes mode 1 + mode 3 real for datasets and workflows, not just
+executions.
+
+(If the deriva-ml library later grows native `dataset_type` /
+`workflow_type` filter params, the impls switch to forwarding them and
+drop the client-side pass — but that is a separate, optional follow-on,
+not a blocker here.)
+
+## Skill / prompt alignment (deriva-skills, separate repo)
+
+`semantic-awareness` (and `references/find-before-you-create.md`)
+currently states the RAG index "covers schema, vocabulary terms, and
+data" and reaches for `rag_search` as step 1. Two refinements under this
+design:
+
+1. **Route by query shape (structured / fuzzy / hybrid).** When the
+   find is fully specified by a type/status/RID/URL, use the
+   deterministic `find_*` / `list_*` filter — do not `rag_search`. Use
+   `rag_search` for free-text description matching, and for the hybrid
+   case (`find Training datasets matching <text>`) apply the structured
+   type filter first, then rank the narrowed set with `rag_search`.
+2. **Warm-before-rank ordering.** The structured `list`/`find` step also
+   warms the per-user index (index-on-find), so doing it first means the
+   subsequent `rag_search` sees freshly-indexed rows. Vocab terms are
+   always warm (on-connect); data rows warm on first browse. Workflow
+   dedup additionally routes to the content-addressed
+   `find_workflow_by_url`.
+
+(Tracked as a follow-on change to
+`deriva-skills`; out of scope for the plugin code change but required
+for end-to-end correctness.)
+
+## Test impact
+
+- `test_rag.py` — drop the three bulk-hook tests (`test_*_hook_writes_
+  one_per_rid_source_per_row`, fetch-exception, per-user-partition bulk
+  tests) and the `_fetch_*_rows` tests. Keep the serializer tests, the
+  per-RID source-naming test, the `_reindex_*` tests, and all vocab
+  tests. Add tests for the new index-on-find helper (fires per row,
+  fire-and-forget, swallows errors, never raises into the read).
+- `test_plugin.py` —
+  `test_register_wires_four_catalog_connect_hooks` → one-hook assertion
+  (vocab only); drop `test_data_sources_use_per_rid_naming` (no bulk
+  hooks); keep `test_vocab_hook_writes_to_vocab_prefix_not_data_prefix`
+  (adjust hook index `[3]` → `[0]`); keep
+  `test_register_does_not_use_rag_dataset_indexer`.
+- `test_maintenance.py` — unchanged: both `deriva_ml_resync_indexes`
+  and `deriva_ml_reindex_vocabularies` tests stay (resync is kept).
+- Add: read-tool tests asserting that `deriva_ml_list_datasets` /
+  `list_workflows` / `list_executions` / `get_execution` schedule the
+  index-on-find write for each returned row (and that a write failure
+  does not affect the tool's returned payload).
+- `test_dataset_mutate.py` / workflow mutate tests — unchanged (the
+  create/mutate reindex path stays).
+- Add: type-filter tests for `_list_datasets_impl(dataset_type=...)` and
+  `_list_workflows_impl(workflow_type=...)` — membership match against
+  the list-valued type field, no match → empty page, `None` → unchanged
+  behavior, and the filter runs before pagination (so `limit` applies to
+  the filtered set, not the pre-filter set).
+
+## Resolved decisions
+
+- **Newest-first background warm order** — yes, the default (no config
+  knob).
+- **`deriva_ml_resync_indexes`** — **kept** as the explicit "warm
+  everything now" operator button; the resync machinery stays.
+- **deriva-skills `semantic-awareness` update** — accepted as a separate
+  follow-on change in that repo.
+
+## Out of scope
+
+- eye-ai-deriva-mcp-plugin (clinical-row indexer already empty/opt-in).
+- The vocabulary indexing mechanism (preserved verbatim).
+- deriva-mcp-core / framework changes.
+- The deriva-skills doc change is required for correctness but is a
+  separate repo + separate change.

--- a/docs/superpowers/specs/2026-06-04-drop-per-user-row-indexing-design.md
+++ b/docs/superpowers/specs/2026-06-04-drop-per-user-row-indexing-design.md
@@ -97,30 +97,34 @@ Re-warming the same rows on every list is acceptable; if profiling shows
 it matters, add a short per-process (host,cat,user,rid) seen-set to skip
 recently-indexed RIDs — deferred until measured.
 
-### Newest-first background warm order
+### Background warm order: follow the read, don't re-sort
 
 The index fills incrementally in the background: `store.add` offloads
 the ONNX embedding via `asyncio.to_thread`
 ([core store.py](../../../../deriva-mcp-core/src/deriva_mcp_core/rag/store.py))
 and the writer adds in batches, so each row becomes `rag_search`-able as
-soon as *its* write lands — not after the whole set finishes. Because
-the warm is a stream of per-row writes, **feed order decides what
-becomes searchable first.**
+soon as *its* write lands — not after the whole set finishes.
 
-The index-on-find path therefore warms **newest-first** (record-creation
-time descending). `_list_executions_impl` already exposes this via its
-`sort=True` mode (forwards to `find_executions(sort=True)`); the
-dataset/workflow impls get the equivalent. Rationale: find-before-create
-and "find that recent run" queries target recent entities, so newest-
-first makes the most-likely-queried rows searchable within the first
-batch while the older backlog trickles in behind.
+The warm indexes rows **in the order the read returned them** — it does
+NOT impose its own sort. An earlier draft of this design had the warm
+re-sort newest-first (record-creation descending) as a heuristic to make
+recently-created rows searchable first during the brief request/index
+overlap window. That heuristic is **dropped**: (1) "most recent = most
+relevant" is false for the dominant use case (find-before-create matches
+*semantic similarity*, where row age is irrelevant); (2) a single list
+page warms in seconds, so the ordering only affects which rows are
+searchable in the first second vs. the next few — a narrow, low-value
+window; and (3) no summary model carries a record-creation timestamp, so
+the sort was inert anyway. Removing it deletes dead plumbing (`rct_key`)
+rather than adding a wire-shape field to honor a questionable heuristic.
 
-Decoupling rule: the read tool's **returned page** keeps its caller-
-requested order and cursor-pagination semantics (default `sort=False`,
-RID-ascending — the stable-cursor contract). The **background index
-write** sorts newest-first independently of what the caller sees. The
-two never interfere: the user's list output is byte-identical to today;
-only the embed order changes.
+If a caller genuinely wants recent-first overlap, the read already
+supports it: `deriva_ml_list_*` exposes `sort=True` (RCT-descending page
+order), and the warm follows whatever order the page came in. So the
+recency preference lives at the call site, where the user's intent
+actually is — not hardcoded in the indexer. The read's default order
+(RID-ascending, the stable-cursor contract) is unchanged; the warm
+simply mirrors the returned page.
 
 ### What is removed
 

--- a/src/deriva_ml_mcp_plugin/_response_models.py
+++ b/src/deriva_ml_mcp_plugin/_response_models.py
@@ -1447,5 +1447,3 @@ class AddDatasetElementTypeResponse(BaseModel):
 # docs/superpowers/notes/2026-05-23-cache-denormalize-deprecation-design.md).
 # Bag materialization is now a user-local Python operation; the
 # response models are no longer needed.
-
-

--- a/src/deriva_ml_mcp_plugin/plugin.py
+++ b/src/deriva_ml_mcp_plugin/plugin.py
@@ -39,19 +39,27 @@ def register(ctx: PluginContext) -> None:
 
     Phase 5 ships dataset, feature, workflow, and execution domain tools.
     Phase 6 added MCP resources and per-user RAG indexing (one GitHub
-    docs source plus three on_catalog_connect hooks for Dataset,
-    Workflow, and Execution rows). v1.0 polish added 3 MCP prompts
+    docs source plus per-user-per-RID writers for Dataset, Workflow,
+    and Execution rows). v1.0 polish added 3 MCP prompts
     (``deriva_ml_getting_started``, ``deriva_ml_execution_lifecycle``,
     ``deriva_ml_workflow_dedup``) so an LLM connecting cold has an
     anchor for the ML domain.
 
-    v1.1 added vocabulary RAG indexing: a fourth on_catalog_connect
-    hook bulk-indexes all discovered vocabulary tables under a
+    v1.1 added vocabulary RAG indexing: an ``on_catalog_connect`` hook
+    bulk-indexes all discovered vocabulary tables under a
     catalog-public ``vocab:`` source, and a one-tool vocabulary domain
     (``deriva_ml_reindex_vocabularies``) lets callers force a refresh
     after using core's ``add_term`` / ``delete_term`` (which don't
     fire any framework lifecycle hook -- tracked upstream as
     deriva-mcp-core#3).
+
+    v1.5 dropped the on-connect bulk pass for Dataset / Workflow /
+    Execution rows: the vocab hook is now the ONLY
+    ``on_catalog_connect`` hook registered. Those rows are indexed
+    read-through instead -- warmed on list/get/find via
+    ``_index_rows_on_find`` and surgically on create/mutate via
+    ``_reindex_*`` (see ``resources/rag.py``), with
+    ``deriva_ml_resync_indexes`` as the manual warm-everything button.
 
     v1.2 added the asset domain (catalog-state operations -- file
     I/O lives in the deriva-skills ``work-with-assets`` skill) plus

--- a/src/deriva_ml_mcp_plugin/prompts.py
+++ b/src/deriva_ml_mcp_plugin/prompts.py
@@ -972,23 +972,25 @@ The picker pattern works for these categories. Freshness varies:
     exists in many tables and need to ask which one.
 
   Workflows, datasets, executions
-    Indexed by this plugin per-user-per-RID. Fresh on first
-    connect AND surgically refreshed on every mutation: each
+    Indexed by this plugin per-user-per-RID, read-through (NOT
+    bulk-indexed on connect). A row becomes rag_search-able once
+    you've listed or fetched it -- each deriva_ml_list_* /
+    deriva_ml_get_* tool warms the index for the rows it just
+    returned -- AND it's surgically refreshed on mutation: each
     deriva_ml_create_* / deriva_ml_update_* / deriva_ml_delete_*
     MCP tool refreshes just the affected source(s) before
     returning. Note that EXECUTION row creation/mutation does NOT
     happen through MCP (executions originate in user-local Python
     per the stateless rule) -- newly-created execution rows
-    surface into RAG via the cross-user refresh path (next
-    first-connect) or via an explicit
+    surface into RAG once you list/get them, or via an explicit
     ``deriva_ml_resync_indexes(target="execution:<rid>")`` call.
 
     Cross-user freshness is best-effort. User A's mutation does
     NOT refresh user B's per-user sources -- B sees A's change only
-    at B's next first-connect to the catalog. Same gap applies to
-    mutations from non-MCP clients (Chaise UI, ERMrest direct,
-    other deriva-ml scripts): they don't propagate to your per-user
-    sources at all.
+    once B next lists/fetches that row (which warms it) or resyncs.
+    Same gap applies to mutations from non-MCP clients (Chaise UI,
+    ERMrest direct, other deriva-ml scripts): they don't propagate
+    to your per-user sources until you next read those rows.
 
     When working on multi-user collaborative catalogs, treat RAG
     hits for shared-visible rows as hints, NOT as ground truth. The
@@ -1131,9 +1133,10 @@ feature, workflow, execution, asset) plus 3 catalog-maintenance tools
 (create_vocabulary, reindex_vocabularies, resync_indexes) -- + 18
 read-only resources under the
 ``deriva://catalog/{h}/{c}/deriva-ml/...`` URI prefix + 1 GitHub doc source
-indexed for RAG (``deriva-ml-docs``) + 3 per-user RAG indexes that
-ingest Dataset / Workflow / Execution rows on first connect to a
-catalog. Plus 4 built-in core prompts and 2 ML prompts: this one
+indexed for RAG (``deriva-ml-docs``) + per-user RAG indexes that
+ingest Dataset / Workflow / Execution rows read-through (warmed when
+you list/get them, surgically refreshed on mutation -- not on
+connect). Plus 4 built-in core prompts and 2 ML prompts: this one
 (``deriva_ml_getting_started``) and ``deriva_ml_concepts``. (v3.x
 removed two earlier prompts, ``deriva_ml_execution_lifecycle`` and
 ``deriva_ml_workflow_dedup``, and redistributed their content to the

--- a/src/deriva_ml_mcp_plugin/prompts.py
+++ b/src/deriva_ml_mcp_plugin/prompts.py
@@ -1141,8 +1141,6 @@ relevant tool docstrings and RAG-indexed docs.)
 """
 
 
-
-
 # Manifest of guides advertised by the primer (manifest-as-data). Each entry
 # is (name, source, summary). source is "deriva-ml" for guides owned by this
 # plugin (fetchable via get_guide) or "core" for deriva-mcp-core tier-1 guides

--- a/src/deriva_ml_mcp_plugin/resources/rag.py
+++ b/src/deriva_ml_mcp_plugin/resources/rag.py
@@ -1,24 +1,35 @@
 """Per-user RAG indexing + vocab indexing + DerivaML docs source for deriva-ml-mcp-plugin.
 
 Phase 6.3 wired three things into the RAG subsystem; v1.1 added a
-fourth (vocabularies); v1.3 (this file) reshapes the per-user trio into
-per-user-per-RID surgical indexers:
+fourth (vocabularies); v1.3 reshaped the per-user trio into
+per-user-per-RID surgical indexers; v1.5 (this file) drops the
+on-connect bulk pass for those three tables in favor of read-through
+(index-on-find) warming:
 
 1. **One GitHub doc source** -- ``informatics-isi-edu/deriva-ml`` ``docs/``
    (declared synchronously via ``ctx.rag_github_source``). The indexer
    crawls it once when RAG is enabled.
 
-2. **Three per-user-per-RID ``on_catalog_connect`` hooks** -- one each
-   for ``Dataset``, ``Workflow``, and ``Execution`` rows. Each hook
-   resolves the calling user's identity, fetches rows under that user's
-   credential, and writes one source per (user, table, RID) tuple to
-   the vector store under
+2. **Read-through (index-on-find) per-user-per-RID writers** -- one
+   logical path each for ``Dataset``, ``Workflow``, and ``Execution``
+   rows. These are NO LONGER ``on_catalog_connect`` hooks (the three
+   bulk first-connect passes were removed in v1.5 because they re-fetched
+   and re-embedded every visible row on every catalog connect). Instead a
+   row's chunk is warmed lazily: the list/get tools call
+   ``_index_rows_on_find(...)`` after a read to schedule a best-effort
+   background ``_reindex_<entity>(...)`` for each row just seen, and the
+   mutating tools call ``_reindex_<entity>(...)`` surgically right after
+   the catalog mutation. Both write one source per (user, table, RID)
+   tuple to the vector store under
    ``data:{host}:{cat}:{user_id}:{table}:{rid}``. The fetch path goes
-   through the plugin's existing ``_list_*_impl`` helpers, so ACL
-   behavior matches the read tools. The per-RID source naming lets
-   mutating tools surgically refresh just the affected source via
-   ``_reindex_<entity>(...)`` immediately after the catalog mutation,
-   so ``rag_search`` finds the change on the very next call.
+   through the plugin's existing ``_list_*_impl`` / ``lookup_*`` helpers,
+   so ACL behavior matches the read tools, and the per-RID source naming
+   lets a single row be refreshed without touching the rest of the
+   user's index, so ``rag_search`` finds the change on the very next
+   call. The ``deriva_ml_resync_indexes`` tool re-runs the same per-RID
+   re-index loop over every visible row on demand (manual "warm
+   everything" backfill via ``_resync_*`` + ``_fetch_*_rows``) -- the
+   replacement for the removed first-connect bulk pass.
 
 3. **One catalog-public ``on_catalog_connect`` hook for vocabularies**
    (v1.1) -- discovers all vocabulary tables via
@@ -37,7 +48,7 @@ per-user-per-RID surgical indexers:
    (``_VocabSerializer``), each producing rich Markdown sections for
    the LLM (header, fields, subsections; empties omitted FaceBase-style).
 
-Why per-user hooks (not ``ctx.rag_dataset_indexer``)?
+Why per-user writers (not ``ctx.rag_dataset_indexer``)?
 ``rag_dataset_indexer`` produces a single global enriched source shared
 across all users (the enricher fires under whichever credential happens
 to connect first). For ML data with per-user ACLs that would leak rows
@@ -77,20 +88,25 @@ Vocab freshness (v1.1):
     is the bridge until upstream ships ``on_data_change``.
 
 First-connect lag (no startup prewarm):
-    All four hooks here fire lazily on the first tool call that
-    connects to a given catalog, so the first user to touch a catalog
-    after a (re)start pays the indexing cost inline. The per-server
-    GitHub doc sources ARE pre-warmed at startup (core's
-    ``_startup_update``), but there is no startup prewarm for
-    per-catalog indexing. The catalog-public parts (core's schema
-    index + this plugin's vocab hook) COULD be primed at startup from
-    an operator-configured catalog list; the per-user trio cannot
-    (no calling-user credential exists at startup -- correct by
+    The vocab ``on_catalog_connect`` hook fires lazily on the first tool
+    call that connects to a given catalog, so the first user to touch a
+    catalog after a (re)start pays the vocab indexing cost inline. The
+    per-user trio no longer indexes on connect at all (v1.5 removed the
+    three bulk first-connect passes); their per-RID chunks are warmed
+    read-through by the list/get tools via ``_index_rows_on_find`` and
+    surgically on mutate via ``_reindex_<entity>``, so there is no
+    per-user bulk cost on connect. The per-server GitHub doc sources ARE
+    pre-warmed at startup (core's ``_startup_update``), but there is no
+    startup prewarm for per-catalog indexing. The catalog-public parts
+    (core's schema index + this plugin's vocab hook) COULD be primed at
+    startup from an operator-configured catalog list; the per-user trio
+    cannot (no calling-user credential exists at startup -- correct by
     design). Tracked upstream as deriva-mcp-core#10 (startup prewarm
     for catalog-public per-catalog indexing). Workaround until then:
     call ``deriva_ml_reindex_vocabularies(hostname, catalog_id)`` once
     per catalog after a restart to remove the vocab portion of the
-    first-connect lag.
+    first-connect lag, and ``deriva_ml_resync_indexes(hostname,
+    catalog_id)`` to warm the calling user's per-user trio in bulk.
 
 Wiring into ``plugin.py`` is in ``register_rag_sources(ctx)``. This
 module is import-safe and idempotent on its own.
@@ -99,7 +115,6 @@ module is import-safe and idempotent on its own.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
@@ -388,18 +403,6 @@ def _fetch_execution_rows(hostname: str, catalog_id: str) -> list[dict[str, Any]
     return [e.model_dump(mode="json") for e in payload.executions]
 
 
-def _coerce_for_index(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Round-trip rows through JSON to drop non-serializable values.
-
-    The execution summary contains ``datetime`` objects; the serializer
-    renders them directly via ``str()`` but the round-trip leaves
-    everything as plain JSON-compatible scalars before chunking, which
-    keeps the per-row write path simple. Datasets and workflows pass
-    through unchanged.
-    """
-    return [json.loads(json.dumps(r, default=str)) for r in rows]
-
-
 # ---------------------------------------------------------------------------
 # Per-RID source naming + single-row write (v1.3 surgical re-index path)
 # ---------------------------------------------------------------------------
@@ -513,8 +516,9 @@ async def _reindex_dataset(hostname: str, catalog_id: str, dataset_rid: str) -> 
     Best-effort: any failure (fetch, render, store I/O) is logged and
     swallowed -- a re-index hiccup must not propagate to the calling
     tool's success path (the catalog mutation already succeeded). On
-    failure returns 0; the next first-connect for this user picks the
-    row up via the bulk path.
+    failure returns 0; the row is picked up on the next read-through
+    warm (a later list/get of this row via ``_index_rows_on_find``) or
+    via ``deriva_ml_resync_indexes``.
 
     Args:
         hostname: Deriva hostname.
@@ -733,11 +737,13 @@ async def _resync_user_sources(
 
     Wrapping orchestrator for the v1.4 manual cross-user-resync tool.
     The v1.3 surgical re-index covers freshness for the calling user's
-    OWN mutations, but mutations by OTHER users (or by non-MCP clients
-    like Chaise) leave the calling user's per-user sources stale until
-    they reconnect. This helper is the bridge: when called, it re-runs
-    the same per-RID re-index loop that ``_make_hook`` runs at first
-    connect, but on demand instead of on connect.
+    OWN mutations, and read-through warming (``_index_rows_on_find``)
+    covers rows the user reads, but mutations by OTHER users (or by
+    non-MCP clients like Chaise) leave the calling user's per-user
+    sources stale until they read or re-index them. This helper is the
+    bridge -- and the replacement for the removed first-connect bulk
+    pass: when called, it re-runs the per-RID re-index loop over every
+    visible row on demand.
 
     Two modes:
 
@@ -752,8 +758,8 @@ async def _resync_user_sources(
       which RID needs refreshing.
 
     Best-effort throughout: per-RID failures are logged and swallowed
-    (same contract as ``_make_hook``). The returned dict reports the
-    count of sources successfully refreshed per table -- a partial
+    (same contract as ``_reindex_<entity>``). The returned dict reports
+    the count of sources successfully refreshed per table -- a partial
     success is normal (e.g. one RID raised; the rest landed).
 
     Args:
@@ -885,120 +891,6 @@ async def _resync_one_table(
                 catalog_id,
             )
     return count
-
-
-# ---------------------------------------------------------------------------
-# Hook factory (first-connect bulk index, per-RID source naming)
-# ---------------------------------------------------------------------------
-
-
-def _make_hook(
-    fetch_fn: Callable[[str, str], list[dict[str, Any]]],
-    table_name: str,
-    table_token: str,
-    serializer: RowSerializer,
-) -> Callable[[str, str, str, dict], Awaitable[None]]:
-    """Build an ``on_catalog_connect`` hook that indexes ``table_name`` per-user-per-RID.
-
-    The returned coroutine fetches rows under the caller's credential,
-    resolves the calling user's identity, and writes one source per
-    (user, table_token, RID) tuple to the vector store. Same total
-    chunk count as v1.0/v1.1's bulk pattern; the difference is that
-    they land in N sources instead of 1, so individual rows can later
-    be replaced surgically by ``_reindex_<entity>``.
-
-    Behavior contract:
-
-    - Wraps the fetch in ``try/except`` so a deriva-ml read failure is
-      logged with table context but does not propagate.
-    - Skips silently (debug log) when ``get_rag_store()`` returns
-      ``None`` -- i.e. when RAG is disabled in this deployment.
-    - Per-row write failures are isolated: a bad row is logged and the
-      loop continues with the rest, so one degenerate row does not
-      poison the whole user's first-connect index pass.
-    - Logs a debug success line including row count + resolved user_id
-      so an operator can investigate "why isn't user X's data showing up?"
-      by flipping on debug logging without overwhelming production logs.
-
-    Args:
-        fetch_fn: Callable that takes ``(hostname, catalog_id)`` and
-            returns summary-shape row dicts.
-        table_name: Catalog table the rows belong to (ERMrest case).
-            Used as the serializer dispatch key.
-        table_token: URL-safe slug for the source-name routing segment
-            (one of ``_DATASET_TOKEN`` / ``_WORKFLOW_TOKEN`` /
-            ``_EXECUTION_TOKEN``).
-        serializer: The ``RowSerializer`` to render each row.
-
-    Returns:
-        An async hook with the ``on_catalog_connect`` signature
-        ``(hostname, catalog_id, schema_hash, schema_json) -> None``.
-    """
-
-    # schema_hash + schema_json are received because deriva-mcp-core's
-    # _dispatch_catalog_connect signature requires them. We deliberately
-    # ignore both: indexing depends only on (host, catalog_id, user_id,
-    # rows), and re-indexing on schema changes is handled separately by
-    # the framework's TTL gating, not by the schema_hash here.
-    async def hook(
-        hostname: str,
-        catalog_id: str,
-        schema_hash: str,  # noqa: ARG001 -- hook signature requires it
-        schema_json: dict,  # noqa: ARG001 -- hook signature requires it
-    ) -> None:
-        try:
-            # fetch_fn wraps synchronous deriva-py HTTP I/O; run it in a
-            # worker thread so the event loop stays responsive while the
-            # catalog is being indexed.
-            raw_rows = await asyncio.to_thread(fetch_fn, hostname, catalog_id)
-            rows = _coerce_for_index(raw_rows)
-        except Exception:  # noqa: BLE001 -- fetch errors are domain-specific
-            logger.exception(
-                "deriva-ml RAG: failed to fetch %s rows for %s/%s",
-                table_name,
-                hostname,
-                catalog_id,
-            )
-            return
-        store = get_rag_store()
-        if store is None:
-            logger.debug("rag store unavailable, skipping %s first-connect index", table_name)
-            return
-        # resolve_user_identity may issue a sync GET /authn/session in
-        # stdio mode; offload so the loop is not blocked on first call.
-        user_id = await asyncio.to_thread(resolve_user_identity, hostname)
-        for row in rows:
-            rid = row.get("rid")
-            if not rid:
-                # Defensive: a row without a RID can't get a stable
-                # per-RID source name; skip with a debug log rather
-                # than silently dropping it under an empty-RID source.
-                logger.debug(
-                    "skipping %s first-connect row with empty rid: %r",
-                    table_name,
-                    row,
-                )
-                continue
-            source = _row_source_name(hostname, catalog_id, user_id, table_token, rid)
-            try:
-                await _write_row_chunk(store, source, table_name, row, serializer)
-            except Exception:  # noqa: BLE001 -- one bad row should not poison the pass
-                logger.exception(
-                    "deriva-ml RAG: failed to first-connect index %s row %s",
-                    table_name,
-                    rid,
-                )
-                continue
-        logger.debug(
-            "first-connect indexed %d %s rows for user=%s host=%s catalog=%s",
-            len(rows),
-            table_name,
-            user_id,
-            hostname,
-            catalog_id,
-        )
-
-    return hook
 
 
 # ---------------------------------------------------------------------------
@@ -1152,11 +1044,13 @@ async def _index_vocabularies(
 def _make_vocab_hook() -> Callable[[str, str, str, dict], Awaitable[None]]:
     """Build the on_catalog_connect hook that bulk-indexes vocabularies.
 
-    Distinct from ``_make_hook`` because vocab indexing has a different
-    shape: one hook fires N writes (one per discovered vocab) rather
-    than one write. Forcing this into the per-user factory's
-    ``(fetch_fn, table_name, serializer)`` signature would obscure the
-    difference. Two clear factories beat one general one.
+    This is the only ``on_catalog_connect`` hook the plugin registers
+    (v1.5 removed the three per-user bulk row hooks). Vocabularies are
+    catalog-public (no per-user ACL) and small, so a single first-connect
+    bulk pass over all discovered vocab tables -- writing one shared
+    ``vocab:`` source per table -- is the right shape. The per-user row
+    tables, by contrast, are warmed read-through and on mutate rather
+    than on connect; see the module docstring.
 
     Returns:
         An async hook with the ``on_catalog_connect`` signature
@@ -1187,25 +1081,31 @@ def _make_vocab_hook() -> Callable[[str, str, str, dict], Awaitable[None]]:
 
 
 def register_rag_sources(ctx: PluginContext) -> None:
-    """Register the DerivaML docs source and four catalog-connect hooks.
+    """Register the GitHub doc sources and the vocabulary catalog-connect hook.
 
-    Hooks fire in registration order on every catalog connect:
+    Wires:
 
-    1. Dataset (per-user-per-RID, ``data:{host}:{cat}:{user_id}:dataset:{rid}``)
-    2. Workflow (per-user-per-RID, ``data:{host}:{cat}:{user_id}:workflow:{rid}``)
-    3. Execution (per-user-per-RID, ``data:{host}:{cat}:{user_id}:execution:{rid}``)
-    4. Vocabularies (catalog-public, custom ``vocab:`` source prefix --
-       v1.1; bypasses upstream's ``data:`` user-id filter, served to
-       all users in the catalog)
+    - Two ``rag_github_source`` declarations (the deriva-ml library docs
+      and this plugin's own README) -- crawled once when RAG is enabled.
+    - One ``on_catalog_connect`` hook for vocabularies (catalog-public,
+      custom ``vocab:`` source prefix -- v1.1; bypasses upstream's
+      ``data:`` user-id filter, served to all users in the catalog).
 
-    The first three are first-connect bulk indexers but write under
-    per-RID source names so mutating tools can later replace just one
-    affected source via the ``_reindex_<entity>`` helpers.
+    v1.5 removed the three per-user bulk row indexers (Dataset,
+    Workflow, Execution) that used to register as ``on_catalog_connect``
+    hooks here -- they re-fetched and re-embedded every visible row on
+    every catalog connect. Those per-user ``data:`` per-RID sources
+    (``data:{host}:{cat}:{user_id}:{table}:{rid}``) are now warmed
+    read-through by the list/get tools (via ``_index_rows_on_find``) and
+    surgically on mutate (via ``_reindex_<entity>``), with the
+    ``deriva_ml_resync_indexes`` tool (``_resync_*`` + ``_fetch_*_rows``)
+    available for manual bulk backfill. The per-RID ``data:`` source
+    shape is unchanged.
 
     Called from ``plugin.register(ctx)``. Safe to call without any RAG
     config -- ``ctx.rag_github_source`` is a no-op when RAG is
-    disabled, and the hooks are best-effort: they swallow fetch
-    exceptions and short-circuit when the vector store is unavailable.
+    disabled, and the vocab hook is best-effort: it swallows fetch
+    exceptions and short-circuits when the vector store is unavailable.
 
     Args:
         ctx: PluginContext supplied by deriva-mcp-core at startup.
@@ -1233,16 +1133,5 @@ def register_rag_sources(ctx: PluginContext) -> None:
         branch=_GITHUB_MCP_DOCS_BRANCH,
         path_prefix=_GITHUB_MCP_DOCS_PATH_PREFIX,
         doc_type=_GITHUB_MCP_DOCS_DOC_TYPE,
-    )
-    ctx.on_catalog_connect(
-        _make_hook(_fetch_dataset_rows, _DATASET_TABLE, _DATASET_TOKEN, _DatasetSerializer())
-    )
-    ctx.on_catalog_connect(
-        _make_hook(_fetch_workflow_rows, _WORKFLOW_TABLE, _WORKFLOW_TOKEN, _WorkflowSerializer())
-    )
-    ctx.on_catalog_connect(
-        _make_hook(
-            _fetch_execution_rows, _EXECUTION_TABLE, _EXECUTION_TOKEN, _ExecutionSerializer()
-        )
     )
     ctx.on_catalog_connect(_make_vocab_hook())

--- a/src/deriva_ml_mcp_plugin/resources/rag.py
+++ b/src/deriva_ml_mcp_plugin/resources/rag.py
@@ -166,6 +166,20 @@ _WORKFLOW_TOKEN = "workflow"
 _EXECUTION_TOKEN = "execution"
 
 
+# Strong references to in-flight index-on-find background tasks. Without
+# this set the event loop may garbage-collect a pending task before it
+# runs (asyncio holds only a weak reference). Mirrors the
+# ``_connect_tasks`` pattern in deriva-mcp-core/tools/catalog.py.
+_on_find_tasks: set[asyncio.Task] = set()
+
+# Maps a per-user-trio table token to the *name* of the surgical
+# re-index coroutine that warms one row of that table. Storing the name
+# (not the function object) lets ``_index_rows_on_find`` resolve the
+# current module-level binding at call time, so ``patch.object`` on a
+# ``_reindex_*`` coroutine is honored. Used by ``_index_rows_on_find``.
+_REINDEX_BY_TOKEN: dict[str, str] = {}
+
+
 # ---------------------------------------------------------------------------
 # Row-rendering helpers
 # ---------------------------------------------------------------------------
@@ -590,6 +604,90 @@ async def _reindex_execution(hostname: str, catalog_id: str, execution_rid: str)
             catalog_id,
         )
         return 0
+
+
+_REINDEX_BY_TOKEN[_DATASET_TOKEN] = _reindex_dataset.__name__
+_REINDEX_BY_TOKEN[_WORKFLOW_TOKEN] = _reindex_workflow.__name__
+_REINDEX_BY_TOKEN[_EXECUTION_TOKEN] = _reindex_execution.__name__
+
+
+def _index_rows_on_find(
+    hostname: str,
+    catalog_id: str,
+    table_token: str,
+    rows: list[dict[str, Any]],
+    *,
+    rct_key: str = "rct",
+) -> None:
+    """Warm the calling user's per-RID RAG sources for rows just read.
+
+    Read-through (index-on-find) indexing: a list/get tool that just
+    fetched ``rows`` calls this to schedule a best-effort background
+    re-index of each row, so a later ``rag_search`` finds them. Rows are
+    warmed **newest-first** (descending ``rct_key``) so the most recently
+    created entities become searchable first.
+
+    Fire-and-forget: schedules one background task per row and returns
+    immediately. Never blocks the caller's response and never raises --
+    a missing event loop (import-time / sync test) is a silent no-op, and
+    each per-row reindex swallows its own errors (see ``_reindex_*``).
+
+    Args:
+        hostname: Deriva hostname.
+        catalog_id: Catalog ID or alias.
+        table_token: One of ``_DATASET_TOKEN`` / ``_WORKFLOW_TOKEN`` /
+            ``_EXECUTION_TOKEN``. Selects the per-row reindex coroutine.
+        rows: Summary-shape row dicts (must carry ``"rid"``). Rows
+            without a RID are skipped.
+        rct_key: Key holding each row's record-creation timestamp, used
+            only to order the warm newest-first. Rows missing the key
+            sort last (treated as oldest).
+
+    Returns:
+        None.
+
+    Example:
+        >>> _index_rows_on_find(  # doctest: +SKIP
+        ...     "host", "1", _DATASET_TOKEN,
+        ...     [{"rid": "1-AAAA", "rct": "2026-06-01T00:00:00+00:00"}],
+        ... )
+    """
+    reindex_name = _REINDEX_BY_TOKEN.get(table_token)
+    if reindex_name is None:
+        return
+    # Resolve the current module-level binding at call time (not the
+    # binding captured at import) so ``patch.object`` on a ``_reindex_*``
+    # coroutine -- as the tests and the per-tool call sites rely on -- is
+    # honored.
+    reindex_fn = globals()[reindex_name]
+    # Newest-first: rows with a later rct warm sooner. Missing/empty rct
+    # sorts last (empty string < any real ISO timestamp).
+    ordered = sorted(rows, key=lambda r: r.get(rct_key) or "", reverse=True)
+
+    async def _do() -> None:
+        for row in ordered:
+            rid = row.get("rid")
+            if not rid:
+                continue
+            try:
+                await reindex_fn(hostname, catalog_id, rid)
+            except Exception:  # noqa: BLE001 -- best-effort warm
+                logger.debug(
+                    "index-on-find reindex failed for %s %s in %s/%s",
+                    table_token,
+                    rid,
+                    hostname,
+                    catalog_id,
+                    exc_info=True,
+                )
+
+    try:
+        task = asyncio.get_running_loop().create_task(_do())
+        _on_find_tasks.add(task)
+        task.add_done_callback(_on_find_tasks.discard)
+    except RuntimeError:
+        # No running event loop (import-time, sync test) -- silent no-op.
+        pass
 
 
 async def _delete_dataset_source(hostname: str, catalog_id: str, dataset_rid: str) -> bool:

--- a/src/deriva_ml_mcp_plugin/resources/rag.py
+++ b/src/deriva_ml_mcp_plugin/resources/rag.py
@@ -620,16 +620,14 @@ def _index_rows_on_find(
     catalog_id: str,
     table_token: str,
     rows: list[dict[str, Any]],
-    *,
-    rct_key: str = "rct",
 ) -> None:
     """Warm the calling user's per-RID RAG sources for rows just read.
 
     Read-through (index-on-find) indexing: a list/get tool that just
     fetched ``rows`` calls this to schedule a best-effort background
     re-index of each row, so a later ``rag_search`` finds them. Rows are
-    warmed **newest-first** (descending ``rct_key``) so the most recently
-    created entities become searchable first.
+    indexed in the order given (the order the read returned them) -- no
+    re-sorting.
 
     Fire-and-forget: schedules one background task per row and returns
     immediately. Never blocks the caller's response and never raises --
@@ -643,17 +641,13 @@ def _index_rows_on_find(
             ``_EXECUTION_TOKEN``. Selects the per-row reindex coroutine.
         rows: Summary-shape row dicts (must carry ``"rid"``). Rows
             without a RID are skipped.
-        rct_key: Key holding each row's record-creation timestamp, used
-            only to order the warm newest-first. Rows missing the key
-            sort last (treated as oldest).
 
     Returns:
         None.
 
     Example:
         >>> _index_rows_on_find(  # doctest: +SKIP
-        ...     "host", "1", _DATASET_TOKEN,
-        ...     [{"rid": "1-AAAA", "rct": "2026-06-01T00:00:00+00:00"}],
+        ...     "host", "1", _DATASET_TOKEN, [{"rid": "1-AAAA"}],
         ... )
     """
     reindex_name = _REINDEX_BY_TOKEN.get(table_token)
@@ -664,12 +658,9 @@ def _index_rows_on_find(
     # coroutine -- as the tests and the per-tool call sites rely on -- is
     # honored.
     reindex_fn = globals()[reindex_name]
-    # Newest-first: rows with a later rct warm sooner. Missing/empty rct
-    # sorts last (empty string < any real ISO timestamp).
-    ordered = sorted(rows, key=lambda r: r.get(rct_key) or "", reverse=True)
 
     async def _do() -> None:
-        for row in ordered:
+        for row in rows:
             rid = row.get("rid")
             if not rid:
                 continue

--- a/src/deriva_ml_mcp_plugin/tools/dataset/mutate.py
+++ b/src/deriva_ml_mcp_plugin/tools/dataset/mutate.py
@@ -769,9 +769,7 @@ def register(ctx: PluginContext) -> None:
                 # object only when an execution_rid was supplied.
                 execution_obj = None
                 if execution_rid is not None:
-                    execution_obj = await asyncio.to_thread(
-                        ml.lookup_execution, execution_rid
-                    )
+                    execution_obj = await asyncio.to_thread(ml.lookup_execution, execution_rid)
 
                 new_version = await asyncio.to_thread(
                     ds.release,

--- a/src/deriva_ml_mcp_plugin/tools/dataset/read.py
+++ b/src/deriva_ml_mcp_plugin/tools/dataset/read.py
@@ -368,8 +368,9 @@ def register(ctx: PluginContext) -> None:
                 )
                 # Read-through indexing: warm the per-user RAG sources for
                 # the rows we just returned so a later rag_search finds
-                # them (newest-first). Fire-and-forget; never blocks or
-                # fails the read. Lazy import avoids the rag<->tools cycle.
+                # them (in the order the read returned them). Fire-and-forget;
+                # never blocks or fails the read. Lazy import avoids the
+                # rag<->tools cycle.
                 try:
                     from deriva_ml_mcp_plugin.resources.rag import (
                         _DATASET_TOKEN,

--- a/src/deriva_ml_mcp_plugin/tools/dataset/read.py
+++ b/src/deriva_ml_mcp_plugin/tools/dataset/read.py
@@ -90,6 +90,7 @@ def _list_datasets_impl(
     limit: int,
     include_deleted: bool = False,
     sort: bool = False,
+    dataset_type: str | None = None,
 ) -> DatasetListResponse:
     """Fetch + paginate datasets. Pure helper -- shared by tool and resource.
 
@@ -106,6 +107,11 @@ def _list_datasets_impl(
             cursor still works ("skip up to this RID in the RCT-sorted
             result"), but pagination through very large sorted result
             sets is bounded by the internal fetch cap.
+        dataset_type: Optional ``Dataset_Type`` vocabulary term. When
+            set, keep only datasets whose ``dataset_types`` list contains
+            this term (membership test, applied before pagination so
+            ``limit`` counts filtered rows). When ``None`` (default), no
+            type filtering.
 
     Returns:
         ``DatasetListResponse`` -- see ``deriva_ml_mcp_plugin._response_models``.
@@ -123,6 +129,8 @@ def _list_datasets_impl(
         datasets = raw
     else:
         datasets = sorted(raw, key=lambda d: d.dataset_rid)
+    if dataset_type is not None:
+        datasets = [d for d in datasets if dataset_type in (d.dataset_types or [])]
     page, truncated, next_after = _paginate(
         datasets,
         after_rid=after_rid,
@@ -165,9 +173,7 @@ def _get_dataset_detail_impl(ml: Any, dataset_rid: str) -> DatasetDetail:
         )
         for h in ds.dataset_history()
     ]
-    cite = _cite_dataset_version_url(
-        ml, dataset_rid, str(ds.current_version), ds=ds
-    )
+    cite = _cite_dataset_version_url(ml, dataset_rid, str(ds.current_version), ds=ds)
     return DatasetDetail(
         **summary.model_dump(),
         cite_url=cite if isinstance(cite, str) else None,
@@ -412,9 +418,7 @@ def register(ctx: PluginContext) -> None:
                 # §"Synchronous work in threads".
                 ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
                 if include_history:
-                    payload = await asyncio.to_thread(
-                        _get_dataset_detail_impl, ml, dataset_rid
-                    )
+                    payload = await asyncio.to_thread(_get_dataset_detail_impl, ml, dataset_rid)
                 else:
                     # Skip the dataset_history() call entirely when not
                     # requested -- it can be expensive on long-lived
@@ -843,9 +847,7 @@ def register(ctx: PluginContext) -> None:
                 # plugin-authoring-guide.md §"Synchronous work in
                 # threads".
                 ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
-                payload = await asyncio.to_thread(
-                    _get_dataset_spec_impl, ml, dataset_rid, version
-                )
+                payload = await asyncio.to_thread(_get_dataset_spec_impl, ml, dataset_rid, version)
             return json.dumps(payload)
         except Exception as exc:
             # Read-only tool: log+return without an audit row (I-2 fix).
@@ -996,9 +998,7 @@ def register(ctx: PluginContext) -> None:
                 # Pydantic class. Pydantic's ValidationError on bad
                 # input bubbles up through the except below.
                 exec_config = ExecutionConfiguration(**config)
-                payload = await asyncio.to_thread(
-                    ml.validate_execution_configuration, exec_config
-                )
+                payload = await asyncio.to_thread(ml.validate_execution_configuration, exec_config)
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
@@ -1068,15 +1068,12 @@ def register(ctx: PluginContext) -> None:
                 # cleaned up immediately after parsing.
                 import os
                 import tempfile
-                with tempfile.NamedTemporaryFile(
-                    suffix=".py", mode="w", delete=False
-                ) as tmp:
+
+                with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as tmp:
                     tmp.write(file_contents)
                     tmp_path = tmp.name
                 try:
-                    payload = await asyncio.to_thread(
-                        ml.validate_config_file, tmp_path
-                    )
+                    payload = await asyncio.to_thread(ml.validate_config_file, tmp_path)
                 finally:
                     try:
                         os.unlink(tmp_path)
@@ -1208,9 +1205,7 @@ def _bag_info_impl(
         warning = None
     else:
         ds = ml.lookup_dataset(dataset_rid)
-        used_version = (
-            str(ds.current_version) if ds.current_version is not None else "0.1.0"
-        )
+        used_version = str(ds.current_version) if ds.current_version is not None else "0.1.0"
         warning = (
             f"version not specified; using current version "
             f"{used_version}. For reproducibility, pin to an explicit "
@@ -1231,9 +1226,7 @@ def _bag_info_impl(
     return info
 
 
-def _get_dataset_spec_impl(
-    ml: Any, dataset_rid: str, version: str | None
-) -> dict[str, Any]:
+def _get_dataset_spec_impl(ml: Any, dataset_rid: str, version: str | None) -> dict[str, Any]:
     """Shared helper: tool ``deriva_ml_get_dataset_spec`` and resource
     ``deriva://catalog/{h}/{c}/deriva-ml/dataset/{rid}/spec`` both call this so
     their payloads cannot drift.
@@ -1260,9 +1253,7 @@ def _get_dataset_spec_impl(
         used_version = version
         warning = None
     else:
-        used_version = (
-            str(ds.current_version) if ds.current_version is not None else "0.1.0"
-        )
+        used_version = str(ds.current_version) if ds.current_version is not None else "0.1.0"
         warning = (
             f"version not specified; using current version "
             f"{used_version}. For reproducibility, pin to an explicit "

--- a/src/deriva_ml_mcp_plugin/tools/dataset/read.py
+++ b/src/deriva_ml_mcp_plugin/tools/dataset/read.py
@@ -250,6 +250,7 @@ def register(ctx: PluginContext) -> None:
         after_rid: str | None = None,
         preflight_count: bool = False,
         sort: bool = False,
+        dataset_type: str | None = None,
     ) -> str:
         """Browse all datasets in the catalog with optional pagination.
 
@@ -307,6 +308,11 @@ def register(ctx: PluginContext) -> None:
                 creation time. Recommended for "show me the most
                 recent datasets" queries. Default False preserves the
                 stable RID-ascending order used for cursor pagination.
+            dataset_type: Optional ``Dataset_Type`` term. When set, only
+                datasets tagged with this type are returned (structured
+                filter -- prefer this over fuzzy ``rag_search`` when the
+                user names a type). Combine with a later ``rag_search``
+                for "Training datasets matching <description text>".
 
         Returns:
             Preflight:
@@ -355,6 +361,7 @@ def register(ctx: PluginContext) -> None:
                     limit=capped,
                     include_deleted=include_deleted,
                     sort=sort,
+                    dataset_type=dataset_type,
                 )
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:

--- a/src/deriva_ml_mcp_plugin/tools/dataset/read.py
+++ b/src/deriva_ml_mcp_plugin/tools/dataset/read.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -57,6 +58,8 @@ from deriva_ml_mcp_plugin._response_models import (
 
 if TYPE_CHECKING:
     from deriva_mcp_core.plugin.api import PluginContext
+
+logger = logging.getLogger(__name__)
 
 
 def _summarize_dataset(ds: Any) -> DatasetSummary:
@@ -363,6 +366,27 @@ def register(ctx: PluginContext) -> None:
                     sort=sort,
                     dataset_type=dataset_type,
                 )
+                # Read-through indexing: warm the per-user RAG sources for
+                # the rows we just returned so a later rag_search finds
+                # them (newest-first). Fire-and-forget; never blocks or
+                # fails the read. Lazy import avoids the rag<->tools cycle.
+                try:
+                    from deriva_ml_mcp_plugin.resources.rag import (
+                        _DATASET_TOKEN,
+                        _index_rows_on_find,
+                    )
+
+                    _index_rows_on_find(
+                        hostname,
+                        catalog_id,
+                        _DATASET_TOKEN,
+                        [d.model_dump(mode="json") for d in payload.datasets],
+                    )
+                except Exception:  # noqa: BLE001 -- warm is best-effort
+                    logger.debug(
+                        "index-on-find scheduling failed for list_datasets",
+                        exc_info=True,
+                    )
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             # Read-only tool: log+return without an audit row (I-2 fix).
@@ -441,6 +465,24 @@ def register(ctx: PluginContext) -> None:
                         **summary.model_dump(),
                         cite_url=cite if isinstance(cite, str) else None,
                         version_history=[],
+                    )
+                # Read-through indexing: warm the per-user RAG source for
+                # the dataset we just returned so a later rag_search finds
+                # it. Fire-and-forget; never blocks or fails the read.
+                # Lazy import avoids the rag<->tools cycle.
+                try:
+                    from deriva_ml_mcp_plugin.resources.rag import (
+                        _DATASET_TOKEN,
+                        _index_rows_on_find,
+                    )
+
+                    _index_rows_on_find(
+                        hostname, catalog_id, _DATASET_TOKEN, [{"rid": dataset_rid}]
+                    )
+                except Exception:  # noqa: BLE001 -- warm is best-effort
+                    logger.debug(
+                        "index-on-find scheduling failed for get_dataset",
+                        exc_info=True,
                     )
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:

--- a/src/deriva_ml_mcp_plugin/tools/execution/read.py
+++ b/src/deriva_ml_mcp_plugin/tools/execution/read.py
@@ -20,6 +20,7 @@ through ``_error_envelope`` (reads only log on failure, no audit row).
 from __future__ import annotations
 
 import asyncio
+import logging
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -59,6 +60,8 @@ from deriva_ml_mcp_plugin._response_models import (
 
 if TYPE_CHECKING:
     from deriva_mcp_core.plugin.api import PluginContext
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_workflow_rid(record: Any) -> str | None:
@@ -645,9 +648,7 @@ def _get_execution_detail_impl(ml: Any, execution_rid: str) -> ExecutionDetail:
                 }
             )
         except Exception as exc:  # noqa: BLE001 -- log but don't break the response
-            import logging
-
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "ExecutionExperiment serialization failed for %s: %s. "
                 "Returning experiment=None; the underlying Experiment object "
                 "from deriva-ml exists but its fields failed validation. This "
@@ -814,6 +815,28 @@ def register(ctx: PluginContext) -> None:
                     dataset=dataset_arg,
                     dataset_role=dataset_role,
                 )
+                # Read-through indexing: warm the per-user RAG sources for
+                # the rows we just returned so a later rag_search finds
+                # them (in the order the read returned them). Fire-and-forget;
+                # never blocks or fails the read. Lazy import avoids the
+                # rag<->tools cycle.
+                try:
+                    from deriva_ml_mcp_plugin.resources.rag import (
+                        _EXECUTION_TOKEN,
+                        _index_rows_on_find,
+                    )
+
+                    _index_rows_on_find(
+                        hostname,
+                        catalog_id,
+                        _EXECUTION_TOKEN,
+                        [e.model_dump(mode="json") for e in payload.executions],
+                    )
+                except Exception:  # noqa: BLE001 -- warm is best-effort
+                    logger.debug(
+                        "index-on-find scheduling failed for list_executions",
+                        exc_info=True,
+                    )
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(
@@ -859,6 +882,24 @@ def register(ctx: PluginContext) -> None:
                 ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
                 record = await asyncio.to_thread(ml.lookup_execution, execution_rid)
                 summary = _summarize_execution(record)
+                # Read-through indexing: warm the per-user RAG source for
+                # the execution we just returned so a later rag_search finds
+                # it. Fire-and-forget; never blocks or fails the read.
+                # Lazy import avoids the rag<->tools cycle.
+                try:
+                    from deriva_ml_mcp_plugin.resources.rag import (
+                        _EXECUTION_TOKEN,
+                        _index_rows_on_find,
+                    )
+
+                    _index_rows_on_find(
+                        hostname, catalog_id, _EXECUTION_TOKEN, [{"rid": execution_rid}]
+                    )
+                except Exception:  # noqa: BLE001 -- warm is best-effort
+                    logger.debug(
+                        "index-on-find scheduling failed for get_execution",
+                        exc_info=True,
+                    )
             return summary.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(

--- a/src/deriva_ml_mcp_plugin/tools/workflow.py
+++ b/src/deriva_ml_mcp_plugin/tools/workflow.py
@@ -311,6 +311,28 @@ def register(ctx: PluginContext) -> None:
                     sort=sort,
                     workflow_type=workflow_type,
                 )
+                # Read-through indexing: warm the per-user RAG sources for
+                # the rows we just returned so a later rag_search finds
+                # them (in the order the read returned them). Fire-and-forget;
+                # never blocks or fails the read. Lazy import avoids the
+                # rag<->tools cycle.
+                try:
+                    from deriva_ml_mcp_plugin.resources.rag import (
+                        _WORKFLOW_TOKEN,
+                        _index_rows_on_find,
+                    )
+
+                    _index_rows_on_find(
+                        hostname,
+                        catalog_id,
+                        _WORKFLOW_TOKEN,
+                        [w.model_dump(mode="json") for w in payload.workflows],
+                    )
+                except Exception:  # noqa: BLE001 -- warm is best-effort
+                    logger.debug(
+                        "index-on-find scheduling failed for list_workflows",
+                        exc_info=True,
+                    )
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:
             # Read-only tool: log+return without an audit row.
@@ -356,6 +378,24 @@ def register(ctx: PluginContext) -> None:
                 # plugin-authoring-guide.md §"Synchronous work in threads".
                 ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
                 summary = await asyncio.to_thread(_get_workflow_impl, ml, workflow_rid)
+                # Read-through indexing: warm the per-user RAG source for
+                # the workflow we just returned so a later rag_search finds
+                # it. Fire-and-forget; never blocks or fails the read.
+                # Lazy import avoids the rag<->tools cycle.
+                try:
+                    from deriva_ml_mcp_plugin.resources.rag import (
+                        _WORKFLOW_TOKEN,
+                        _index_rows_on_find,
+                    )
+
+                    _index_rows_on_find(
+                        hostname, catalog_id, _WORKFLOW_TOKEN, [{"rid": workflow_rid}]
+                    )
+                except Exception:  # noqa: BLE001 -- warm is best-effort
+                    logger.debug(
+                        "index-on-find scheduling failed for get_workflow",
+                        exc_info=True,
+                    )
             return summary.model_dump_json(by_alias=True)
         except Exception as exc:
             return _error_envelope(

--- a/src/deriva_ml_mcp_plugin/tools/workflow.py
+++ b/src/deriva_ml_mcp_plugin/tools/workflow.py
@@ -143,6 +143,7 @@ def _list_workflows_impl(
     after_rid: str | None,
     limit: int,
     sort: bool = False,
+    workflow_type: str | None = None,
 ) -> WorkflowListResponse:
     """Fetch + paginate workflows. Pure helper -- shared by tool and resource.
 
@@ -158,6 +159,11 @@ def _list_workflows_impl(
             cursor still works ("skip up to this RID in the RCT-sorted
             result"), but pagination through very large sorted result
             sets is bounded by the internal fetch cap.
+        workflow_type: Optional ``Workflow_Type`` vocabulary term. When
+            set, keep only workflows whose ``workflow_type`` list
+            contains this term (membership test, applied before
+            pagination so ``limit`` counts filtered rows). When ``None``
+            (default), no type filtering.
 
     Returns:
         ``WorkflowListResponse`` -- see ``deriva_ml_mcp_plugin._response_models``.
@@ -177,6 +183,8 @@ def _list_workflows_impl(
         workflows = raw
     else:
         workflows = sorted(raw, key=lambda w: _resolve_workflow_rid(w) or "")
+    if workflow_type is not None:
+        workflows = [w for w in workflows if workflow_type in (w.workflow_type or [])]
     page, truncated, next_after = _paginate(
         workflows,
         after_rid=after_rid,
@@ -233,6 +241,7 @@ def register(ctx: PluginContext) -> None:
         after_rid: str | None = None,
         preflight_count: bool = False,
         sort: bool = False,
+        workflow_type: str | None = None,
     ) -> str:
         """Browse all workflows registered in the catalog.
 
@@ -246,6 +255,11 @@ def register(ctx: PluginContext) -> None:
                 creation time. Recommended for "show me the most
                 recent workflows" queries. Default False preserves the
                 stable RID-ascending order used for cursor pagination.
+            workflow_type: Optional ``Workflow_Type`` term. When set, only
+                workflows tagged with this type are returned (structured
+                filter -- prefer this over fuzzy ``rag_search`` when the
+                user names a type). Combine with a later ``rag_search``
+                for "Model_Training workflows matching <description text>".
 
         Returns:
             Preflight:
@@ -295,6 +309,7 @@ def register(ctx: PluginContext) -> None:
                     after_rid=after_rid,
                     limit=capped,
                     sort=sort,
+                    workflow_type=workflow_type,
                 )
             return payload.model_dump_json(by_alias=True)
         except Exception as exc:

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -216,9 +216,7 @@ async def test_find_assets_empty_match_returns_empty_list_not_error(
 
 async def test_find_assets_scoped_to_one_table(asset_ctx, capturing_mcp, mock_ml):
     """asset_table without asset_type narrows the scan to one table."""
-    mock_ml.find_assets.return_value = iter(
-        [_make_asset_mock("1-AAAA", asset_table="Image")]
-    )
+    mock_ml.find_assets.return_value = iter([_make_asset_mock("1-AAAA", asset_table="Image")])
     out = json.loads(
         await capturing_mcp.tools["deriva_ml_find_assets"](
             hostname="h", catalog_id="1", asset_table="Image"
@@ -244,21 +242,15 @@ async def test_find_assets_both_scoping_kwargs_are_forwarded(asset_ctx, capturin
         )
     )
     assert out["count"] == 1
-    mock_ml.find_assets.assert_called_with(
-        asset_table="Trained_Model", asset_type="Model_File"
-    )
+    mock_ml.find_assets.assert_called_with(asset_table="Trained_Model", asset_type="Model_File")
 
 
-async def test_find_assets_validation_requires_one_identifier(
-    asset_ctx, capturing_mcp, mock_ml
-):
+async def test_find_assets_validation_requires_one_identifier(asset_ctx, capturing_mcp, mock_ml):
     """Neither asset_type nor asset_table => validation error envelope,
     no catalog call. Unfiltered cross-catalog scans are intentionally
     not exposed."""
     out = json.loads(
-        await capturing_mcp.tools["deriva_ml_find_assets"](
-            hostname="h", catalog_id="1"
-        )
+        await capturing_mcp.tools["deriva_ml_find_assets"](hostname="h", catalog_id="1")
     )
     assert "error" in out
     assert "at least one" in out["error"]

--- a/tests/test_dataset_complex.py
+++ b/tests/test_dataset_complex.py
@@ -35,13 +35,13 @@ def dataset_ctx(ctx, mock_ml):
         dataset_module.register(ctx)
         yield ctx
 
+
 # NOTE: cache_dataset tests were removed in v0.5.0 along with the
 # deriva_ml_cache_dataset tool. The denormalize_dataset tests below
 # transitively exercise cache_dataset via the library call inside
 # get_denormalized_as_dict, but the wire-level tool is gone.
 # See docs/audit-2026-05-23.md and the design note at
 # docs/superpowers/notes/2026-05-23-cache-denormalize-deprecation-design.md.
-
 
 
 # ---------------------------------------------------------------------------
@@ -286,4 +286,3 @@ async def test_denormalize_dataset_islice_bounds_generator_consumption(
     # Returned page is a real page of 5; islice consumed at most 6.
     assert out["returned_count"] == 5
     assert consumed["n"] <= 6, f"generator consumed {consumed['n']} times (expected ≤ 6)"
-

--- a/tests/test_dataset_mutate.py
+++ b/tests/test_dataset_mutate.py
@@ -198,7 +198,10 @@ async def test_add_dataset_members_with_list(dataset_ctx, capturing_mcp, mock_ml
     assert out["dataset_rid"] == "1-AAAA"
     assert out["new_version"] == "1.1.0"
     ds.add_dataset_members.assert_called_once_with(
-        members=["r1", "r2", "r3"], validate=True, description="adding three", execution_rid="EXEC-1"
+        members=["r1", "r2", "r3"],
+        validate=True,
+        description="adding three",
+        execution_rid="EXEC-1",
     )
     success = _success_calls(mock_audit, "deriva_ml_add_dataset_members")
     assert success
@@ -677,9 +680,7 @@ async def test_release_major(dataset_ctx, capturing_mcp, mock_ml):
 async def test_release_error_no_dev_period(dataset_ctx, capturing_mcp, mock_ml):
     """Releasing a dataset with no dev period surfaces the deriva-ml error."""
     ds = _make_dataset_mock("1-AAAA")
-    ds.release.side_effect = RuntimeError(
-        "Dataset 1-AAAA has no dev period to release"
-    )
+    ds.release.side_effect = RuntimeError("Dataset 1-AAAA has no dev period to release")
     mock_ml.lookup_dataset.return_value = ds
     with _patch_audit() as mock_audit:
         out = json.loads(

--- a/tests/test_dataset_read.py
+++ b/tests/test_dataset_read.py
@@ -185,6 +185,27 @@ def test_list_datasets_impl_dataset_type_none_returns_all() -> None:
     assert {d.rid for d in resp.datasets} == {"1-A", "1-B"}
 
 
+async def test_list_datasets_tool_forwards_dataset_type(dataset_ctx, capturing_mcp, mock_ml):
+    """``deriva_ml_list_datasets(dataset_type=...)`` forwards the filter to the impl."""
+    from deriva_ml_mcp_plugin._response_models import DatasetListResponse
+
+    seen: dict = {}
+
+    def spy(ml, **kwargs):
+        seen.update(kwargs)
+        return DatasetListResponse(datasets=[], count=0, truncated=False, next_after_rid=None)
+
+    with patch(
+        "deriva_ml_mcp_plugin.tools.dataset.read._list_datasets_impl",
+        side_effect=spy,
+    ):
+        await capturing_mcp.tools["deriva_ml_list_datasets"](
+            hostname="h", catalog_id="1", dataset_type="Training"
+        )
+
+    assert seen.get("dataset_type") == "Training"
+
+
 # ---------------------------------------------------------------------------
 # get_dataset
 # ---------------------------------------------------------------------------

--- a/tests/test_dataset_read.py
+++ b/tests/test_dataset_read.py
@@ -206,6 +206,56 @@ async def test_list_datasets_tool_forwards_dataset_type(dataset_ctx, capturing_m
     assert seen.get("dataset_type") == "Training"
 
 
+async def test_list_datasets_tool_schedules_index_on_find(dataset_ctx, capturing_mcp, mock_ml):
+    """``deriva_ml_list_datasets`` warms the returned rows via _index_rows_on_find."""
+    mock_ml.find_datasets.return_value = [
+        _make_dataset_mock("1-AAAA", "first", ["Training"], "1.0.0"),
+        _make_dataset_mock("1-BBBB", "second", ["Testing"], "1.1.0"),
+    ]
+
+    captured: dict = {}
+
+    def fake_warm(hostname, catalog_id, token, rows, **kwargs):
+        captured["token"] = token
+        captured["rids"] = [r.get("rid") for r in rows]
+
+    # The tool does a lazy ``from deriva_ml_mcp_plugin.resources.rag import
+    # _index_rows_on_find`` at call time, so patch the name in its
+    # defining module (the lazy import binds to ``rag._index_rows_on_find``).
+    with patch(
+        "deriva_ml_mcp_plugin.resources.rag._index_rows_on_find",
+        side_effect=fake_warm,
+    ):
+        await capturing_mcp.tools["deriva_ml_list_datasets"](hostname="h", catalog_id="1")
+
+    from deriva_ml_mcp_plugin.resources.rag import _DATASET_TOKEN
+
+    assert captured.get("token") == _DATASET_TOKEN
+    assert set(captured.get("rids") or []) == {"1-AAAA", "1-BBBB"}
+
+
+async def test_list_datasets_preflight_does_not_index_on_find(dataset_ctx, capturing_mcp, mock_ml):
+    """The preflight (count-only) path returns before building rows, so it must
+    NOT schedule a read-through warm."""
+    mock_ml.find_datasets.return_value = [_make_dataset_mock(f"1-{i:04d}") for i in range(3)]
+
+    called = False
+
+    def fake_warm(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    with patch(
+        "deriva_ml_mcp_plugin.resources.rag._index_rows_on_find",
+        side_effect=fake_warm,
+    ):
+        await capturing_mcp.tools["deriva_ml_list_datasets"](
+            hostname="h", catalog_id="1", preflight_count=True
+        )
+
+    assert called is False
+
+
 # ---------------------------------------------------------------------------
 # get_dataset
 # ---------------------------------------------------------------------------
@@ -273,6 +323,34 @@ async def test_get_dataset_not_found(dataset_ctx, capturing_mcp, mock_ml):
         )
     )
     assert out == {"error": "Dataset not found"}
+
+
+async def test_get_dataset_tool_schedules_index_on_find(dataset_ctx, capturing_mcp, mock_ml):
+    """``deriva_ml_get_dataset`` warms the single returned row via _index_rows_on_find."""
+    mock_ml.lookup_dataset.return_value = _make_dataset_mock(
+        "1-AAAA", "desc", ["Training"], "1.0.0"
+    )
+
+    captured: dict = {}
+
+    def fake_warm(hostname, catalog_id, token, rows, **kwargs):
+        captured["token"] = token
+        captured["rids"] = [r.get("rid") for r in rows]
+
+    # Lazy import in the tool binds to ``rag._index_rows_on_find`` at call
+    # time, so patch the name in its defining module.
+    with patch(
+        "deriva_ml_mcp_plugin.resources.rag._index_rows_on_find",
+        side_effect=fake_warm,
+    ):
+        await capturing_mcp.tools["deriva_ml_get_dataset"](
+            hostname="h", catalog_id="1", dataset_rid="1-AAAA"
+        )
+
+    from deriva_ml_mcp_plugin.resources.rag import _DATASET_TOKEN
+
+    assert captured.get("token") == _DATASET_TOKEN
+    assert captured.get("rids") == ["1-AAAA"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dataset_read.py
+++ b/tests/test_dataset_read.py
@@ -140,6 +140,51 @@ async def test_list_datasets_sort_default_preserves_rid_sort(dataset_ctx, captur
     assert rids == ["1-A", "1-Z"]
 
 
+def test_list_datasets_impl_filters_by_dataset_type() -> None:
+    """``dataset_type=`` keeps only datasets whose type list contains it."""
+    from types import SimpleNamespace
+
+    from deriva_ml_mcp_plugin.tools.dataset.read import _list_datasets_impl
+
+    def _ds(rid, types):
+        return SimpleNamespace(
+            dataset_rid=rid,
+            description="d",
+            dataset_types=types,
+            current_version=None,
+        )
+
+    fake_ml = SimpleNamespace(
+        find_datasets=lambda deleted, sort: [
+            _ds("1-TRN", ["Training"]),
+            _ds("1-TST", ["Testing"]),
+            _ds("1-BTH", ["Training", "Validation"]),
+        ]
+    )
+
+    resp = _list_datasets_impl(fake_ml, after_rid=None, limit=100, dataset_type="Training")
+    rids = [d.rid for d in resp.datasets]
+    assert rids == ["1-BTH", "1-TRN"]  # RID-ascending of the two Training matches
+
+
+def test_list_datasets_impl_dataset_type_none_returns_all() -> None:
+    """No filter -> unchanged behavior (all datasets)."""
+    from types import SimpleNamespace
+
+    from deriva_ml_mcp_plugin.tools.dataset.read import _list_datasets_impl
+
+    def _ds(rid, types):
+        return SimpleNamespace(
+            dataset_rid=rid, description="d", dataset_types=types, current_version=None
+        )
+
+    fake_ml = SimpleNamespace(
+        find_datasets=lambda deleted, sort: [_ds("1-A", ["Training"]), _ds("1-B", ["Testing"])]
+    )
+    resp = _list_datasets_impl(fake_ml, after_rid=None, limit=100, dataset_type=None)
+    assert {d.rid for d in resp.datasets} == {"1-A", "1-B"}
+
+
 # ---------------------------------------------------------------------------
 # get_dataset
 # ---------------------------------------------------------------------------
@@ -650,9 +695,7 @@ async def test_validate_dataset_specs_error_path(dataset_ctx, capturing_mcp, moc
     assert "error" in out
 
 
-async def test_validate_execution_configuration_success(
-    dataset_ctx, capturing_mcp, mock_ml
-):
+async def test_validate_execution_configuration_success(dataset_ctx, capturing_mcp, mock_ml):
     """The tool coerces the dict to ExecutionConfiguration and serializes
     the validation report. We patch ExecutionConfiguration to bypass
     its full validation here -- the wrapper's only job is wiring; full
@@ -690,9 +733,7 @@ async def test_validate_execution_configuration_success(
         "deriva_ml.execution.execution_configuration.ExecutionConfiguration",
         return_value=fake_config,
     ):
-        result = await capturing_mcp.tools[
-            "deriva_ml_validate_execution_configuration"
-        ](
+        result = await capturing_mcp.tools["deriva_ml_validate_execution_configuration"](
             hostname="h",
             catalog_id="1",
             config={
@@ -709,9 +750,7 @@ async def test_validate_execution_configuration_success(
     mock_ml.validate_execution_configuration.assert_called_once_with(fake_config)
 
 
-async def test_validate_execution_configuration_error_path(
-    dataset_ctx, capturing_mcp, mock_ml
-):
+async def test_validate_execution_configuration_error_path(dataset_ctx, capturing_mcp, mock_ml):
     """Underlying ``ml.validate_execution_configuration`` raising propagates
     as ``{"error": ...}``."""
     fake_config = MagicMock(name="ExecutionConfiguration_instance")
@@ -723,9 +762,7 @@ async def test_validate_execution_configuration_error_path(
         return_value=fake_config,
     ):
         out = json.loads(
-            await capturing_mcp.tools[
-                "deriva_ml_validate_execution_configuration"
-            ](
+            await capturing_mcp.tools["deriva_ml_validate_execution_configuration"](
                 hostname="h",
                 catalog_id="1",
                 config={"workflow": {"rid": "1-WFLW"}},
@@ -750,9 +787,7 @@ async def test_validate_execution_configuration_error_path(
 # ---------------------------------------------------------------------------
 
 
-async def test_validate_config_file_with_file_contents(
-    dataset_ctx, capturing_mcp, mock_ml
-) -> None:
+async def test_validate_config_file_with_file_contents(dataset_ctx, capturing_mcp, mock_ml) -> None:
     """``file_contents`` is the sole accepted input: wrapper writes a
     temp file and calls the ml method with the temp path. The path
     passed to ml ends with ``.py`` and the temp file is cleaned up."""
@@ -766,7 +801,7 @@ async def test_validate_config_file_with_file_contents(
     )
 
     src = (
-        'from deriva_ml.dataset import DatasetSpecConfig\n'
+        "from deriva_ml.dataset import DatasetSpecConfig\n"
         'datasets_store(name="x", spec=DatasetSpecConfig(rid="1-A", version="0.1.0"))\n'
     )
     result = await capturing_mcp.tools["deriva_ml_validate_config_file"](
@@ -779,12 +814,11 @@ async def test_validate_config_file_with_file_contents(
     assert called_path.endswith(".py")
     # Temp file is cleaned up immediately after parsing.
     import os
+
     assert not os.path.exists(called_path)
 
 
-async def test_validate_config_file_error_path(
-    dataset_ctx, capturing_mcp, mock_ml
-) -> None:
+async def test_validate_config_file_error_path(dataset_ctx, capturing_mcp, mock_ml) -> None:
     mock_ml.validate_config_file.side_effect = RuntimeError("AST blew up")
     result = await capturing_mcp.tools["deriva_ml_validate_config_file"](
         hostname="h", catalog_id="1", file_contents="# empty"
@@ -793,9 +827,7 @@ async def test_validate_config_file_error_path(
     assert out == {"error": "AST blew up"}
 
 
-async def test_bootstrap_config_default_kinds(
-    dataset_ctx, capturing_mcp, mock_ml
-) -> None:
+async def test_bootstrap_config_default_kinds(dataset_ctx, capturing_mcp, mock_ml) -> None:
     """Default invocation propagates ``kinds=None`` and
     ``dataset_type_filter=None`` to the ml method."""
     from deriva_ml.config.bootstrap import BootstrapReport, BootstrapSuggestion
@@ -816,16 +848,12 @@ async def test_bootstrap_config_default_kinds(
         skipped=[],
     )
 
-    result = await capturing_mcp.tools["deriva_ml_bootstrap_config"](
-        hostname="h", catalog_id="1"
-    )
+    result = await capturing_mcp.tools["deriva_ml_bootstrap_config"](hostname="h", catalog_id="1")
     out = json.loads(result)
     assert out["catalog"]["hostname"] == "h"
     assert len(out["suggestions"]) == 1
     assert out["suggestions"][0]["spec_string"].startswith("DatasetSpecConfig(")
-    mock_ml.bootstrap_config.assert_called_once_with(
-        kinds=None, dataset_type_filter=None
-    )
+    mock_ml.bootstrap_config.assert_called_once_with(kinds=None, dataset_type_filter=None)
 
 
 async def test_bootstrap_config_kinds_filter_propagates(
@@ -849,12 +877,8 @@ async def test_bootstrap_config_kinds_filter_propagates(
     )
 
 
-async def test_bootstrap_config_error_path(
-    dataset_ctx, capturing_mcp, mock_ml
-) -> None:
+async def test_bootstrap_config_error_path(dataset_ctx, capturing_mcp, mock_ml) -> None:
     mock_ml.bootstrap_config.side_effect = RuntimeError("cannot connect")
-    result = await capturing_mcp.tools["deriva_ml_bootstrap_config"](
-        hostname="h", catalog_id="1"
-    )
+    result = await capturing_mcp.tools["deriva_ml_bootstrap_config"](hostname="h", catalog_id="1")
     out = json.loads(result)
     assert out == {"error": "cannot connect"}

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -181,6 +181,60 @@ async def test_list_executions_workflow_type_filter_forwarded(
     assert kwargs["workflow_type"] == "Inference"
 
 
+async def test_list_executions_tool_schedules_index_on_find(execution_ctx, capturing_mcp, mock_ml):
+    """``deriva_ml_list_executions`` warms the returned rows via _index_rows_on_find."""
+    mock_ml.find_executions.return_value = [
+        _make_execution_record_mock(rid="1-AAA", workflow_rid="1-WF"),
+        _make_execution_record_mock(rid="1-BBB", workflow_rid="1-WF"),
+    ]
+
+    captured: dict = {}
+
+    def fake_warm(hostname, catalog_id, token, rows, **kwargs):
+        captured["token"] = token
+        captured["rids"] = [r.get("rid") for r in rows]
+
+    # The tool does a lazy ``from deriva_ml_mcp_plugin.resources.rag import
+    # _index_rows_on_find`` at call time, so patch the name in its
+    # defining module (the lazy import binds to ``rag._index_rows_on_find``).
+    with patch(
+        "deriva_ml_mcp_plugin.resources.rag._index_rows_on_find",
+        side_effect=fake_warm,
+    ):
+        await capturing_mcp.tools["deriva_ml_list_executions"](hostname="h", catalog_id="1")
+
+    from deriva_ml_mcp_plugin.resources.rag import _EXECUTION_TOKEN
+
+    assert captured.get("token") == _EXECUTION_TOKEN
+    assert set(captured.get("rids") or []) == {"1-AAA", "1-BBB"}
+
+
+async def test_list_executions_preflight_does_not_index_on_find(
+    execution_ctx, capturing_mcp, mock_ml
+):
+    """The preflight (count-only) path returns before building rows, so it must
+    NOT schedule a read-through warm."""
+    mock_ml.find_executions.return_value = [
+        _make_execution_record_mock(rid=f"1-{i:03d}") for i in range(3)
+    ]
+
+    called = False
+
+    def fake_warm(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    with patch(
+        "deriva_ml_mcp_plugin.resources.rag._index_rows_on_find",
+        side_effect=fake_warm,
+    ):
+        await capturing_mcp.tools["deriva_ml_list_executions"](
+            hostname="h", catalog_id="1", preflight_count=True
+        )
+
+    assert called is False
+
+
 # ---------------------------------------------------------------------------
 # get_execution
 # ---------------------------------------------------------------------------
@@ -214,6 +268,34 @@ async def test_get_execution_error_path(execution_ctx, capturing_mcp, mock_ml):
     assert "error" in payload
     assert "not found" in payload["error"]
     assert mock_audit.call_count == 0
+
+
+async def test_get_execution_tool_schedules_index_on_find(execution_ctx, capturing_mcp, mock_ml):
+    """``deriva_ml_get_execution`` warms the single returned row via _index_rows_on_find."""
+    mock_ml.lookup_execution.return_value = _make_execution_record_mock(
+        rid="1-EXEC", workflow_rid="1-WF"
+    )
+
+    captured: dict = {}
+
+    def fake_warm(hostname, catalog_id, token, rows, **kwargs):
+        captured["token"] = token
+        captured["rids"] = [r.get("rid") for r in rows]
+
+    # Lazy import in the tool binds to ``rag._index_rows_on_find`` at call
+    # time, so patch the name in its defining module.
+    with patch(
+        "deriva_ml_mcp_plugin.resources.rag._index_rows_on_find",
+        side_effect=fake_warm,
+    ):
+        await capturing_mcp.tools["deriva_ml_get_execution"](
+            hostname="h", catalog_id="1", execution_rid="1-EXEC"
+        )
+
+    from deriva_ml_mcp_plugin.resources.rag import _EXECUTION_TOKEN
+
+    assert captured.get("token") == _EXECUTION_TOKEN
+    assert captured.get("rids") == ["1-EXEC"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -362,17 +362,16 @@ def test_register_wires_rag_github_sources(ctx):
     assert names == {"deriva-ml-docs", "deriva-ml-mcp-plugin-docs"}
 
 
-def test_register_wires_four_catalog_connect_hooks(ctx):
-    """``register(ctx)`` must wire the four RAG catalog hooks.
+def test_register_wires_one_catalog_connect_hook(ctx):
+    """``register(ctx)`` wires exactly the vocab catalog-connect hook.
 
-    Three per-user row indexers (Dataset, Workflow, Execution) plus
-    one catalog-public vocab indexer (added in v1.1). Hook identity
-    is already covered by ``tests/test_rag.py``; this test only pins
-    the count so that dropping one hook from ``register_rag_sources``
-    is also caught at the plugin level.
+    Read-through indexing removed the three per-user bulk row indexers
+    (Dataset/Workflow/Execution). Only the catalog-public vocab indexer
+    fires on connect now. Hook identity is covered in test_rag.py; this
+    pins the count so re-adding a bulk hook is caught at the plugin level.
     """
     register(ctx)
-    assert len(ctx._catalog_connect_hooks) == 4
+    assert len(ctx._catalog_connect_hooks) == 1
 
 
 def test_register_wires_ml_prompts(ctx, capturing_mcp):
@@ -410,7 +409,7 @@ def test_register_does_not_use_rag_dataset_indexer(ctx):
 def test_vocab_hook_writes_to_vocab_prefix_not_data_prefix(ctx):
     """Architectural carve-out pin: vocab chunks land under ``vocab:``, never ``data:``.
 
-    The vocab hook is the fourth ``on_catalog_connect`` hook registered
+    The vocab hook is the only ``on_catalog_connect`` hook registered
     by ``register_rag_sources``. It MUST write to the vector store
     under a ``vocab:`` source prefix (catalog-public, no per-user
     partitioning) and MUST NOT route through ``index_table_data``
@@ -428,7 +427,7 @@ def test_vocab_hook_writes_to_vocab_prefix_not_data_prefix(ctx):
     from unittest.mock import AsyncMock, MagicMock, patch
 
     register(ctx)
-    vocab_hook = ctx._catalog_connect_hooks[3]
+    vocab_hook = ctx._catalog_connect_hooks[0]
 
     # Mock the vocab table the hook iterates over.
     vocab_table = MagicMock()
@@ -470,64 +469,3 @@ def test_vocab_hook_writes_to_vocab_prefix_not_data_prefix(ctx):
             assert not chunk.source.startswith("data:"), (
                 f"vocab hook accidentally routed through data: prefix: {chunk.source!r}"
             )
-
-
-def test_data_sources_use_per_rid_naming(ctx):
-    """v1.3 pin: per-user trio chunks land under ``data:{h}:{c}:{user_id}:{table}:{rid}``.
-
-    The pre-v1.3 source-name shape was ``data:{host}:{cat}:{user_id}``
-    (one source per user, all rows lumped together). v1.3's surgical
-    re-index requires per-RID source naming so a single mutating tool
-    can refresh just one source via ``_reindex_<entity>``. This test
-    pins that source-naming shape end-to-end at the plugin level: fire
-    each hook with mocked fetchers + a captured ``_write_row_chunk``,
-    then assert every captured source name matches the v1.3 shape AND
-    starts with the user-id prefix that upstream's filter gates on.
-    """
-    from unittest.mock import MagicMock, patch
-
-    captured: list[tuple[str, str]] = []
-
-    async def fake_write(store, source, table_name, row, serializer):
-        captured.append((table_name, source))
-        return 1
-
-    from deriva_ml_mcp_plugin.resources import rag as rag_module
-
-    user_id = "https://auth.example.org/sub/u1"
-    user_prefix = f"data:h.example:1:{user_id}"
-
-    # Patch the fetchers BEFORE register(ctx) -- the hook factory
-    # captures the fetch fn at registration time, so any post-register
-    # patch.object on the module-level fetch name has no effect on the
-    # already-captured closure reference.
-    with (
-        patch.object(rag_module, "_fetch_dataset_rows", return_value=[{"rid": "1-DSAA"}]),
-        patch.object(rag_module, "_fetch_workflow_rows", return_value=[{"rid": "1-WFAA"}]),
-        patch.object(rag_module, "_fetch_execution_rows", return_value=[{"rid": "1-EXAA"}]),
-        patch.object(rag_module, "resolve_user_identity", return_value=user_id),
-        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write),
-    ):
-        register(ctx)
-        dataset_hook = ctx._catalog_connect_hooks[0]
-        workflow_hook = ctx._catalog_connect_hooks[1]
-        execution_hook = ctx._catalog_connect_hooks[2]
-
-        import asyncio
-
-        asyncio.run(dataset_hook("h.example", "1", "hash", {}))
-        asyncio.run(workflow_hook("h.example", "1", "hash", {}))
-        asyncio.run(execution_hook("h.example", "1", "hash", {}))
-
-    # Every source carries the user-id prefix (so upstream's user-id
-    # filter still gates correctly) AND the per-RID shape.
-    assert captured == [
-        ("Dataset", f"{user_prefix}:dataset:1-DSAA"),
-        ("Workflow", f"{user_prefix}:workflow:1-WFAA"),
-        ("Execution", f"{user_prefix}:execution:1-EXAA"),
-    ]
-    for _, source in captured:
-        assert source.startswith(user_prefix + ":"), (
-            f"per-RID source must extend user-id prefix; got {source!r}"
-        )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -186,8 +186,8 @@ def test_render_primer_has_three_blocks():
     """The primer has a mandatory-core header, a manifest header, and a closing directive."""
     body = prompts._render_primer()
     assert "DERIVA-ML AGENT GUIDELINES" in body  # block 1 header
-    assert "ON-DEMAND GUIDES" in body            # block 2 header
-    assert "get_guide" in body                   # block 3 references on-demand fetch
+    assert "ON-DEMAND GUIDES" in body  # block 2 header
+    assert "get_guide" in body  # block 3 references on-demand fetch
 
 
 def test_get_guide_returns_plugin_guide_body(ctx, capturing_mcp):

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -2,22 +2,23 @@
 
 Two surfaces under test:
 
-1. ``register_rag_sources(ctx)`` -- declarative wiring: one
-   ``rag_github_source`` declaration plus four ``on_catalog_connect``
-   callbacks.
+1. ``register_rag_sources(ctx)`` -- declarative wiring: two
+   ``rag_github_source`` declarations plus the single vocabulary
+   ``on_catalog_connect`` callback. (v1.5 removed the three per-user
+   bulk first-connect hooks; their per-RID writes are now exercised via
+   the ``_reindex_<entity>`` and ``_index_rows_on_find`` tests below.)
 
-2. The serializers, per-user hook bodies, and v1.3 surgical re-index
-   helpers -- rich Markdown rendering for Dataset / Workflow / Execution
-   rows, fall-through to the generic serializer for unknown tables,
-   per-row write isolation inside the first-connect hooks (one bad row
-   doesn't poison the rest), and best-effort failure handling inside
-   ``_reindex_<entity>`` (the catalog mutation already succeeded; a
-   re-index hiccup must not propagate).
+2. The serializers and the v1.3 surgical re-index helpers -- rich
+   Markdown rendering for Dataset / Workflow / Execution rows,
+   fall-through to the generic serializer for unknown tables, and
+   best-effort failure handling inside ``_reindex_<entity>`` (the
+   catalog mutation already succeeded; a re-index hiccup must not
+   propagate).
 
 All tests are fully mocked. ``_write_row_chunk`` is patched in the
-hook-flow tests so we can assert on per-RID source naming without
+re-index tests so we can assert on per-RID source naming without
 touching a real vector store; the row fetchers are patched to keep
-the hook tests independent of the underlying ``_list_*_impl`` shape.
+the resync tests independent of the underlying ``_list_*_impl`` shape.
 """
 
 from __future__ import annotations
@@ -38,14 +39,12 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-# Hook registration order in register_rag_sources(ctx):
-#   0 -> Dataset, 1 -> Workflow, 2 -> Execution, 3 -> Vocabularies.
-# Tests pull hooks via index rather than by name because the factory
-# refactor produces anonymous closures (no module-level attribute to import).
-_DATASET_HOOK_IDX = 0
-_WORKFLOW_HOOK_IDX = 1
-_EXECUTION_HOOK_IDX = 2
-_VOCAB_HOOK_IDX = 3
+# Hook registration order in register_rag_sources(ctx): the vocabulary
+# hook is the only on_catalog_connect callback (v1.5 removed the three
+# per-user bulk hooks). Tests pull it via index rather than by name
+# because the factory produces an anonymous closure (no module-level
+# attribute to import).
+_VOCAB_HOOK_IDX = 0
 
 
 def _hook_at(idx: int):
@@ -109,9 +108,15 @@ def test_register_rag_sources_mcp_source_targets_deriva_ml_mcp_readme(rag_ctx) -
     assert decl.doc_type == "ml-mcp-docs"
 
 
-def test_register_rag_sources_registers_four_catalog_hooks(rag_ctx) -> None:
-    """Four on_catalog_connect callbacks are registered (Dataset, Workflow, Execution, Vocab)."""
-    assert len(rag_ctx._catalog_connect_hooks) == 4
+def test_register_rag_sources_registers_one_catalog_hook(rag_ctx) -> None:
+    """Only the vocab on_catalog_connect callback is registered.
+
+    v1.5 removed the three per-user bulk first-connect hooks (Dataset,
+    Workflow, Execution); their per-RID indexing is now read-through
+    (via the list/get tools + ``_index_rows_on_find``) and surgical on
+    mutate (via ``_reindex_<entity>``), not on connect.
+    """
+    assert len(rag_ctx._catalog_connect_hooks) == 1
 
 
 def test_register_rag_sources_does_not_use_rag_dataset_indexer(rag_ctx) -> None:
@@ -305,246 +310,6 @@ def test_execution_serializer_returns_none_for_other_table() -> None:
     from deriva_ml_mcp_plugin.resources.rag import _ExecutionSerializer
 
     assert _ExecutionSerializer().serialize("Dataset", {"rid": "x"}) is None
-
-
-# ---------------------------------------------------------------------------
-# 5. Per-user hook flow -- index_table_data is called with resolved user_id
-# ---------------------------------------------------------------------------
-
-
-_USER_ID = "https://auth.example.org/sub/test-user-1"
-
-
-def test_dataset_hook_writes_one_per_rid_source_per_row() -> None:
-    """First-connect Dataset hook writes one per-RID source per row for the caller.
-
-    Each row's chunk lands under
-    ``data:{host}:{cat}:{user_id}:dataset:{rid}`` (the v1.3 surgical
-    naming) so a later mutating tool can refresh that one source via
-    ``_reindex_dataset`` without touching anything else.
-    """
-    from deriva_ml_mcp_plugin.resources import rag as rag_module
-
-    captured_calls: list[dict[str, Any]] = []
-    rows = [{"rid": "1-DSAA", "name": "x"}, {"rid": "1-DSBB", "name": "y"}]
-
-    async def fake_write_row_chunk(store, source, table_name, row, serializer):
-        captured_calls.append(
-            {
-                "source": source,
-                "table_name": table_name,
-                "row_rid": row["rid"],
-            }
-        )
-        return 1
-
-    with (
-        patch.object(rag_module, "_fetch_dataset_rows", return_value=rows),
-        patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
-        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write_row_chunk),
-    ):
-        _run(_hook_at(_DATASET_HOOK_IDX)("h.example", "1", "hash", {}))
-
-    assert len(captured_calls) == 2
-    expected_sources = {
-        f"data:h.example:1:{_USER_ID}:dataset:1-DSAA",
-        f"data:h.example:1:{_USER_ID}:dataset:1-DSBB",
-    }
-    assert {c["source"] for c in captured_calls} == expected_sources
-    assert all(c["table_name"] == "Dataset" for c in captured_calls)
-
-
-def test_workflow_hook_writes_one_per_rid_source_per_row() -> None:
-    """First-connect Workflow hook writes one per-RID source per row for the caller."""
-    from deriva_ml_mcp_plugin.resources import rag as rag_module
-
-    captured_calls: list[dict[str, Any]] = []
-    rows = [{"rid": "1-WFAA", "name": "y"}]
-
-    async def fake_write_row_chunk(store, source, table_name, row, serializer):
-        captured_calls.append({"source": source, "table_name": table_name})
-        return 1
-
-    with (
-        patch.object(rag_module, "_fetch_workflow_rows", return_value=rows),
-        patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
-        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write_row_chunk),
-    ):
-        _run(_hook_at(_WORKFLOW_HOOK_IDX)("h.example", "1", "hash", {}))
-
-    assert captured_calls == [
-        {
-            "source": f"data:h.example:1:{_USER_ID}:workflow:1-WFAA",
-            "table_name": "Workflow",
-        }
-    ]
-
-
-def test_execution_hook_writes_one_per_rid_source_per_row() -> None:
-    """First-connect Execution hook writes one per-RID source per row for the caller."""
-    from deriva_ml_mcp_plugin.resources import rag as rag_module
-
-    captured_calls: list[dict[str, Any]] = []
-    rows = [{"rid": "1-EXAA", "workflow_rid": "1-WFAA", "status": "Created"}]
-
-    async def fake_write_row_chunk(store, source, table_name, row, serializer):
-        captured_calls.append({"source": source, "table_name": table_name})
-        return 1
-
-    with (
-        patch.object(rag_module, "_fetch_execution_rows", return_value=rows),
-        patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
-        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write_row_chunk),
-    ):
-        _run(_hook_at(_EXECUTION_HOOK_IDX)("h.example", "1", "hash", {}))
-
-    assert captured_calls == [
-        {
-            "source": f"data:h.example:1:{_USER_ID}:execution:1-EXAA",
-            "table_name": "Execution",
-        }
-    ]
-
-
-# ---------------------------------------------------------------------------
-# 6. Best-effort behavior -- exceptions never propagate from hooks
-# ---------------------------------------------------------------------------
-
-
-def test_dataset_hook_swallows_fetch_exception() -> None:
-    """If the row fetch raises, the hook logs and returns without propagating.
-
-    The fetch-side ``try/except`` is retained inside the hook because
-    a deriva-ml read failure is domain-specific (table-name context in
-    the log helps debugging). The framework's ``_safe_call`` would catch
-    it too, but with a generic message.
-    """
-    from deriva_ml_mcp_plugin.resources import rag as rag_module
-
-    fake_write = AsyncMock()
-    with (
-        patch.object(rag_module, "_fetch_dataset_rows", side_effect=RuntimeError("boom")),
-        patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
-        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "_write_row_chunk", new=fake_write),
-    ):
-        # Must not raise
-        _run(_hook_at(_DATASET_HOOK_IDX)("h.example", "1", "hash", {}))
-
-    fake_write.assert_not_called()
-
-
-def test_workflow_hook_isolates_per_row_write_failures(caplog) -> None:
-    """If one row's write raises, the hook logs and continues with the rest.
-
-    v1.3 contract: per-row writes are independently wrapped so one
-    degenerate row cannot poison the whole user's first-connect index.
-    The previous v1.0 contract (let ``index_table_data`` raise out)
-    no longer applies: the hook now drives N writes, and a single bad
-    row is the most likely failure shape.
-    """
-    from deriva_ml_mcp_plugin.resources import rag as rag_module
-
-    rows = [{"rid": "1-WFAA"}, {"rid": "1-WFBB"}, {"rid": "1-WFCC"}]
-    write_calls: list[str] = []
-
-    async def fake_write(store, source, table_name, row, serializer):
-        write_calls.append(source)
-        if row["rid"] == "1-WFBB":
-            raise RuntimeError("boom on middle row")
-        return 1
-
-    with (
-        patch.object(rag_module, "_fetch_workflow_rows", return_value=rows),
-        patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
-        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write),
-        caplog.at_level("ERROR", logger="deriva_ml_mcp_plugin.resources.rag"),
-    ):
-        # Must not raise -- the hook isolates the bad row.
-        _run(_hook_at(_WORKFLOW_HOOK_IDX)("h.example", "1", "hash", {}))
-
-    # All three rows attempted (the bad one in the middle did not abort the loop).
-    assert len(write_calls) == 3
-    assert any("1-WFBB" in record.message for record in caplog.records)
-
-
-def test_hook_short_circuits_when_rag_store_is_none() -> None:
-    """When RAG is disabled (get_rag_store -> None), the hook does nothing."""
-    from deriva_ml_mcp_plugin.resources import rag as rag_module
-
-    fake_write = AsyncMock()
-    rows = [{"rid": "1-DSAA"}]
-    with (
-        patch.object(rag_module, "_fetch_dataset_rows", return_value=rows),
-        patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
-        patch.object(rag_module, "get_rag_store", return_value=None),
-        patch.object(rag_module, "_write_row_chunk", new=fake_write),
-    ):
-        _run(_hook_at(_DATASET_HOOK_IDX)("h.example", "1", "hash", {}))
-
-    fake_write.assert_not_called()
-
-
-def test_dataset_hook_skips_rows_without_rid() -> None:
-    """Rows with empty/missing rid are skipped (cannot form a stable per-RID source)."""
-    from deriva_ml_mcp_plugin.resources import rag as rag_module
-
-    rows = [{"rid": "1-DSAA"}, {"rid": "", "name": "broken"}, {"name": "no-rid-key"}]
-    captured_sources: list[str] = []
-
-    async def fake_write(store, source, table_name, row, serializer):
-        captured_sources.append(source)
-        return 1
-
-    with (
-        patch.object(rag_module, "_fetch_dataset_rows", return_value=rows),
-        patch.object(rag_module, "resolve_user_identity", return_value=_USER_ID),
-        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write),
-    ):
-        _run(_hook_at(_DATASET_HOOK_IDX)("h.example", "1", "hash", {}))
-
-    assert captured_sources == [f"data:h.example:1:{_USER_ID}:dataset:1-DSAA"]
-
-
-def test_dataset_hook_partitions_per_user() -> None:
-    """Two consecutive calls under different identities partition by user_id.
-
-    v1.3 update: the partition is now visible in the per-RID source
-    name shape (``data:h:c:userA:dataset:RID`` vs
-    ``data:h:c:userB:dataset:RID``). Same contract as v1.0 (user A's
-    rows must not bleed into user B's index); the assertion just
-    targets the new naming.
-    """
-    from deriva_ml_mcp_plugin.resources import rag as rag_module
-
-    rows = [{"rid": "1-DSAA", "name": "shared"}]
-    captured: list[str] = []
-
-    async def fake_write(store, source, table_name, row, serializer):
-        captured.append(source)
-        return 1
-
-    with (
-        patch.object(rag_module, "_fetch_dataset_rows", return_value=rows),
-        patch.object(rag_module, "resolve_user_identity", side_effect=["userA", "userB"]),
-        patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
-        patch.object(rag_module, "_write_row_chunk", side_effect=fake_write),
-    ):
-        # Build the hook inside the patch context so the factory's closure
-        # captures the patched fetch fn rather than the real one.
-        hook = _hook_at(_DATASET_HOOK_IDX)
-        _run(hook("h.example", "1", "hash", {}))
-        _run(hook("h.example", "1", "hash", {}))
-
-    assert captured == [
-        "data:h.example:1:userA:dataset:1-DSAA",
-        "data:h.example:1:userB:dataset:1-DSAA",
-    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1160,17 +1160,13 @@ def test_resync_user_sources_skips_rows_with_empty_rid() -> None:
 
 
 def test_index_rows_on_find_schedules_reindex_per_rid() -> None:
-    """``_index_rows_on_find`` fires one reindex coroutine per row, newest-first."""
+    """``_index_rows_on_find`` fires one reindex coroutine per row, in given order."""
     import asyncio
     from unittest.mock import AsyncMock, patch
 
     from deriva_ml_mcp_plugin.resources import rag as rag_module
 
-    # Rows as the list impls produce them (RID + an RCT for sort order).
-    rows = [
-        {"rid": "1-OLD", "rct": "2026-01-01T00:00:00+00:00"},
-        {"rid": "1-NEW", "rct": "2026-06-01T00:00:00+00:00"},
-    ]
+    rows = [{"rid": "1-AAAA"}, {"rid": "1-BBBB"}]
     calls: list[str] = []
 
     async def fake_reindex(hostname, catalog_id, rid):
@@ -1179,14 +1175,13 @@ def test_index_rows_on_find_schedules_reindex_per_rid() -> None:
 
     async def run() -> None:
         with patch.object(rag_module, "_reindex_dataset", new=AsyncMock(side_effect=fake_reindex)):
-            rag_module._index_rows_on_find("h", "1", rag_module._DATASET_TOKEN, rows, rct_key="rct")
-            # Let the scheduled background tasks run to completion.
+            rag_module._index_rows_on_find("h", "1", rag_module._DATASET_TOKEN, rows)
             await asyncio.gather(*rag_module._on_find_tasks)
 
     asyncio.run(run())
 
-    # Both RIDs indexed, newest-first (1-NEW before 1-OLD).
-    assert calls == ["1-NEW", "1-OLD"]
+    # Indexed in the order given (no re-sorting).
+    assert calls == ["1-AAAA", "1-BBBB"]
 
 
 def test_index_rows_on_find_swallows_reindex_errors() -> None:
@@ -1196,12 +1191,12 @@ def test_index_rows_on_find_swallows_reindex_errors() -> None:
 
     from deriva_ml_mcp_plugin.resources import rag as rag_module
 
-    rows = [{"rid": "1-AAAA", "rct": "2026-01-01T00:00:00+00:00"}]
+    rows = [{"rid": "1-AAAA"}]
 
     async def run() -> None:
         boom = AsyncMock(side_effect=RuntimeError("rag boom"))
         with patch.object(rag_module, "_reindex_dataset", new=boom):
-            rag_module._index_rows_on_find("h", "1", rag_module._DATASET_TOKEN, rows, rct_key="rct")
+            rag_module._index_rows_on_find("h", "1", rag_module._DATASET_TOKEN, rows)
             # gather must not raise even though the reindex raised.
             await asyncio.gather(*rag_module._on_find_tasks, return_exceptions=True)
 
@@ -1213,6 +1208,4 @@ def test_index_rows_on_find_no_running_loop_is_noop() -> None:
     from deriva_ml_mcp_plugin.resources import rag as rag_module
 
     # Not inside asyncio.run -> no running loop. Must not raise.
-    rag_module._index_rows_on_find(
-        "h", "1", rag_module._DATASET_TOKEN, [{"rid": "1-AAAA"}], rct_key="rct"
-    )
+    rag_module._index_rows_on_find("h", "1", rag_module._DATASET_TOKEN, [{"rid": "1-AAAA"}])

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1387,3 +1387,67 @@ def test_resync_user_sources_skips_rows_with_empty_rid() -> None:
 
     assert counts["dataset"] == 1
     fake_reindex_ds.assert_awaited_once_with("h.example", "1", "1-DSAA")
+
+
+# ---------------------------------------------------------------------------
+# 14. _index_rows_on_find read-through warm helper
+# ---------------------------------------------------------------------------
+
+
+def test_index_rows_on_find_schedules_reindex_per_rid() -> None:
+    """``_index_rows_on_find`` fires one reindex coroutine per row, newest-first."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    # Rows as the list impls produce them (RID + an RCT for sort order).
+    rows = [
+        {"rid": "1-OLD", "rct": "2026-01-01T00:00:00+00:00"},
+        {"rid": "1-NEW", "rct": "2026-06-01T00:00:00+00:00"},
+    ]
+    calls: list[str] = []
+
+    async def fake_reindex(hostname, catalog_id, rid):
+        calls.append(rid)
+        return 1
+
+    async def run() -> None:
+        with patch.object(rag_module, "_reindex_dataset", new=AsyncMock(side_effect=fake_reindex)):
+            rag_module._index_rows_on_find("h", "1", rag_module._DATASET_TOKEN, rows, rct_key="rct")
+            # Let the scheduled background tasks run to completion.
+            await asyncio.gather(*rag_module._on_find_tasks)
+
+    asyncio.run(run())
+
+    # Both RIDs indexed, newest-first (1-NEW before 1-OLD).
+    assert calls == ["1-NEW", "1-OLD"]
+
+
+def test_index_rows_on_find_swallows_reindex_errors() -> None:
+    """A failing reindex never propagates out of the background task."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    rows = [{"rid": "1-AAAA", "rct": "2026-01-01T00:00:00+00:00"}]
+
+    async def run() -> None:
+        boom = AsyncMock(side_effect=RuntimeError("rag boom"))
+        with patch.object(rag_module, "_reindex_dataset", new=boom):
+            rag_module._index_rows_on_find("h", "1", rag_module._DATASET_TOKEN, rows, rct_key="rct")
+            # gather must not raise even though the reindex raised.
+            await asyncio.gather(*rag_module._on_find_tasks, return_exceptions=True)
+
+    asyncio.run(run())  # no exception escapes
+
+
+def test_index_rows_on_find_no_running_loop_is_noop() -> None:
+    """Called with no running event loop, the helper is a silent no-op (import-time safety)."""
+    from deriva_ml_mcp_plugin.resources import rag as rag_module
+
+    # Not inside asyncio.run -> no running loop. Must not raise.
+    rag_module._index_rows_on_find(
+        "h", "1", rag_module._DATASET_TOKEN, [{"rid": "1-AAAA"}], rct_key="rct"
+    )

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -150,9 +150,7 @@ async def test_create_vocabulary_explicit_schema(vocabulary_ctx, capturing_mcp, 
     )
 
 
-async def test_create_vocabulary_failure_emits_failed_audit(
-    vocabulary_ctx, capturing_mcp, mock_ml
-):
+async def test_create_vocabulary_failure_emits_failed_audit(vocabulary_ctx, capturing_mcp, mock_ml):
     """Failure path: error envelope returned, failed-audit emitted, no success-audit."""
     mock_ml.create_vocabulary.side_effect = RuntimeError("Table Tissue_Type already exist")
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -232,6 +232,58 @@ async def test_list_workflows_tool_forwards_workflow_type(workflow_ctx, capturin
     assert seen.get("workflow_type") == "Model_Training"
 
 
+async def test_list_workflows_tool_schedules_index_on_find(workflow_ctx, capturing_mcp, mock_ml):
+    """``deriva_ml_list_workflows`` warms the returned rows via _index_rows_on_find."""
+    mock_ml.find_workflows.return_value = [
+        _make_workflow_mock(rid="1-AAA", name="A"),
+        _make_workflow_mock(rid="1-BBB", name="B"),
+    ]
+
+    captured: dict = {}
+
+    def fake_warm(hostname, catalog_id, token, rows, **kwargs):
+        captured["token"] = token
+        captured["rids"] = [r.get("rid") for r in rows]
+
+    # The tool does a lazy ``from deriva_ml_mcp_plugin.resources.rag import
+    # _index_rows_on_find`` at call time, so patch the name in its
+    # defining module (the lazy import binds to ``rag._index_rows_on_find``).
+    with patch(
+        "deriva_ml_mcp_plugin.resources.rag._index_rows_on_find",
+        side_effect=fake_warm,
+    ):
+        await capturing_mcp.tools["deriva_ml_list_workflows"](hostname="h", catalog_id="1")
+
+    from deriva_ml_mcp_plugin.resources.rag import _WORKFLOW_TOKEN
+
+    assert captured.get("token") == _WORKFLOW_TOKEN
+    assert set(captured.get("rids") or []) == {"1-AAA", "1-BBB"}
+
+
+async def test_list_workflows_preflight_does_not_index_on_find(
+    workflow_ctx, capturing_mcp, mock_ml
+):
+    """The preflight (count-only) path returns before building rows, so it must
+    NOT schedule a read-through warm."""
+    mock_ml.find_workflows.return_value = [_make_workflow_mock(rid=f"1-{i:03d}") for i in range(3)]
+
+    called = False
+
+    def fake_warm(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    with patch(
+        "deriva_ml_mcp_plugin.resources.rag._index_rows_on_find",
+        side_effect=fake_warm,
+    ):
+        await capturing_mcp.tools["deriva_ml_list_workflows"](
+            hostname="h", catalog_id="1", preflight_count=True
+        )
+
+    assert called is False
+
+
 # ---------------------------------------------------------------------------
 # get_workflow
 # ---------------------------------------------------------------------------
@@ -262,6 +314,32 @@ async def test_get_workflow_error_path(workflow_ctx, capturing_mcp, mock_ml):
     assert "error" in payload
     assert "not found" in payload["error"]
     assert mock_audit.call_count == 0
+
+
+async def test_get_workflow_tool_schedules_index_on_find(workflow_ctx, capturing_mcp, mock_ml):
+    """``deriva_ml_get_workflow`` warms the single returned row via _index_rows_on_find."""
+    mock_ml.lookup_workflow.return_value = _make_workflow_mock(rid="1-WF", name="MyPipeline")
+
+    captured: dict = {}
+
+    def fake_warm(hostname, catalog_id, token, rows, **kwargs):
+        captured["token"] = token
+        captured["rids"] = [r.get("rid") for r in rows]
+
+    # Lazy import in the tool binds to ``rag._index_rows_on_find`` at call
+    # time, so patch the name in its defining module.
+    with patch(
+        "deriva_ml_mcp_plugin.resources.rag._index_rows_on_find",
+        side_effect=fake_warm,
+    ):
+        await capturing_mcp.tools["deriva_ml_get_workflow"](
+            hostname="h", catalog_id="1", workflow_rid="1-WF"
+        )
+
+    from deriva_ml_mcp_plugin.resources.rag import _WORKFLOW_TOKEN
+
+    assert captured.get("token") == _WORKFLOW_TOKEN
+    assert captured.get("rids") == ["1-WF"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -157,6 +157,81 @@ async def test_list_workflows_sort_default_preserves_rid_sort(workflow_ctx, capt
     assert rids == ["1-A", "1-Z"]
 
 
+def test_list_workflows_impl_filters_by_workflow_type() -> None:
+    """``workflow_type=`` keeps only workflows whose type list contains it."""
+    from types import SimpleNamespace
+
+    from deriva_ml_mcp_plugin.tools.workflow import _list_workflows_impl
+
+    def _wf(rid, types):
+        return SimpleNamespace(
+            workflow_rid=rid,
+            name="w",
+            url="u",
+            checksum="c",
+            version="1",
+            workflow_type=types,
+            description="d",
+        )
+
+    fake_ml = SimpleNamespace(
+        find_workflows=lambda sort: [
+            _wf("1-TRN", ["Model_Training"]),
+            _wf("1-INF", ["Inference"]),
+        ]
+    )
+    resp = _list_workflows_impl(fake_ml, after_rid=None, limit=100, workflow_type="Model_Training")
+    assert [w.rid for w in resp.workflows] == ["1-TRN"]
+
+
+def test_list_workflows_impl_workflow_type_none_returns_all() -> None:
+    """No filter -> unchanged behavior (all workflows)."""
+    from types import SimpleNamespace
+
+    from deriva_ml_mcp_plugin.tools.workflow import _list_workflows_impl
+
+    def _wf(rid, types):
+        return SimpleNamespace(
+            workflow_rid=rid,
+            name="w",
+            url="u",
+            checksum="c",
+            version="1",
+            workflow_type=types,
+            description="d",
+        )
+
+    fake_ml = SimpleNamespace(
+        find_workflows=lambda sort: [
+            _wf("1-TRN", ["Model_Training"]),
+            _wf("1-INF", ["Inference"]),
+        ]
+    )
+    resp = _list_workflows_impl(fake_ml, after_rid=None, limit=100, workflow_type=None)
+    assert {w.rid for w in resp.workflows} == {"1-TRN", "1-INF"}
+
+
+async def test_list_workflows_tool_forwards_workflow_type(workflow_ctx, capturing_mcp, mock_ml):
+    """``deriva_ml_list_workflows(workflow_type=...)`` forwards the filter to the impl."""
+    from deriva_ml_mcp_plugin._response_models import WorkflowListResponse
+
+    seen: dict = {}
+
+    def spy(ml, **kwargs):
+        seen.update(kwargs)
+        return WorkflowListResponse(workflows=[], count=0, truncated=False, next_after_rid=None)
+
+    with patch(
+        "deriva_ml_mcp_plugin.tools.workflow._list_workflows_impl",
+        side_effect=spy,
+    ):
+        await capturing_mcp.tools["deriva_ml_list_workflows"](
+            hostname="h", catalog_id="1", workflow_type="Model_Training"
+        )
+
+    assert seen.get("workflow_type") == "Model_Training"
+
+
 # ---------------------------------------------------------------------------
 # get_workflow
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replaces **connect-time bulk indexing** of Dataset/Workflow/Execution rows with **read-through (index-on-find) indexing**, to cut per-connection startup overhead. Vocabulary stays bulk-indexed on connect (catalog-public, cheap); schema indexing is owned by `deriva-mcp-core` and untouched.

- **Removed** the three per-user on-connect bulk indexers (`_make_hook` + its `on_catalog_connect` registrations). The vocab hook is now the only `on_catalog_connect` hook this plugin registers.
- **Added** `_index_rows_on_find(hostname, catalog_id, table_token, rows)` — a fire-and-forget read-through warm helper (mirrors the `create_task` idiom in `deriva-mcp-core`'s `_on_catalog_access`). It warms each returned row's per-user `data:` RAG source so a later `rag_search` finds it.
- **Wired** that warm into the list + get tools for all three entities (dataset / workflow / execution). Rows now enter RAG read-through: surgically on create/mutate (existing `_reindex_*`) **and** on list/get/find (the new warm).
- **Added** client-side `dataset_type` / `workflow_type` membership filters to the dataset/workflow list impls + tools — a consistent structured-filter surface so type lookups ("find Training datasets") are deterministic instead of fuzzy, and to enable the hybrid filter-then-`rag_search` flow.
- **Kept** `deriva_ml_resync_indexes` (+ its `_resync_*` machinery and `ResyncIndexesResponse`) as the manual "warm everything for this catalog now" button.
- **Dropped** an initially-planned newest-first warm sort after review: it never fired (no summary model carries a record-creation timestamp) and "most recent = most relevant" is wrong for semantic find-before-create. The warm now indexes rows in the order the read returned them; callers wanting recent-first pass `sort=True` to the list.
- **Docs** updated to the new model: `CLAUDE.md`, the `register` docstring in `plugin.py`, the user-facing RAG description in `prompts.py`, and the `rag.py` module docstring.

### Behavior change
Datasets/Workflows/Executions are no longer `rag_search`-able purely from an on-connect bulk pass; they become searchable once listed/fetched (which warms them) or on mutation, or via `deriva_ml_resync_indexes`. They remain fully reachable via the `deriva://.../deriva-ml/...` resources and `deriva_ml_list_*`/`get_*` tools regardless.

### Follow-on (separate repo, not in this PR)
`deriva-skills` `semantic-awareness` should be updated to route structured finds (type/status/RID/URL) to deterministic `find_*`/`list_*` and reserve `rag_search` for free-text — and to do the list/find warm step before leaning on `rag_search` for data rows.

Design spec and implementation plan are included under `docs/superpowers/`.

## Test Plan
- [x] Unit suite: `uv run pytest -q` → **369 passed**
- [x] Integration suite (live demo catalog): `uv run pytest -m integration` → **20 passed**
- [x] Lint/format: `uv run ruff check src tests` clean; `ruff format --check` clean
- [x] Per-task spec + code-quality review on every commit; final whole-implementation review (resync path intact, no orphaned/dead code, docs match code)
- [ ] Reviewer: confirm the read-through trade-off (rows searchable after first list/get rather than on connect) is acceptable for the target deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)