### PR TITLE
feat(resolve): deriva_ml_describe_rid — step 0 for bare-RID questions

### DIFF
--- a/src/deriva_ml_mcp_plugin/_response_models.py
+++ b/src/deriva_ml_mcp_plugin/_response_models.py
@@ -1447,3 +1447,31 @@ class AddDatasetElementTypeResponse(BaseModel):
 # docs/superpowers/notes/2026-05-23-cache-denormalize-deprecation-design.md).
 # Bag materialization is now a user-local Python operation; the
 # response models are no longer needed.
+
+
+class DescribeRidResponse(BaseModel):
+    """Response shape for ``deriva_ml_describe_rid``.
+
+    The "step 0" answer for a bare RID of unknown type: where it lives
+    (schema, table), which DerivaML abstraction it is, and what to call
+    next. ``resource_uri`` carries the matching ``ml/<kind>/{rid}``
+    resource for the kinds that have one (dataset / workflow /
+    execution / asset) and is ``None`` otherwise.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    rid: str
+    schema_: str = Field(alias="schema")
+    table: str
+    kind: Literal[
+        "dataset",
+        "workflow",
+        "execution",
+        "vocabulary_term",
+        "asset",
+        "association",
+        "entity",
+    ]
+    suggestion: str
+    resource_uri: str | None = None

--- a/src/deriva_ml_mcp_plugin/plugin.py
+++ b/src/deriva_ml_mcp_plugin/plugin.py
@@ -27,6 +27,7 @@ from deriva_ml_mcp_plugin.tools import dataset as _dataset
 from deriva_ml_mcp_plugin.tools import execution as _execution
 from deriva_ml_mcp_plugin.tools import feature as _feature
 from deriva_ml_mcp_plugin.tools import maintenance as _maintenance
+from deriva_ml_mcp_plugin.tools import resolve as _resolve
 from deriva_ml_mcp_plugin.tools import vocabulary as _vocabulary
 from deriva_ml_mcp_plugin.tools import workflow as _workflow
 
@@ -90,6 +91,7 @@ def register(ctx: PluginContext) -> None:
     _asset.register(ctx)
     _vocabulary.register(ctx)
     _maintenance.register(ctx)
+    _resolve.register(ctx)
     _ml_resources.register(ctx)
     _ml_rag.register_rag_sources(ctx)
     _ml_prompts.register(ctx)

--- a/src/deriva_ml_mcp_plugin/prompts.py
+++ b/src/deriva_ml_mcp_plugin/prompts.py
@@ -677,10 +677,12 @@ you're driving the library directly from a notebook or skill.
 
 THE FIVE ML DOMAINS
 -------------------
-Forty-one of the 44 tools are organized into five domain modules (the
-other three are the catalog-maintenance tools
+Forty-one of the 45 tools are organized into five domain modules (the
+other four are the catalog-maintenance tools
 ``deriva_ml_create_vocabulary``, ``deriva_ml_reindex_vocabularies``,
-and ``deriva_ml_resync_indexes``). Pick the domain first, then the
+``deriva_ml_resync_indexes``, and the cross-domain
+``deriva_ml_describe_rid`` -- resolve a bare RID to its table and the
+right next tool). Pick the domain first, then the
 verb. All actual tool names are prefixed
 ``deriva_ml_<verb>`` (e.g. the ``create`` verb under ``dataset`` is
 the ``deriva_ml_create_dataset`` tool). The bare verbs below name the
@@ -928,6 +930,14 @@ duration / inputs / outputs), which datasets a run consumed or
 produced, asset provenance, a lineage walk, dataset membership --
 recognize the pattern EARLY and run this escalation ladder. Do not
 start at step 3.
+
+0. UNKNOWN RID? DESCRIBE IT FIRST. If the user hands you a bare RID
+   and you don't know what it identifies, call
+   ``deriva_ml_describe_rid(hostname, catalog_id, rid)`` -- one call
+   resolves it catalog-wide, classifies it (dataset / workflow /
+   execution / vocabulary_term / asset / association / entity), and
+   names the right next tool. Do NOT guess by trying get_dataset then
+   get_execution in turn, and do not schema-spelunk to find the table.
 
 1. TYPED DERIVA-ML SURFACE FIRST. If your client reads MCP resources,
    the ``ml/<kind>/{rid}`` resource is the preferred one-fetch form for
@@ -1268,9 +1278,10 @@ and ``description``. There is no compat shim; update any references.
 
 THE MENU
 --------
-Quick orientation: 44 tools -- 41 across the 5 ML domains (dataset,
+Quick orientation: 45 tools -- 41 across the 5 ML domains (dataset,
 feature, workflow, execution, asset) plus 3 catalog-maintenance tools
-(create_vocabulary, reindex_vocabularies, resync_indexes) -- + 18
+(create_vocabulary, reindex_vocabularies, resync_indexes) plus the
+cross-domain describe_rid -- + 18
 read-only resources under the
 ``deriva://catalog/{h}/{c}/deriva-ml/...`` URI prefix + 1 GitHub doc source
 indexed for RAG (``deriva-ml-docs``) + per-user RAG indexes that

--- a/src/deriva_ml_mcp_plugin/tools/resolve.py
+++ b/src/deriva_ml_mcp_plugin/tools/resolve.py
@@ -1,0 +1,192 @@
+"""RID description tool: resolve a bare RID and route to the right surface.
+
+``deriva_ml_describe_rid`` is "step 0" of the ordered query strategy in
+``deriva_ml_getting_started``: given a RID of unknown type, resolve it
+to its (schema, table) via ERMrest's catalog-wide RID resolution
+(``DerivaML.resolve_rid``), classify it into the DerivaML abstractions,
+and name the typed tool / resource to call next. This replaces the
+try-``get_dataset``-then-``get_execution`` guessing an LLM otherwise
+does with a bare RID.
+
+RID resolution itself is a GENERIC Deriva primitive (an ERMrest
+feature surfaced by deriva-py's ``ErmrestCatalog.resolve_rid``), so the
+plain resolve belongs in deriva-mcp-core per the boundary rules --
+tracked upstream as a core issue. This tool is the ML-domain value-add
+on top: the classification into the five abstractions and the
+next-tool routing. When core ships its generic ``resolve_rid``, this
+tool keeps its classification layer and can delegate the resolve.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from deriva_mcp_core import deriva_call
+
+from deriva_ml_mcp_plugin._helpers import _error_envelope
+from deriva_ml_mcp_plugin._response_models import DescribeRidResponse
+from deriva_ml_mcp_plugin.ml_context import get_ml
+
+if TYPE_CHECKING:
+    from deriva_mcp_core.plugin.api import PluginContext
+
+
+def _classify(ml, table) -> tuple[str, str, str | None]:
+    """Classify a resolved table into a DerivaML kind + routing suggestion.
+
+    Args:
+        ml: A connected ``deriva_ml.DerivaML`` instance (consulted for
+            ``ml_schema`` and the ``model.is_*`` classifiers).
+        table: The ermrest ``Table`` object from ``resolve_rid``.
+
+    Returns:
+        ``(kind, suggestion, resource_uri_suffix)`` where the suffix is
+        the ``deriva-ml/...`` resource path tail for kinds that have a
+        per-RID resource (``None`` otherwise; the caller prepends the
+        catalog prefix and appends the RID).
+    """
+    tname = table.name
+    sname = table.schema.name
+    if sname == ml.ml_schema and tname == "Dataset":
+        return (
+            "dataset",
+            "Call deriva_ml_get_dataset(rid) for summary + version history; "
+            "deriva_ml_list_dataset_members(rid) for contents; "
+            "deriva_ml_get_lineage(rid) for provenance.",
+            "dataset",
+        )
+    if sname == ml.ml_schema and tname == "Workflow":
+        return (
+            "workflow",
+            "Call deriva_ml_get_workflow(rid) for detail; "
+            "deriva_ml_find_workflow_executions(rid) for its runs.",
+            "workflow",
+        )
+    if sname == ml.ml_schema and tname == "Execution":
+        return (
+            "execution",
+            "Call deriva_ml_get_execution(rid) for status/detail, then chain "
+            "deriva_ml_get_lineage(rid) for consumed/produced artifacts.",
+            "execution",
+        )
+    if ml.model.is_vocabulary(table):
+        return (
+            "vocabulary_term",
+            f"This RID is a term in the {sname}.{tname} vocabulary. Use core's "
+            "lookup_term / the vocabularies resource for term detail.",
+            None,
+        )
+    if ml.model.is_asset(table):
+        return (
+            "asset",
+            "Call deriva_ml_lookup_asset(rid) for metadata + download URL; "
+            "deriva_ml_get_lineage(rid) for the producing execution.",
+            "asset",
+        )
+    if ml.model.is_association(table):
+        return (
+            "association",
+            f"This RID is a link row in {sname}.{tname}. If it is a feature-values "
+            "table, query it via deriva_ml_list_feature_values (selectors pick the "
+            "annotation layer); otherwise deriva_ml_get_lineage on the linked "
+            "entity RIDs.",
+            None,
+        )
+    return (
+        "entity",
+        f"This RID is a domain row in {sname}.{tname}. deriva_ml_get_lineage(rid) "
+        "walks its provenance if it is dataset/execution-linked; generic catalog "
+        "tools (get_entities / query_attribute) read the row itself.",
+        None,
+    )
+
+
+def register(ctx: PluginContext) -> None:
+    """Register the RID description tool with the plugin context.
+
+    Args:
+        ctx: PluginContext supplied by deriva-mcp-core at startup.
+
+    Returns:
+        None.
+
+    Example:
+        >>> from deriva_mcp_core.plugin.api import PluginContext
+        >>> # ctx provided by the framework
+        >>> register(ctx)  # doctest: +SKIP
+    """
+
+    @ctx.tool(mutates=False)
+    async def deriva_ml_describe_rid(
+        hostname: str,
+        catalog_id: str,
+        rid: str,
+    ) -> str:
+        """Describe a RID: which table it lives in, what kind of thing it is, what to call next.
+
+        STEP 0 of the ordered query strategy (see
+        ``deriva_ml_getting_started``): when the user hands you a bare
+        RID and you don't know what it identifies, call this FIRST --
+        do not guess by trying deriva_ml_get_dataset /
+        deriva_ml_get_execution in turn, and do not go schema-spelunking.
+        One call resolves the RID catalog-wide (ERMrest RID resolution),
+        classifies it (dataset / workflow / execution / vocabulary_term /
+        asset / association / entity), and names the right next tool.
+
+        Args:
+            rid: The RID to describe (e.g. ``"1-ABCD"``). Any table,
+                any schema.
+
+        Returns:
+            JSON string: ``{"rid", "schema", "table", "kind",
+            "suggestion", "resource_uri"}``. ``resource_uri`` is the
+            matching ``deriva://catalog/.../deriva-ml/<kind>/{rid}``
+            resource for dataset / workflow / execution / asset RIDs,
+            else ``null``.
+
+        Raises:
+            RuntimeError: Wrapped as ``{"error": ...}`` -- propagated
+                from ``DerivaML.resolve_rid`` when the RID does not
+                exist in the catalog.
+
+        Example:
+            ``{"rid": "1-ABCD", "schema": "deriva-ml",
+            "table": "Execution", "kind": "execution",
+            "suggestion": "Call deriva_ml_get_execution(rid)...",
+            "resource_uri":
+            "deriva://catalog/h/1/deriva-ml/execution/1-ABCD"}``.
+        """
+        try:
+            with deriva_call():
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                # resolve_rid + the model classifiers are synchronous
+                # deriva-py/deriva-ml catalog I/O; run the whole
+                # resolve-and-classify in a worker thread.
+
+                def _resolve_and_classify():
+                    result = ml.resolve_rid(rid)
+                    return result.table, _classify(ml, result.table)
+
+                table, (kind, suggestion, uri_kind) = await asyncio.to_thread(_resolve_and_classify)
+            resource_uri = (
+                f"deriva://catalog/{hostname}/{catalog_id}/deriva-ml/{uri_kind}/{rid}"
+                if uri_kind
+                else None
+            )
+            return DescribeRidResponse(
+                rid=rid,
+                schema_=table.schema.name,
+                table=table.name,
+                kind=kind,
+                suggestion=suggestion,
+                resource_uri=resource_uri,
+            ).model_dump_json(by_alias=True)
+        except Exception as exc:
+            return _error_envelope(
+                exc,
+                operation="describe_rid",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,  # pure read
+            )

--- a/tests/test_async_thread_wrap.py
+++ b/tests/test_async_thread_wrap.py
@@ -48,6 +48,7 @@ TOOL_MODULES: list[Path] = [
     TOOLS_ROOT / "dataset" / "mutate.py",
     TOOLS_ROOT / "dataset" / "complex.py",
     TOOLS_ROOT / "execution" / "read.py",
+    TOOLS_ROOT / "resolve.py",
     # NOTE: execution/mutate.py was removed in v0.5.0 -- the execution
     # lifecycle moved to user-local Python per the stateless rule.
     # See docs/audit-2026-05-23.md.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -138,6 +138,17 @@ _VOCABULARY_TOOLS = frozenset(
     }
 )
 
+# Cross-domain RID description tool (tools/resolve.py): "step 0" of the
+# ordered query strategy -- resolve a bare RID catalog-wide, classify it
+# into the DerivaML abstractions, route to the right typed tool. The
+# generic resolve primitive is tracked upstream (deriva-mcp-core); this
+# tool owns the ML classification layer.
+_RESOLVE_TOOLS = frozenset(
+    {
+        "deriva_ml_describe_rid",
+    }
+)
+
 # Orientation tools registered by ``prompts.py`` (not part of the five ML
 # domains). ``deriva_ml_primer`` returns the startup primer body; it is the
 # tool-shaped counterpart of the ``deriva_ml_primer`` prompt, for agents that
@@ -162,6 +173,7 @@ _ALL_REGISTERED_TOOLS = (
     | _EXECUTION_TOOLS
     | _VOCABULARY_TOOLS
     | _ASSET_TOOLS
+    | _RESOLVE_TOOLS
     | _PRIMER_TOOLS
 )
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,0 +1,184 @@
+"""Unit tests for the deriva_ml_describe_rid tool (tools/resolve.py).
+
+``deriva_ml_describe_rid`` is the "step 0" of the ordered query
+strategy: given a bare RID of unknown type, resolve it to its
+(schema, table), classify it into the DerivaML abstractions, and
+suggest the right typed tool / resource to call next -- replacing the
+try-get_dataset-then-get_execution guessing an LLM otherwise does.
+
+All tests are fully mocked: ``get_ml`` is patched at the module's
+import site and the fake DerivaML exposes ``resolve_rid`` plus the
+``model.is_vocabulary`` / ``model.is_asset`` / ``model.is_association``
+classifiers the tool consults.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def resolve_ctx(ctx):
+    """Register the resolve tools on a fresh PluginContext."""
+    from deriva_ml_mcp_plugin.tools import resolve as resolve_module
+
+    resolve_module.register(ctx)
+    return ctx
+
+
+def _fake_ml(
+    *,
+    table_name: str,
+    schema_name: str,
+    ml_schema: str = "deriva-ml",
+    is_vocabulary: bool = False,
+    is_asset: bool = False,
+    is_association: bool = False,
+):
+    """Build a fake DerivaML whose resolve_rid lands in (schema, table)."""
+    ml = MagicMock()
+    ml.ml_schema = ml_schema
+    table = MagicMock()
+    table.name = table_name
+    table.schema.name = schema_name
+    result = MagicMock()
+    result.table = table
+    ml.resolve_rid.return_value = result
+    ml.model.is_vocabulary.return_value = is_vocabulary
+    ml.model.is_asset.return_value = is_asset
+    ml.model.is_association.return_value = is_association
+    return ml
+
+
+async def _describe(capturing_mcp, fake_ml, rid="1-ABCD"):
+    from deriva_ml_mcp_plugin.tools import resolve as resolve_module
+
+    with patch.object(resolve_module, "get_ml", return_value=fake_ml):
+        raw = await capturing_mcp.tools["deriva_ml_describe_rid"](
+            hostname="h.example", catalog_id="1", rid=rid
+        )
+    return json.loads(raw)
+
+
+async def test_describe_rid_classifies_dataset(resolve_ctx, capturing_mcp):
+    """A RID in the ML schema's Dataset table classifies as kind=dataset."""
+    payload = await _describe(
+        capturing_mcp, _fake_ml(table_name="Dataset", schema_name="deriva-ml")
+    )
+    assert payload["rid"] == "1-ABCD"
+    assert payload["schema"] == "deriva-ml"
+    assert payload["table"] == "Dataset"
+    assert payload["kind"] == "dataset"
+    assert "deriva_ml_get_dataset" in payload["suggestion"]
+    assert payload["resource_uri"].endswith("/deriva-ml/dataset/1-ABCD")
+
+
+async def test_describe_rid_classifies_execution_with_lineage_chain(resolve_ctx, capturing_mcp):
+    """An Execution RID suggests get_execution AND the lineage chain."""
+    payload = await _describe(
+        capturing_mcp, _fake_ml(table_name="Execution", schema_name="deriva-ml")
+    )
+    assert payload["kind"] == "execution"
+    assert "deriva_ml_get_execution" in payload["suggestion"]
+    assert "deriva_ml_get_lineage" in payload["suggestion"]
+    assert payload["resource_uri"].endswith("/deriva-ml/execution/1-ABCD")
+
+
+async def test_describe_rid_classifies_workflow(resolve_ctx, capturing_mcp):
+    """A Workflow RID suggests get_workflow."""
+    payload = await _describe(
+        capturing_mcp, _fake_ml(table_name="Workflow", schema_name="deriva-ml")
+    )
+    assert payload["kind"] == "workflow"
+    assert "deriva_ml_get_workflow" in payload["suggestion"]
+    assert payload["resource_uri"].endswith("/deriva-ml/workflow/1-ABCD")
+
+
+async def test_describe_rid_classifies_vocabulary_term(resolve_ctx, capturing_mcp):
+    """A RID in a vocabulary table classifies as a term, not a dataset."""
+    payload = await _describe(
+        capturing_mcp,
+        _fake_ml(table_name="Diagnosis_Tag", schema_name="eye-ai", is_vocabulary=True),
+    )
+    assert payload["kind"] == "vocabulary_term"
+    assert payload["table"] == "Diagnosis_Tag"
+    assert payload["resource_uri"] is None
+
+
+async def test_describe_rid_classifies_asset(resolve_ctx, capturing_mcp):
+    """A RID in an asset table suggests lookup_asset + lineage."""
+    payload = await _describe(
+        capturing_mcp,
+        _fake_ml(table_name="Model_Artifact", schema_name="eye-ai", is_asset=True),
+    )
+    assert payload["kind"] == "asset"
+    assert "deriva_ml_lookup_asset" in payload["suggestion"]
+    assert "deriva_ml_get_lineage" in payload["suggestion"]
+    assert payload["resource_uri"].endswith("/deriva-ml/asset/1-ABCD")
+
+
+async def test_describe_rid_classifies_association(resolve_ctx, capturing_mcp):
+    """A RID in an association table is named as such (possible feature values)."""
+    payload = await _describe(
+        capturing_mcp,
+        _fake_ml(table_name="Image_Diagnosis", schema_name="eye-ai", is_association=True),
+    )
+    assert payload["kind"] == "association"
+    assert "deriva_ml_list_feature_values" in payload["suggestion"]
+    assert payload["resource_uri"] is None
+
+
+async def test_describe_rid_classifies_domain_entity(resolve_ctx, capturing_mcp):
+    """A plain domain-table RID falls through to kind=entity with generic guidance."""
+    payload = await _describe(capturing_mcp, _fake_ml(table_name="Image", schema_name="eye-ai"))
+    assert payload["kind"] == "entity"
+    assert "deriva_ml_get_lineage" in payload["suggestion"]
+    assert payload["resource_uri"] is None
+
+
+async def test_describe_rid_invalid_rid_returns_error_envelope(resolve_ctx, capturing_mcp):
+    """An unresolvable RID returns {"error": ...} without raising."""
+    from deriva_ml_mcp_plugin.tools import resolve as resolve_module
+
+    ml = MagicMock()
+    ml.resolve_rid.side_effect = RuntimeError("Invalid RID 9-NOPE")
+    with patch.object(resolve_module, "get_ml", return_value=ml):
+        raw = await capturing_mcp.tools["deriva_ml_describe_rid"](
+            hostname="h.example", catalog_id="1", rid="9-NOPE"
+        )
+    payload = json.loads(raw)
+    assert "error" in payload
+    assert "9-NOPE" in payload["error"]
+
+
+def test_describe_rid_registered_read_only(ctx):
+    """describe_rid is mutates=False (pure read; no audit on success).
+
+    ``PluginContext.tool`` strips ``mutates`` before forwarding to
+    FastMCP, so we wrap ``ctx.tool`` to capture the declared value --
+    same pattern as test_plugin.py's plugin-wide mutates check.
+    """
+    from deriva_ml_mcp_plugin.tools import resolve as resolve_module
+
+    seen: dict[str, bool] = {}
+    original_tool = ctx.tool
+
+    def capturing_tool(*args, mutates, **kwargs):
+        decorator = original_tool(*args, mutates=mutates, **kwargs)
+
+        def wrapper(fn):
+            seen[fn.__name__] = mutates
+            return decorator(fn)
+
+        return wrapper
+
+    ctx.tool = capturing_tool
+    try:
+        resolve_module.register(ctx)
+    finally:
+        ctx.tool = original_tool
+
+    assert seen == {"deriva_ml_describe_rid": False}


### PR DESCRIPTION
## Problem

An LLM handed a bare RID of unknown type has no way to ask "what is this?" — observed behavior is guessing (`get_dataset` → error → `get_execution` → …) or schema-spelunking. ERMrest has catalog-wide RID resolution and deriva-ml surfaces it (`DerivaML.resolve_rid`), but no MCP tool exposed it.

## Change

New cross-domain tool **`deriva_ml_describe_rid(hostname, catalog_id, rid)`**:
- resolves the RID to its (schema, table) via ERMrest RID resolution;
- classifies it into the DerivaML abstractions — `dataset / workflow / execution / vocabulary_term / asset / association / entity` (ml-schema match + `model.is_vocabulary` / `is_asset` / `is_association`);
- returns a routing `suggestion` naming the right next tool, plus the matching `ml/<kind>/{rid}` resource URI where one exists.

Wired into the ordered query strategy (#72) as **step 0**: "unknown RID? describe it first — don't guess."

## Boundary note

The plain resolve is a **generic Deriva primitive** and belongs in deriva-mcp-core per the boundary rules — companion core issue filed. This tool owns the ML classification + routing layer and can delegate the resolve once core ships it.

## Verification

- 9 new tests (per-kind classification, error envelope, `mutates=False` registration) — **387 total pass**.
- Tool pinned in `test_plugin.py`'s exact-equality frozensets; `resolve.py` added to the async-thread-wrap structural check; prompt tool counts updated (44 → 45).
- New `DescribeRidResponse` Pydantic model (`extra="forbid"`).
- New tool ⇒ warrants a **minor** version bump (`0.6.x` → `0.7.0`) on merge per the versioning convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)