### PR TITLE
Review sweep: prompt/docstring accuracy, tiered primer, machine-readable error_type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,20 +23,25 @@ src/deriva_ml_mcp_plugin/
 ├── ml_context.py        # The single helper that builds a DerivaML from core's credential
 ├── _helpers.py          # _error_envelope, _paginate, _read_rid, _table_qname,
 │                        # _table_to_dict, _MAX_LIMIT (shared)
-├── prompts.py           # 3 MCP prompts: deriva_ml_getting_started /
-│                        #   _execution_lifecycle / _workflow_dedup
-├── tools/               # Per-domain tool modules (40 tools across 5 domains)
-│   ├── dataset/         #   17 tools, split into focused submodules:
+├── prompts.py           # 3 MCP prompts (deriva_ml_concepts /
+│                        #   _getting_started / _primer) + the
+│                        #   deriva_ml_primer + get_guide orientation tools
+├── tools/               # Per-domain tool modules (47 tools total)
+│   ├── dataset/         #   19 tools, split into focused submodules:
 │   │   ├── __init__.py  #     register aggregator + helper re-exports
-│   │   ├── read.py      #     7 read tools + 4 shared helpers
-│   │   ├── mutate.py    #     7 simple mutation tools
-│   │   └── complex.py   #     3 complex tools (cache, denormalize, split)
-│   ├── feature.py       #    6 tools
+│   │   ├── read.py      #     11 read tools + shared helpers
+│   │   ├── mutate.py    #     7 mutation tools
+│   │   └── complex.py   #     1 complex tool (denormalize)
+│   ├── feature.py       #    5 tools
 │   ├── workflow.py      #    5 tools
-│   ├── execution.py     #   11 tools
-│   └── vocabulary.py    #    1 tool (deriva_ml_reindex_vocabularies)
+│   ├── execution/       #    8 read-only tools (lifecycle is local Python)
+│   ├── asset.py         #    4 tools
+│   ├── vocabulary.py    #    1 tool (deriva_ml_create_vocabulary)
+│   ├── maintenance.py   #    2 tools (reindex_vocabularies, resync_indexes)
+│   └── resolve.py       #    1 tool (deriva_ml_describe_rid -- RID -> kind + routing)
 └── resources/           # MCP resources + per-user RAG
-    ├── ml.py            #   9 read-only resources under deriva://catalog/{h}/{c}/ml/...
+    ├── ml.py            #   19 resources (16 catalog-scoped under
+    │                    #   deriva://catalog/{h}/{c}/deriva-ml/... + 3 static)
     └── rag.py           #   1 GitHub doc source +
                          #   read-through per-user-per-RID writers (Dataset/Workflow/Execution,
                          #   warmed on list/get/find + surgically on mutate; no on-connect pass)

--- a/src/deriva_ml_mcp_plugin/_helpers.py
+++ b/src/deriva_ml_mcp_plugin/_helpers.py
@@ -89,8 +89,10 @@ def _error_envelope(
             ``audit=False``.
 
     Returns:
-        JSON string. Default shape is ``{"error": str(exc)}``; with
-        ``response_fields`` it becomes ``{"error": ..., **response_fields}``.
+        JSON string. Default shape is ``{"error": str(exc),
+        "error_type": type(exc).__name__}``; with ``response_fields``
+        it becomes ``{"error": ..., "error_type": ...,
+        **response_fields}``.
 
     Example (illustrative -- runs only inside an except block):
         >>> # return _error_envelope(exc, operation="create_dataset",
@@ -111,7 +113,10 @@ def _error_envelope(
             error_type=type(exc).__name__,
             **audit_fields,
         )
-    payload: dict[str, Any] = {"error": str(exc)}
+    # error_type gives LLM callers a machine-readable discriminator
+    # (not-found vs permission vs validation) without parsing the
+    # human-oriented message; same value the audit row already carries.
+    payload: dict[str, Any] = {"error": str(exc), "error_type": type(exc).__name__}
     if response_fields:
         payload.update(response_fields)
     # Structured-error uplift (audit T2.3): when the underlying

--- a/src/deriva_ml_mcp_plugin/_response_models.py
+++ b/src/deriva_ml_mcp_plugin/_response_models.py
@@ -666,37 +666,6 @@ class FeatureSummary(BaseModel):
     value_columns: list[str]
 
 
-class FeatureColumnSpec(BaseModel):
-    """One column on a Feature's detail view."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    name: str
-    type: str
-    nullok: bool
-    vocabulary: str | None = None
-    asset_table: str | None = None
-
-
-class FeatureDetail(BaseModel):
-    """Full Feature detail with column specs. Produced by feature get tools.
-
-    Note: this is NOT a subclass of FeatureSummary because the
-    ``*_columns`` fields change type (list[str] in Summary,
-    list[FeatureColumnSpec] in Detail).
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    feature_name: str
-    target_table: str
-    feature_table: str
-    term_columns: list[FeatureColumnSpec]
-    asset_columns: list[FeatureColumnSpec]
-    value_columns: list[FeatureColumnSpec]
-    required_fields: list[str]
-
-
 class FeatureListResponse(_PaginationFields):
     """Paginated list of Features. Produced by ``_list_features_impl``."""
 

--- a/src/deriva_ml_mcp_plugin/prompts.py
+++ b/src/deriva_ml_mcp_plugin/prompts.py
@@ -4,7 +4,7 @@ These are MCP prompts (registered via ``@ctx.prompt(...)``), not Python
 docstrings. FastMCP surfaces them through the MCP ``prompts/list`` and
 ``prompts/get`` endpoints so an LLM client can pull them up by name at
 the start of a conversation -- they are the cold-start anchor for the
-plugin's 44 tools and 18 resources.
+plugin's 47 tools and 19 resources.
 
 The two prompts complement the four built-in core prompts shipped by
 ``deriva-mcp-core`` (``query_guide``, ``entity_guide``,
@@ -194,7 +194,7 @@ DERIVA-ML DOMAIN OBJECTS, NOT AS RAW TABLES.
              access to the user's local filesystem). Use
              ``deriva_ml_list_assets``, ``deriva_ml_lookup_asset``,
              ``deriva_ml_update_asset``. Browse asset tables by schema
-             via the ``ml/assets/{schema}`` resource. For asset bytes, hand off to
+             via the ``deriva-ml/assets/{schema}`` resource. For asset bytes, hand off to
              local Python via the user's environment (``ml.download_asset``,
              ``exe.asset_file_path()``).
 
@@ -677,13 +677,14 @@ you're driving the library directly from a notebook or skill.
 
 THE FIVE ML DOMAINS
 -------------------
-Forty-one of the 45 tools are organized into five domain modules (the
-other four are the catalog-maintenance tools
+Forty-one of the 47 tools are organized into five domain modules. The
+other six: the catalog-maintenance tools
 ``deriva_ml_create_vocabulary``, ``deriva_ml_reindex_vocabularies``,
-``deriva_ml_resync_indexes``, and the cross-domain
-``deriva_ml_describe_rid`` -- resolve a bare RID to its table and the
-right next tool). Pick the domain first, then the
-verb. All actual tool names are prefixed
+``deriva_ml_resync_indexes``; the cross-domain
+``deriva_ml_describe_rid`` (resolve a bare RID to its table and the
+right next tool); and the orientation pair ``deriva_ml_primer`` /
+``get_guide`` (static text, no catalog I/O). Pick the domain first,
+then the verb. All actual tool names are prefixed
 ``deriva_ml_<verb>`` (e.g. the ``create`` verb under ``dataset`` is
 the ``deriva_ml_create_dataset`` tool). The bare verbs below name the
 concept; prepend ``deriva_ml_`` (and append the noun where natural)
@@ -741,7 +742,7 @@ for the wire name.
                   doc_type="ml-docs")`` (user-guide/assets.md). Verbs:
                   list_assets / find_assets / lookup / update. For "what
                   asset tables exist in a schema?" use the
-                  ml/assets/{schema} resource (no dedicated tool).
+                  deriva-ml/assets/{schema} resource (no dedicated tool).
 
 READ-SIDE QUESTIONS: FETCH THE RESOURCE FIRST
 ---------------------------------------------
@@ -763,8 +764,8 @@ ANTI-PATTERN (resource-capable clients): do NOT call
 ``deriva_ml_get_execution`` (or ``deriva_ml_get_dataset``, etc.) when
 you already have the RID, want the entity's full state, and your client
 can fetch MCP resources. Those tools return a thinner record and force
-follow-up calls; the ``ml/<kind>/{rid}`` resource is the one-fetch
-answer. If your client cannot read resources, the tools ARE the right
+follow-up calls; the ``deriva-ml/<kind>/{rid}`` resource is the
+one-fetch answer. If your client cannot read resources, the tools ARE the right
 surface -- follow the ORDERED STRATEGY ladder below (typed deriva-ml
 tools, chained; generic catalog tools only as the gated fallback).
 
@@ -909,12 +910,17 @@ COMMON TASKS -> WHERE TO LOOK
     Intent                         Tools / route
     ------------------------------ --------------------------------------------
     "what's in this catalog?"      rag_search(doc_type="catalog-schema" |
-                                   "catalog-data"); ml/datasets, ml/workflows
-                                   resources
+                                   "catalog-data"); the deriva-ml/datasets and
+                                   deriva-ml/workflows resources
     "set up / run an experiment"   create_workflow (MCP) -> local Python
                                    execution; rag_search "execution lifecycle"
     "organize data for ML"         create_dataset, add_dataset_members,
-                                   split_dataset, release; rag_search "datasets"
+                                   release; splitting is local Python --
+                                   rag_search "split dataset"
+    "compare metrics across runs"  find_experiments / list_feature_values(
+                                   execution_rids=[...]) for features-as-
+                                   scalars; metrics-as-JSONL assets download
+                                   in local Python
     "label / score records"        create_feature (MCP) + exe.add_features
                                    (local); rag_search "features"
     "upload / fetch a file"        exe.asset_file_path / exe.download_asset
@@ -940,8 +946,8 @@ start at step 3.
    get_execution in turn, and do not schema-spelunk to find the table.
 
 1. TYPED DERIVA-ML SURFACE FIRST. If your client reads MCP resources,
-   the ``ml/<kind>/{rid}`` resource is the preferred one-fetch form for
-   a known-RID detail question (it bundles the entity plus its children
+   the ``deriva-ml/<kind>/{rid}`` resource is the preferred one-fetch
+   form for a known-RID detail question (it bundles the entity plus its children
    -- see READ-SIDE QUESTIONS above); the tools below are the same data
    for tool-only clients and for filtered / paginated questions the
    resources don't express. Either way, the typed deriva-ml surface
@@ -1278,20 +1284,19 @@ and ``description``. There is no compat shim; update any references.
 
 THE MENU
 --------
-Quick orientation: 45 tools -- 41 across the 5 ML domains (dataset,
+Quick orientation: 47 tools -- 41 across the 5 ML domains (dataset,
 feature, workflow, execution, asset) plus 3 catalog-maintenance tools
-(create_vocabulary, reindex_vocabularies, resync_indexes) plus the
-cross-domain describe_rid -- + 18
-read-only resources under the
-``deriva://catalog/{h}/{c}/deriva-ml/...`` URI prefix + 1 GitHub doc source
-indexed for RAG (``deriva-ml-docs``) + per-user RAG indexes that
+(create_vocabulary, reindex_vocabularies, resync_indexes), the
+cross-domain describe_rid, and the orientation pair (primer,
+get_guide) -- + 19 read-only resources (16 catalog-scoped under the
+``deriva://catalog/{h}/{c}/deriva-ml/...`` URI prefix + 3 static
+cold-start) + GitHub doc sources indexed for RAG (``deriva-ml-docs``,
+``deriva-ml-mcp-plugin-docs``) + per-user RAG indexes that
 ingest Dataset / Workflow / Execution rows read-through (warmed when
 you list/get them, surgically refreshed on mutation -- not on
-connect). Plus 4 built-in core prompts and 2 ML prompts: this one
-(``deriva_ml_getting_started``) and ``deriva_ml_concepts``. (v3.x
-removed two earlier prompts, ``deriva_ml_execution_lifecycle`` and
-``deriva_ml_workflow_dedup``, and redistributed their content to the
-relevant tool docstrings and RAG-indexed docs.)
+connect). Plus 4 built-in core prompts and 3 ML prompts: this one
+(``deriva_ml_getting_started``), ``deriva_ml_concepts``, and
+``deriva_ml_primer`` (the compact operating contract).
 """
 
 
@@ -1306,11 +1311,89 @@ relevant tool docstrings and RAG-indexed docs.)
 # prompts at runtime without reaching into core internals; the names are
 # stable public API. The drift-guard test lives in test_prompts.py.
 _GUIDE_MANIFEST: list[tuple[str, str, str]] = [
+    (
+        "deriva_ml_concepts",
+        "deriva-ml",
+        "full conceptual frame: the five abstractions in depth, provenance "
+        "principle, vocabulary-extension pattern, inheritance-with-override",
+    ),
+    (
+        "deriva_ml_getting_started",
+        "deriva-ml",
+        "full operational guide: pagination contract, query-strategy ladder "
+        "+ anti-patterns, common-task routing, RID discipline, curation "
+        "patterns, index freshness",
+    ),
     ("query_guide", "core", "ERMrest query and path syntax, pagination, result interpretation"),
     ("entity_guide", "core", "entity CRUD, preflight count rule, display rules"),
     ("annotation_guide", "core", "Chaise annotation patterns, context names, templates"),
     ("catalog_guide", "core", "catalog create/clone/alias, snaptime format, history"),
 ]
+
+
+# Compact operating contract returned by the primer. This is the
+# load-bearing subset a cold-start client must see WITHOUT fetching
+# anything (the tiering decision from the 2026-06-12 review: the old
+# primer concatenated both full guides, ~17K tokens; the full texts are
+# now on-demand via get_guide and listed in the manifest).
+_PRIMER_CONTRACT = """\
+WHAT THIS IS. DerivaML runs reproducible ML workflows on Deriva
+catalogs. Five abstractions, all carrying RIDs (permanent record IDs):
+
+  Dataset    -- versioned, curated bundle of catalog rows (training
+                sets, splits). Versions are immutable once released.
+  Workflow   -- registered runnable artifact (script + Git URL +
+                checksum). Deduplicated by URL/checksum.
+  Execution  -- one run of a Workflow against Datasets/Assets. The
+                provenance hub: every artifact links to its producing
+                Execution.
+  Feature    -- typed per-row annotation (label/score/asset) on a
+                target table, written with execution provenance.
+  Asset      -- file-backed catalog row (images, model weights) with
+                checksummed object-store storage.
+
+CALL RULE. The server is stateless: EVERY tool takes hostname= and
+catalog_id=. There is no connect step.
+
+QUERY STRATEGY (full ladder + anti-patterns: get_guide
+"deriva_ml_getting_started").
+  0. Bare RID of unknown type? deriva_ml_describe_rid(rid) FIRST --
+     never guess by trying typed get-tools in turn.
+  1. Typed deriva-ml surface first. Known-RID detail in
+     resource-capable clients: read the
+     deriva://catalog/{host}/{cat}/deriva-ml/<kind>/{rid} resource
+     (one fetch, bundles children). Tool-only clients / filtered
+     scans: the deriva_ml_* read tools.
+  2. Chain: deriva_ml_get_execution -> deriva_ml_get_lineage (when
+     inputs/outputs are implicated) -> deriva_ml_get_dataset on the
+     consumed RIDs. Feature values: deriva_ml_list_feature_values
+     (selectors pick the annotation layer; raw feature-table reads
+     mix ground truth with every model's predictions).
+  3. Generic catalog tools (query_attribute / get_entities) are the
+     gated FALLBACK for shapes the typed tools can't express -- never
+     the opening move. An empty per-RID slice of one association
+     table does NOT mean no data: report "no RECORDED provenance",
+     never speculate, never fish in Hatrac.
+
+PAGINATION. Paginated tools: optional preflight_count=True returns the
+total; pages carry truncated + next_after_rid -- pass it back as
+after_rid= to advance. Resources are page-free snapshots capped at
+1000 rows with a truncated flag (switch to the tool to page).
+
+ERRORS. Failures return {"error": "<message>", "error_type":
+"<ExceptionClass>"} (plus context fields on partial mutations) instead
+of raising.
+
+MUTATION BOUNDARY. Catalog-state mutations (datasets, feature
+definitions, workflows, vocabularies) happen here via deriva_ml_*
+tools. The EXECUTION LIFECYCLE (create/start/commit runs, upload
+assets, write feature values) is deliberately NOT on this surface --
+it runs in user-local Python (with ml.create_execution(...) as exe:);
+route users to rag_search(query="execution lifecycle",
+doc_type="ml-docs") for the pattern. Vocabulary terms: use core's
+add_term -- check for an existing term first; add_term does not
+auto-reindex RAG (call deriva_ml_reindex_vocabularies after bulk term
+edits; deriva_ml_resync_indexes refreshes your per-user row indexes)."""
 
 
 # Bodies of guides this plugin owns and can return directly via get_guide.
@@ -1325,10 +1408,18 @@ _PLUGIN_GUIDE_BODIES: dict[str, str] = {
 def _render_primer() -> str:
     """Render the DerivaML startup primer body.
 
-    Composes three blocks: (1) the mandatory-core guide bodies
-    (concepts + getting-started), (2) a one-line manifest of on-demand
-    guides grouped by source, and (3) a closing directive on when to
-    fetch a guide and to prefer resources for read-side questions.
+    Composes three blocks: (1) the compact operating contract
+    (``_PRIMER_CONTRACT`` -- the load-bearing facts a cold-start client
+    needs without fetching anything), (2) a one-line manifest of
+    on-demand guides grouped by source (including the two full plugin
+    guides, fetchable via ``get_guide``), and (3) a closing directive
+    on when to fetch a guide and to prefer resources for read-side
+    questions.
+
+    Tiering history: through the 2026-06-12 review the primer inlined
+    both full guide bodies (~17K tokens of cold-start cost per
+    client). The full texts remain authoritative and on-demand; the
+    primer now carries only the contract.
 
     The body is phrased neutrally ("DERIVA-ML AGENT GUIDELINES") rather
     than "you MUST", so it reads correctly whether it lands in a system
@@ -1347,10 +1438,9 @@ def _render_primer() -> str:
 
     parts: list[str] = []
 
-    # Block 1 -- mandatory core (full bodies).
+    # Block 1 -- the compact operating contract.
     parts.append("=== DERIVA-ML AGENT GUIDELINES ===\n")
-    parts.append(_CONCEPTS_GUIDE)
-    parts.append(_GETTING_STARTED_GUIDE)
+    parts.append(_PRIMER_CONTRACT)
 
     # Block 2 -- manifest of on-demand guides.
     parts.append("=== ON-DEMAND GUIDES ===")

--- a/src/deriva_ml_mcp_plugin/tools/asset.py
+++ b/src/deriva_ml_mcp_plugin/tools/asset.py
@@ -247,6 +247,10 @@ def register(ctx: PluginContext) -> None:
     ) -> str:
         """List the rows in one asset table, with cursor pagination.
 
+        Use this when you know WHICH asset table to read. To search by
+        an identifying value (filename, MD5, URL, or Asset_Type term)
+        across tables, use ``deriva_ml_find_assets`` instead.
+
         See ``deriva_ml_getting_started`` (PAGINATION CONTRACT) for the two-step pagination flow.
 
         ``asset_types`` field note: execution-linked assets carry an
@@ -608,7 +612,7 @@ def register(ctx: PluginContext) -> None:
             RuntimeError: Wrapped, propagated from
                 ``deriva_ml.DerivaML.lookup_asset``,
                 ``Asset.add_asset_type`` / ``remove_asset_type``, or
-                the Description pathBuilder write (e.g. unknown
+                the ``description`` setter's catalog write (e.g. unknown
                 Asset_Type term, missing asset RID, read-only catalog).
 
         Example:

--- a/src/deriva_ml_mcp_plugin/tools/dataset/complex.py
+++ b/src/deriva_ml_mcp_plugin/tools/dataset/complex.py
@@ -150,6 +150,13 @@ def register(ctx: PluginContext) -> None:
             plus ``"rows", "returned_count", "truncated", "next_after_rid"``.
             Dataset preflight: ``{"mode": "dataset_preflight", "dataset_rid",
             "total_count", "entities_fetched": False, "action_required"}``.
+            Preflight REQUIRED (returned instead of rows when the
+            planner's estimate exceeds 10x the requested limit):
+            ``{"mode": "dataset_preflight_required", "dataset_rid",
+            "estimated_row_count", "requested_limit",
+            "entities_fetched": False, "action_required"}`` -- follow
+            its instruction (confirm with ``preflight_count=True``,
+            then pick a larger limit) rather than retrying blindly.
 
         Raises:
             RuntimeError: Wrapped, propagated from

--- a/src/deriva_ml_mcp_plugin/tools/dataset/mutate.py
+++ b/src/deriva_ml_mcp_plugin/tools/dataset/mutate.py
@@ -92,9 +92,22 @@ def register(ctx: PluginContext) -> None:
     ) -> str:
         """Register a new dataset under an execution for provenance tracking.
 
+        WHERE execution_rid COMES FROM. Executions are minted in
+        user-local Python, not on this MCP surface (stateless rule) --
+        there is no create-execution tool to call first. Three routes:
+        (1) reuse an existing in-flight execution's RID if this dataset
+        is being created as part of that run; (2) for standalone
+        curation, the user runs a small local curation execution
+        (``with ml.create_execution(...) as exe:``) and passes its RID
+        -- route them to ``rag_search(query="execution lifecycle",
+        doc_type="ml-docs")`` for the pattern; (3) pick an existing
+        appropriate execution via ``deriva_ml_list_executions``. Do not
+        invent a RID -- creation fails on an unknown execution_rid.
+
         Args:
             execution_rid: RID of the parent Execution. Required -- the new
-                dataset's provenance is rooted in this execution.
+                dataset's provenance is rooted in this execution. See
+                "WHERE execution_rid COMES FROM" above.
             dataset_types: Optional list of dataset-type term names to tag
                 the new dataset with.
             description: Free-text description of the dataset.
@@ -286,11 +299,11 @@ def register(ctx: PluginContext) -> None:
             JSON string ``{"status": "added", "added_count",
             "dataset_rid", "new_version"}``. ``new_version`` is a
             dev label; call ``deriva_ml_release`` to promote to a
-            released label.
+            released label. Supplying neither or both of
+            ``member_rids`` / ``members_by_table`` returns
+            ``{"error": ...}`` directly (no exception raised).
 
         Raises:
-            ValueError: If neither or both of ``member_rids``/
-                ``members_by_table`` are supplied.
             RuntimeError: Wrapped, propagated from
                 ``deriva_ml.dataset.dataset.Dataset.add_dataset_members``
                 (e.g. table not a registered element type, would create a
@@ -484,14 +497,9 @@ def register(ctx: PluginContext) -> None:
         property performs the catalog write and the in-memory mirror
         in one call); this tool delegates to that setter.
 
-        v1.2 breaking rename. This tool used to be
-        ``deriva_ml_update_dataset_types`` with separate ``add`` /
-        ``remove`` kwargs. The new shape mirrors the curation pattern
-        shared with ``update_workflow`` / ``update_asset`` /
-        ``update_execution``: a single per-entity update tool with
-        only-the-changed-fields semantics. Skill consumers (the
-        ``deriva-skills`` plugin) must update references to the new
-        name and signature.
+        This tool follows the curation pattern shared with
+        ``update_workflow`` / ``update_asset``: a single per-entity
+        update tool with only-the-changed-fields semantics.
 
         Args:
             dataset_rid: The RID of the dataset to update.
@@ -503,25 +511,27 @@ def register(ctx: PluginContext) -> None:
         Returns:
             JSON string ``{"status": "updated", "dataset_rid",
             "updated_fields": [...], "dataset_types", "added",
-            "removed", "new_version"}``. ``dataset_types`` /
-            ``added`` / ``removed`` are present only when
-            ``dataset_types`` was actually edited. ``new_version`` is
-            the dataset's version after the update (the underlying
-            type-mutation APIs auto-bump the minor version).
+            "removed", "new_version"}``. ``dataset_types`` / ``added``
+            / ``removed`` are ALWAYS present -- ``null`` when only the
+            description was edited. ``new_version`` is the dataset's
+            version after the update. Per ADR-0003, a type edit lands
+            the dataset on a DEV version (``<release>.post1.devN``),
+            not a released bump -- call ``deriva_ml_release`` afterward
+            to promote the change to a released snapshot.
 
         Raises:
             RuntimeError: Wrapped, propagated from
                 ``deriva_ml.dataset.dataset.Dataset.add_dataset_types``
                 / ``remove_dataset_type`` (e.g. unknown vocabulary
-                term) or the Description pathBuilder write (e.g.
-                read-only catalog).
+                term) or the ``description`` setter's catalog write
+                (e.g. read-only catalog).
 
         Example:
             ``{"status": "updated", "dataset_rid": "1-AAAA",
             "updated_fields": ["dataset_types", "description"],
             "dataset_types": ["Training", "Validation"],
             "added": ["Validation"], "removed": [],
-            "new_version": "1.4.0"}``.
+            "new_version": "1.3.0.post1.dev2"}``.
         """
         # Argument validation -- return errors directly without audit.
         if dataset_types is None and description is None:

--- a/src/deriva_ml_mcp_plugin/tools/dataset/read.py
+++ b/src/deriva_ml_mcp_plugin/tools/dataset/read.py
@@ -1,11 +1,15 @@
 """Read-only dataset tools and shared dataset helpers.
 
-This submodule houses the 7 read tools (``deriva_ml_list_datasets``,
+This submodule houses the 11 read tools (``deriva_ml_list_datasets``,
 ``deriva_ml_get_dataset``, ``deriva_ml_list_dataset_members``,
 ``deriva_ml_list_dataset_relations``, ``deriva_ml_list_dataset_element_types``,
-``deriva_ml_bag_info``, ``deriva_ml_get_dataset_spec``) plus the four
-helpers (``_summarize_dataset``, ``_list_datasets_impl``,
-``_get_dataset_detail_impl``, ``_list_dataset_members_summary_impl``)
+``deriva_ml_bag_info``, ``deriva_ml_get_dataset_spec``,
+``deriva_ml_validate_dataset_specs``,
+``deriva_ml_validate_execution_configuration``,
+``deriva_ml_validate_config_file``, ``deriva_ml_bootstrap_config``)
+plus the shared helpers (``_summarize_dataset``, ``_list_datasets_impl``,
+``_get_dataset_detail_impl``, ``_list_dataset_members_summary_impl``,
+``_get_dataset_spec_impl``, ``_bag_info_impl``)
 that the read tools and the ``resources/ml.py`` / ``resources/rag.py``
 modules consume to keep tool / resource shapes in sync.
 
@@ -644,7 +648,11 @@ def register(ctx: PluginContext) -> None:
     ) -> str:
         """Walk a dataset's nesting hierarchy in either direction.
 
-        See ``deriva_ml_getting_started`` (PAGINATION CONTRACT) for the two-step pagination flow.
+        Pagination here is simpler than the standard preflight contract:
+        there is no ``preflight_count`` and the response carries no
+        ``next_after_rid``. To page a single-direction walk, pass the
+        RID of the last relation in the previous page as ``after_rid``;
+        a ``*_truncated: true`` flag tells you another page exists.
 
         Args:
             dataset_rid: The RID of the dataset whose relations to list.
@@ -653,7 +661,8 @@ def register(ctx: PluginContext) -> None:
             recurse: If True, also include indirect ancestors/descendants.
             limit: Max relations per side (default 100, max 1000).
             after_rid: RID cursor; skip relations with RID <= after_rid.
-                Ignored when ``direction="both"`` (see above).
+                Single-direction only -- ignored (with a ``warning``)
+                when ``direction="both"``.
             version: Optional dataset version to query.
 
         Returns:
@@ -817,11 +826,18 @@ def register(ctx: PluginContext) -> None:
                 tables).
 
         Returns:
-            JSON string ``{"tables": {<name>: {"row_count", "is_asset",
-            "asset_bytes"}}, "total_rows", "total_asset_bytes",
-            "total_asset_size", "cache_status", "cache_path"}``. Fields are
-            shaped by ``deriva_ml.DerivaML.bag_info``; non-JSON-serializable
-            values (e.g. ``Path``) are stringified.
+            JSON string ``{"dataset_rid", "version", "tables": {<name>:
+            {"row_count", "is_asset", "asset_bytes"}}, "total_rows",
+            "total_asset_bytes", "total_asset_size", "cache_status",
+            "cache_path", "warning"?}``. Fields are shaped by
+            ``deriva_ml.DerivaML.bag_info``; non-JSON-serializable
+            values (e.g. ``Path``) are stringified. CAVEAT:
+            ``cache_status`` / ``cache_path`` describe the MCP
+            **server's** local bag cache, NOT the caller's machine --
+            do not present them to the user as their own cache state;
+            a bag the server has cached still needs a local
+            ``ml.cache_dataset(...)`` on the user's machine before
+            local code can read it.
 
         Raises:
             RuntimeError: Wrapped as ``{"error": ...}``, propagated from
@@ -1192,6 +1208,11 @@ def register(ctx: PluginContext) -> None:
             [...]}``. Each suggestion carries ``{kind, config_name,
             rid, version?, spec_string, description?, rationale}``.
             Each skipped entry carries ``{kind, rid, reason}``.
+
+        Raises:
+            RuntimeError: Wrapped as ``{"error": ...}``, propagated
+                from the catalog scan (e.g. connection or permission
+                failure).
 
         Example:
             ``{"catalog": {"hostname": "data.example.org",

--- a/src/deriva_ml_mcp_plugin/tools/execution/read.py
+++ b/src/deriva_ml_mcp_plugin/tools/execution/read.py
@@ -1,10 +1,12 @@
 """Read-only execution tools and shared execution helpers.
 
-This submodule houses the 5 read tools (``deriva_ml_list_executions``,
+This submodule houses the 8 read tools (``deriva_ml_list_executions``,
 ``deriva_ml_get_execution``, ``deriva_ml_find_workflow_executions``,
-``deriva_ml_list_execution_children``, ``deriva_ml_list_execution_parents``)
-plus the three helpers (``_summarize_execution``,
-``_list_executions_impl``, ``_get_execution_detail_impl``) that the
+``deriva_ml_find_dataset_executions``, ``deriva_ml_find_experiments``,
+``deriva_ml_list_execution_children``, ``deriva_ml_list_execution_parents``,
+``deriva_ml_get_lineage``) plus the shared helpers
+(``_summarize_execution``, ``_list_executions_impl``,
+``_get_execution_detail_impl``, ``_get_lineage_impl``) that the
 read tools and the ``resources/ml.py`` / ``resources/rag.py`` modules
 consume to keep tool / resource shapes in sync.
 
@@ -853,14 +855,17 @@ def register(ctx: PluginContext) -> None:
         catalog_id: str,
         execution_rid: str,
     ) -> str:
-        """Read full details of one execution by RID.
+        """Read one execution's summary by RID.
 
         FIRST CALL for any execution-detail question (status, duration,
         description). When the question also implicates the run's
         inputs, outputs, or related artifacts, chain into
         ``deriva_ml_get_lineage`` next; for the nested-execution tree
         use ``deriva_ml_list_execution_parents`` /
-        ``deriva_ml_list_execution_children``. Raw ``query_attribute``
+        ``deriva_ml_list_execution_children``. For the bundled DETAIL
+        shape (inputs + outputs + ``experiment`` in one fetch), read the
+        ``deriva://catalog/{h}/{c}/deriva-ml/execution/{rid}`` resource
+        instead (resource-capable clients). Raw ``query_attribute``
         joins over the Execution association tables are the fallback
         for when these tools fail or don't cover the question (e.g.
         domain-specific relationships outside the ML provenance graph)
@@ -873,7 +878,8 @@ def register(ctx: PluginContext) -> None:
         Returns:
             JSON string with the execution summary: ``{"rid",
             "workflow_rid", "status", "description", "start_time",
-            "stop_time", "duration"}``.
+            "stop_time", "duration", "download_duration",
+            "upload_duration"}``.
 
         Raises:
             RuntimeError: Wrapped, propagated from
@@ -882,7 +888,8 @@ def register(ctx: PluginContext) -> None:
         Example:
             ``{"rid": "1-EXEC", "workflow_rid": "1-WF", "status": "Stopped",
             "description": "training run", "start_time": "...",
-            "stop_time": "...", "duration": "..."}``.
+            "stop_time": "...", "duration": "...",
+            "download_duration": null, "upload_duration": null}``.
         """
         try:
             with deriva_call():
@@ -1279,9 +1286,11 @@ def register(ctx: PluginContext) -> None:
 
         Returns executions that have a Hydra configuration asset
         (``*-config.yaml`` in ``Execution_Metadata``). Experiment
-        detail (``config_choices``, ``model_config``) is available
-        per-execution via ``deriva_ml_get_execution`` followed by
-        inspecting the ``experiment`` field on the detail payload.
+        detail (``config_choices``, ``model_config``) lives on the
+        ``experiment`` field of the execution DETAIL resource --
+        read ``deriva://catalog/{h}/{c}/deriva-ml/execution/{rid}``
+        per execution. (The ``deriva_ml_get_execution`` tool returns
+        the summary shape, which does NOT carry ``experiment``.)
 
         Returns execution summaries in the same shape as
         ``deriva_ml_list_executions`` -- the two can be used

--- a/src/deriva_ml_mcp_plugin/tools/feature.py
+++ b/src/deriva_ml_mcp_plugin/tools/feature.py
@@ -419,13 +419,22 @@ def register(ctx: PluginContext) -> None:
         Selectors:
 
         - ``none`` -- return all matching records (multiple per target).
-        - ``newest`` / ``latest`` / ``first`` -- time-based collapse via
-          the corresponding ``FeatureRecord.select_*`` staticmethod.
+        - ``newest`` -- per target, keep the record with the most recent
+          row-creation time (RCT). ``latest`` is an exact alias of
+          ``newest``; ``first`` keeps the EARLIEST record instead.
         - ``majority_vote`` -- collapse by most common value.
         - ``by_workflow`` -- filter to records from one workflow.
           Requires ``selector_workflow``.
         - ``by_execution`` -- filter to records from one execution.
           Requires ``selector_execution_rid``.
+
+        COMPARE-RUNS RECIPE: to compare a metric across N known runs in
+        one round-trip, pass ``execution_rids=[ridA, ridB, ...]`` (no
+        selector) -- the response carries one row per (record,
+        execution), so group client-side by the ``Execution`` column.
+        Discover the run RIDs first via ``deriva_ml_find_experiments``
+        or ``deriva_ml_list_executions``. Metrics stored as JSONL asset
+        files (not features) are downloaded in local Python instead.
 
         Exactly one selector strategy applies per call: ``selector`` is a
         single value. Supply ``selector_workflow`` ONLY with
@@ -750,6 +759,13 @@ def register(ctx: PluginContext) -> None:
         feature_name: str,
     ) -> str:
         """Remove a feature definition and all its values.
+
+        DESTRUCTIVE: this drops every value ever recorded for the
+        feature (ground truth AND model predictions, from every
+        execution), not just the definition. Before calling, run
+        ``deriva_ml_list_feature_values(table, feature_name,
+        preflight_count=True)`` and report the count to the user so
+        they can confirm the blast radius -- there is no undo.
 
         Args:
             table: Target table the feature is defined on.

--- a/src/deriva_ml_mcp_plugin/tools/vocabulary.py
+++ b/src/deriva_ml_mcp_plugin/tools/vocabulary.py
@@ -98,10 +98,10 @@ def register(ctx: PluginContext) -> None:
             update_navbar: If ``True`` (default), refresh the
                 catalog's navigation bar so the new vocab shows up
                 in Chaise immediately. Set to ``False`` during batch
-                table creation, then call
-                ``deriva_ml_apply_catalog_annotations`` once at the
-                end (not currently exposed as an MCP tool -- batch
-                callers should use the Python API directly).
+                table creation, then apply catalog annotations once at
+                the end via the Python API
+                (``ml.apply_catalog_annotations()`` -- deliberately not
+                exposed as an MCP tool).
 
         Returns:
             JSON string ``{"status": "created", "schema",

--- a/src/deriva_ml_mcp_plugin/tools/workflow.py
+++ b/src/deriva_ml_mcp_plugin/tools/workflow.py
@@ -502,10 +502,10 @@ def register(ctx: PluginContext) -> None:
 
             # ANTI-PATTERN -- do not do this
             existing = deriva_ml_find_workflow_by_url(url=X)
-            if existing is None:
+            if "error" in existing:  # not found
                 deriva_ml_create_workflow(url=X, checksum=Y, ...)
             else:
-                workflow_rid = existing["workflow_rid"]
+                workflow_rid = existing["rid"]
 
         The right pattern::
 

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -127,7 +127,7 @@ async def test_list_assets_failure_returns_error_envelope(asset_ctx, capturing_m
                 hostname="h", catalog_id="1", asset_table="Image"
             )
         )
-    assert out == {"error": "not an asset table"}
+    assert out == {"error": "not an asset table", "error_type": "RuntimeError"}
     # Read-only: no audit on failure.
     assert mock_audit.call_count == 0
 
@@ -298,7 +298,7 @@ async def test_find_assets_failure_returns_error_envelope(asset_ctx, capturing_m
                 hostname="h", catalog_id="1", asset_type="Model_File"
             )
         )
-    assert out == {"error": "Model_File: term not found"}
+    assert out == {"error": "Model_File: term not found", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 
@@ -479,7 +479,7 @@ async def test_lookup_asset_failure_returns_error_envelope(asset_ctx, capturing_
                 hostname="h", catalog_id="1", asset_rid="1-XXXX"
             )
         )
-    assert out == {"error": "not an asset"}
+    assert out == {"error": "not an asset", "error_type": "RuntimeError"}
     # Read-only: no audit on failure.
     assert mock_audit.call_count == 0
 

--- a/tests/test_dataset_complex.py
+++ b/tests/test_dataset_complex.py
@@ -215,7 +215,7 @@ async def test_denormalize_dataset_error_path(dataset_ctx, capturing_mcp, mock_m
             include_tables=["Image"],
         )
     )
-    assert out == {"error": "schema error"}
+    assert out == {"error": "schema error", "error_type": "RuntimeError"}
 
 
 async def test_denormalize_dataset_refuses_oversize_fetch_without_preflight(

--- a/tests/test_dataset_mutate.py
+++ b/tests/test_dataset_mutate.py
@@ -109,7 +109,7 @@ async def test_create_dataset_failure_emits_failed_audit(dataset_ctx, capturing_
                 dataset_types=["BadTerm"],
             )
         )
-    assert out == {"error": "invalid term"}
+    assert out == {"error": "invalid term", "error_type": "RuntimeError"}
 
     failed = _success_calls(mock_audit, "deriva_ml_create_dataset_failed")
     assert failed, "expected deriva_ml_create_dataset_failed audit event"
@@ -167,7 +167,7 @@ async def test_delete_dataset_error_path(dataset_ctx, capturing_mcp, mock_ml):
                 hostname="h", catalog_id="1", dataset_rid="missing"
             )
         )
-    assert out == {"error": "not found"}
+    assert out == {"error": "not found", "error_type": "RuntimeError"}
     failed = _success_calls(mock_audit, "deriva_ml_delete_dataset_failed")
     assert failed
     assert failed[0].kwargs["error_type"] == "RuntimeError"
@@ -267,7 +267,7 @@ async def test_add_dataset_members_error_path(dataset_ctx, capturing_mcp, mock_m
                 member_rids=["r1"],
             )
         )
-    assert out == {"error": "cycle detected"}
+    assert out == {"error": "cycle detected", "error_type": "RuntimeError"}
     failed = _success_calls(mock_audit, "deriva_ml_add_dataset_members_failed")
     assert failed
     assert failed[0].kwargs["attempted_count"] == 1
@@ -316,7 +316,7 @@ async def test_delete_dataset_members_error(dataset_ctx, capturing_mcp, mock_ml)
                 member_rids=["r1", "r2", "r3"],
             )
         )
-    assert out == {"error": "rid not in dataset"}
+    assert out == {"error": "rid not in dataset", "error_type": "RuntimeError"}
     failed = _success_calls(mock_audit, "deriva_ml_delete_dataset_members_failed")
     assert failed
     assert failed[0].kwargs["attempted_count"] == 3
@@ -596,7 +596,7 @@ async def test_add_dataset_element_type_error(dataset_ctx, capturing_mcp, mock_m
                 hostname="h", catalog_id="1", table_name="Execution"
             )
         )
-    assert out == {"error": "not a domain table"}
+    assert out == {"error": "not a domain table", "error_type": "RuntimeError"}
     failed = _success_calls(mock_audit, "deriva_ml_add_dataset_element_type_failed")
     assert failed
     assert failed[0].kwargs["table_name"] == "Execution"

--- a/tests/test_dataset_read.py
+++ b/tests/test_dataset_read.py
@@ -106,7 +106,7 @@ async def test_list_datasets_error_path(dataset_ctx, capturing_mcp, mock_ml):
     out = json.loads(
         await capturing_mcp.tools["deriva_ml_list_datasets"](hostname="h", catalog_id="1")
     )
-    assert out == {"error": "boom"}
+    assert out == {"error": "boom", "error_type": "RuntimeError"}
 
 
 async def test_list_datasets_sort_forwards_to_deriva_ml(dataset_ctx, capturing_mcp, mock_ml):
@@ -322,7 +322,7 @@ async def test_get_dataset_not_found(dataset_ctx, capturing_mcp, mock_ml):
             hostname="h", catalog_id="1", dataset_rid="missing"
         )
     )
-    assert out == {"error": "Dataset not found"}
+    assert out == {"error": "Dataset not found", "error_type": "RuntimeError"}
 
 
 async def test_get_dataset_tool_schedules_index_on_find(dataset_ctx, capturing_mcp, mock_ml):
@@ -444,7 +444,7 @@ async def test_list_dataset_members_error_path(dataset_ctx, capturing_mcp, mock_
             hostname="h", catalog_id="1", dataset_rid="1-AAAA"
         )
     )
-    assert out == {"error": "nope"}
+    assert out == {"error": "nope", "error_type": "RuntimeError"}
 
 
 # ---------------------------------------------------------------------------
@@ -497,7 +497,7 @@ async def test_list_dataset_relations_error(dataset_ctx, capturing_mcp, mock_ml)
             hostname="h", catalog_id="1", dataset_rid="x"
         )
     )
-    assert out == {"error": "relations boom"}
+    assert out == {"error": "relations boom", "error_type": "RuntimeError"}
 
 
 async def test_list_dataset_relations_after_rid_with_both_emits_warning(
@@ -611,7 +611,7 @@ async def test_list_dataset_element_types_error(dataset_ctx, capturing_mcp, mock
             hostname="h", catalog_id="1"
         )
     )
-    assert out == {"error": "bad"}
+    assert out == {"error": "bad", "error_type": "RuntimeError"}
 
 
 # ---------------------------------------------------------------------------
@@ -671,7 +671,7 @@ async def test_bag_info_error(dataset_ctx, capturing_mcp, mock_ml):
             version="1.0.0",
         )
     )
-    assert out == {"error": "cant compute"}
+    assert out == {"error": "cant compute", "error_type": "RuntimeError"}
 
 
 # ---------------------------------------------------------------------------
@@ -721,7 +721,7 @@ async def test_get_dataset_spec_error(dataset_ctx, capturing_mcp, mock_ml):
             hostname="h", catalog_id="1", dataset_rid="1-AAAA"
         )
     )
-    assert out == {"error": "missing"}
+    assert out == {"error": "missing", "error_type": "RuntimeError"}
 
 
 # ---------------------------------------------------------------------------
@@ -867,7 +867,7 @@ async def test_validate_execution_configuration_error_path(dataset_ctx, capturin
                 config={"workflow": {"rid": "1-WFLW"}},
             )
         )
-    assert out == {"error": "config has unresolvable workflow"}
+    assert out == {"error": "config has unresolvable workflow", "error_type": "RuntimeError"}
 
 
 # ---------------------------------------------------------------------------
@@ -923,7 +923,7 @@ async def test_validate_config_file_error_path(dataset_ctx, capturing_mcp, mock_
         hostname="h", catalog_id="1", file_contents="# empty"
     )
     out = json.loads(result)
-    assert out == {"error": "AST blew up"}
+    assert out == {"error": "AST blew up", "error_type": "RuntimeError"}
 
 
 async def test_bootstrap_config_default_kinds(dataset_ctx, capturing_mcp, mock_ml) -> None:
@@ -980,4 +980,4 @@ async def test_bootstrap_config_error_path(dataset_ctx, capturing_mcp, mock_ml) 
     mock_ml.bootstrap_config.side_effect = RuntimeError("cannot connect")
     result = await capturing_mcp.tools["deriva_ml_bootstrap_config"](hostname="h", catalog_id="1")
     out = json.loads(result)
-    assert out == {"error": "cannot connect"}
+    assert out == {"error": "cannot connect", "error_type": "RuntimeError"}

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -561,7 +561,7 @@ async def test_get_lineage_error_path_workflow_rid(execution_ctx, capturing_mcp,
             hostname="h", catalog_id="1", rid="1-WF"
         )
     payload = json.loads(result)
-    assert payload == {"error": "Workflow RIDs are not lineage-shaped"}
+    assert payload == {"error": "Workflow RIDs are not lineage-shaped", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -137,7 +137,7 @@ async def test_list_features_error_path(feature_ctx, capturing_mcp, mock_ml):
         out = json.loads(
             await capturing_mcp.tools["deriva_ml_list_features"](hostname="h", catalog_id="1")
         )
-    assert out == {"error": "schema down"}
+    assert out == {"error": "schema down", "error_type": "RuntimeError"}
     # Read tool: no audit on failure.
     assert mock_audit.call_count == 0
 
@@ -188,7 +188,7 @@ async def test_get_feature_error_path(feature_ctx, capturing_mcp, mock_ml):
                 hostname="h", catalog_id="1", table="Image", feature_name="Missing"
             )
         )
-    assert out == {"error": "no such feature"}
+    assert out == {"error": "no such feature", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 
@@ -359,7 +359,7 @@ async def test_list_feature_values_error_path(feature_ctx, capturing_mcp, mock_m
                 hostname="h", catalog_id="1", table="Image", feature_name="Quality"
             )
         )
-    assert out == {"error": "ermrest down"}
+    assert out == {"error": "ermrest down", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 
@@ -685,7 +685,7 @@ async def test_create_feature_failure_emits_failed_audit(feature_ctx, capturing_
                 terms=["BadTerm"],
             )
         )
-    assert out == {"error": "invalid term table"}
+    assert out == {"error": "invalid term table", "error_type": "RuntimeError"}
 
     failed = _success_calls(mock_audit, "deriva_ml_create_feature_failed")
     assert failed, "expected deriva_ml_create_feature_failed audit event"
@@ -743,7 +743,7 @@ async def test_delete_feature_failure_emits_failed_audit(feature_ctx, capturing_
                 hostname="h", catalog_id="1", table="Image", feature_name="Quality"
             )
         )
-    assert out == {"error": "permission denied"}
+    assert out == {"error": "permission denied", "error_type": "RuntimeError"}
     failed = _success_calls(mock_audit, "deriva_ml_delete_feature_failed")
     assert failed
     assert failed[0].kwargs["error_type"] == "RuntimeError"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -109,5 +109,28 @@ def test_error_envelope_no_missing_rids_for_generic_exception() -> None:
             audit=False,
         )
     )
-    assert out == {"error": "something else broke"}
+    assert out == {"error": "something else broke", "error_type": "RuntimeError"}
     assert "missing_rids" not in out
+
+
+def test_error_envelope_carries_machine_readable_error_type() -> None:
+    """The wire envelope includes error_type (exception class name).
+
+    Already computed for the audit row; surfacing it on the wire lets an
+    LLM distinguish not-found / permission / validation failures without
+    parsing the human-oriented message string.
+    """
+    import json
+
+    from deriva_ml_mcp_plugin._helpers import _error_envelope
+
+    raw = _error_envelope(
+        ValueError("boom"),
+        operation="unit_test",
+        hostname="h",
+        catalog_id="1",
+        audit=False,
+    )
+    payload = json.loads(raw)
+    assert payload["error"] == "boom"
+    assert payload["error_type"] == "ValueError"

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -162,12 +162,22 @@ def test_prompts_are_ascii(ctx, capturing_mcp):
             raise AssertionError(f"{name} contains non-ASCII characters: {exc}") from exc
 
 
-def test_render_primer_contains_both_guide_bodies():
-    """The primer inlines the concepts and getting-started guide bodies."""
+def test_render_primer_carries_operating_contract():
+    """The primer carries the compact operating contract (tiered, 2026-06-12).
+
+    The full guide bodies are no longer inlined (see
+    test_primer_is_tiered_not_concatenated); the contract's load-bearing
+    sections must be present.
+    """
     body = prompts._render_primer()
-    # A distinctive phrase from each guide must be present verbatim.
-    assert "DERIVA-ML GETTING STARTED" in body
-    assert "five core abstractions" in body or "Dataset" in body
+    for marker in (
+        "CALL RULE",
+        "QUERY STRATEGY",
+        "PAGINATION",
+        "MUTATION BOUNDARY",
+        "Dataset",
+    ):
+        assert marker in body, f"{marker} missing from primer contract"
 
 
 def test_render_primer_lists_all_guide_names():
@@ -224,3 +234,42 @@ def test_get_guide_registered_read_only(ctx, capturing_mcp):
     """get_guide is a read-only tool."""
     prompts.register(ctx)
     assert "get_guide" in capturing_mcp.tools
+
+
+# ---------------------------------------------------------------------------
+# Tiered primer (review sweep): compact contract + manifest, not full guides
+# ---------------------------------------------------------------------------
+
+
+def test_primer_is_tiered_not_concatenated():
+    """The primer returns a compact operating contract, NOT both full guides.
+
+    Cold-start cost: the old primer concatenated _CONCEPTS_GUIDE +
+    _GETTING_STARTED_GUIDE (~17K tokens). The tiered primer carries the
+    load-bearing operating contract only; the full guides are fetched
+    on demand via get_guide (they appear in the manifest instead).
+    """
+    body = prompts._render_primer()
+    # Deep-guide-only markers must NOT be inlined any more.
+    assert "ANTI-PATTERNS (observed failures" not in body
+    assert "THE ENTITY RESOLUTION WORKFLOW" not in body
+    # The compact contract's load-bearing facts ARE present.
+    assert "DERIVA-ML AGENT GUIDELINES" in body
+    assert "hostname" in body and "catalog_id" in body
+    assert "deriva_ml_describe_rid" in body  # step-0 routing survives tiering
+    # Both full guides are offered on demand in the manifest.
+    assert "deriva_ml_concepts" in body
+    assert "deriva_ml_getting_started" in body
+    assert "get_guide" in body
+    # And the primer is actually compact: well under a third of the
+    # combined full-guide length.
+    combined = len(prompts._CONCEPTS_GUIDE) + len(prompts._GETTING_STARTED_GUIDE)
+    assert len(body) < combined / 3, (
+        f"primer is {len(body)} chars; expected < {combined // 3} (1/3 of full guides)"
+    )
+
+
+def test_guide_manifest_lists_both_plugin_guides():
+    """The manifest carries deriva-ml rows for concepts + getting_started."""
+    ml_rows = {n for (n, src, _s) in prompts._GUIDE_MANIFEST if src == "deriva-ml"}
+    assert {"deriva_ml_concepts", "deriva_ml_getting_started"} <= ml_rows

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -268,7 +268,7 @@ async def test_ml_datasets_error_path_is_silent(resource_ctx, capturing_mcp, moc
     mock_ml.find_datasets.side_effect = RuntimeError("kaboom")
     with patch("deriva_ml_mcp_plugin._helpers.audit_event") as mock_audit:
         out = json.loads(await capturing_mcp.resources[_DATASETS_URI](hostname="h", catalog_id="1"))
-    assert out == {"error": "kaboom"}
+    assert out == {"error": "kaboom", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 
@@ -322,7 +322,7 @@ async def test_ml_dataset_detail_not_found(resource_ctx, capturing_mcp, mock_ml)
                 hostname="h", catalog_id="1", dataset_rid="missing"
             )
         )
-    assert out == {"error": "Dataset not found"}
+    assert out == {"error": "Dataset not found", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 
@@ -377,7 +377,7 @@ async def test_ml_dataset_members_error_path(resource_ctx, capturing_mcp, mock_m
                 hostname="h", catalog_id="1", dataset_rid="bad"
             )
         )
-    assert out == {"error": "nope"}
+    assert out == {"error": "nope", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 
@@ -419,7 +419,7 @@ async def test_ml_dataset_spec_error_path_is_silent(resource_ctx, capturing_mcp,
                 hostname="h", catalog_id="1", dataset_rid="missing"
             )
         )
-    assert out == {"error": "Dataset not found"}
+    assert out == {"error": "Dataset not found", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 
@@ -482,7 +482,7 @@ async def test_ml_dataset_bag_preview_error_path_is_silent(resource_ctx, capturi
                 hostname="h", catalog_id="1", dataset_rid="missing"
             )
         )
-    assert out == {"error": "Dataset not found"}
+    assert out == {"error": "Dataset not found", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 
@@ -508,7 +508,7 @@ async def test_ml_workflows_error_path(resource_ctx, capturing_mcp, mock_ml):
         out = json.loads(
             await capturing_mcp.resources[_WORKFLOWS_URI](hostname="h", catalog_id="1")
         )
-    assert out == {"error": "kaboom"}
+    assert out == {"error": "kaboom", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 
@@ -538,7 +538,7 @@ async def test_ml_workflow_detail_not_found(resource_ctx, capturing_mcp, mock_ml
                 hostname="h", catalog_id="1", workflow_rid="missing"
             )
         )
-    assert out == {"error": "Workflow not found"}
+    assert out == {"error": "Workflow not found", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 
@@ -564,7 +564,7 @@ async def test_ml_executions_error_path(resource_ctx, capturing_mcp, mock_ml):
         out = json.loads(
             await capturing_mcp.resources[_EXECUTIONS_URI](hostname="h", catalog_id="1")
         )
-    assert out == {"error": "boom"}
+    assert out == {"error": "boom", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 
@@ -948,7 +948,7 @@ async def test_ml_execution_detail_not_found(resource_ctx, capturing_mcp, mock_m
                 hostname="h", catalog_id="1", execution_rid="missing"
             )
         )
-    assert out == {"error": "Execution not found"}
+    assert out == {"error": "Execution not found", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 
@@ -1019,7 +1019,7 @@ async def test_ml_lineage_error_path_is_silent(resource_ctx, capturing_mcp, mock
         out = json.loads(
             await capturing_mcp.resources[_LINEAGE_URI](hostname="h", catalog_id="1", rid="1-WF")
         )
-    assert out == {"error": "Workflow RIDs are not lineage-shaped"}
+    assert out == {"error": "Workflow RIDs are not lineage-shaped", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 
@@ -1053,7 +1053,7 @@ async def test_ml_features_for_table_error_path(resource_ctx, capturing_mcp, moc
                 hostname="h", catalog_id="1", table_name="Image"
             )
         )
-    assert out == {"error": "nope"}
+    assert out == {"error": "nope", "error_type": "RuntimeError"}
     assert mock_audit.call_count == 0
 
 

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -166,7 +166,7 @@ async def test_create_vocabulary_failure_emits_failed_audit(vocabulary_ctx, capt
             )
         )
 
-    assert out == {"error": "Table Tissue_Type already exist"}
+    assert out == {"error": "Table Tissue_Type already exist", "error_type": "RuntimeError"}
 
     failed = _success_calls(mock_audit, "deriva_ml_create_vocabulary_failed")
     assert failed, "expected deriva_ml_create_vocabulary_failed audit event"


### PR DESCRIPTION
## What this is

Output of a comprehensive four-dimension review of the plugin (prompt factual accuracy vs the registered surface; tool docstring quality; resource-surface completeness; user-journey quality for an ML-developer and a catalog-manager persona). Two behavior changes + a factual sweep. Full findings are summarized in the commit message.

## Behavior changes

1. **Tiered primer** — `deriva_ml_primer` (tool/prompt/resource) now returns a compact operating contract (**~1.1K tokens**, was **~16K**: both full guides concatenated). The full `deriva_ml_concepts` / `deriva_ml_getting_started` texts are unchanged and fetchable on demand via `get_guide`; they're now listed in the primer's manifest. ~94% cold-start cost reduction.
2. **`error_type` on the error envelope** — `{"error": msg, "error_type": "ExceptionClass"}` so LLM callers can branch on failure class without parsing prose. Additive; 37 test assertions updated.

## Factual corrections (highlights — all HIGH findings)

- `split_dataset` removed from the cold-start COMMON TASKS table (retired tool taught as live = guaranteed failing call).
- `update_dataset` docstring: v3.0 always-present-null contract; ADR-0003 dev-version semantics (was claiming a released minor auto-bump); removed-tool citation dropped.
- `find_experiments` / `get_execution`: experiment detail correctly routed to the execution detail **resource**; `get_execution` retitled to summary + full key list.
- `bag_info`: `cache_status`/`cache_path` flagged as the **server's** cache (stateless rule #6); missing response keys documented.
- `create_dataset`: documents where the required `execution_rid` comes from (the local-Python lifecycle; three routes).
- Counts corrected everywhere (47 tools / 19 resources / 3 prompts), `/ml/` URI prose shorthand → `/deriva-ml/`, compare-runs recipe added, `delete_feature` blast-radius guard, `newest`/`latest` selector semantics, dead `FeatureDetail` models deleted, module docstring inventories fixed, repo CLAUDE.md architecture sketch updated.

## Verification

390 tests pass (+5 new: primer tiering, contract markers, manifest rows, error_type). `ruff check` + `format` clean. Rebased onto main post-#73.

## Not in this PR (flagged for later decisions)

- `get_guide` is the only unprefixed tool (collision risk; rename = breaking — next breaking window).
- `release` / `resync_indexes`-vs-`reindex_vocabularies` naming harmonization (breaking).
- An "unlinked provenance" enumeration path for curators (new feature).
- Cross-repo: stale package path in the `using-deriva-mcp` skill (deriva-ml-skills repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)