### PR TITLE
feat(rag): ML-kind doc_types on RAG chunks (closes #7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,10 +116,14 @@ prefix that bypasses upstream's `data:` user-id filter and serves
 chunks to all users in the catalog. See `resources/rag.py`'s module
 docstring for the full rationale.
 
-One upstream gap remains: deriva-mcp-core#2 (`index_table_data`
-should accept a `doc_type` parameter so per-table RAG chunks can
-be filtered by `rag_search(doc_type="ml-dataset")`). Tracked
-inline at the call site with `# TODO(upstream-rag-doctype)`.
+ML-kind doc_types (issue #7, resolved plugin-side): because the
+plugin writes chunks directly to the store, it tags them
+`ml-dataset` / `ml-workflow` / `ml-execution` / `ml-vocab` so
+`rag_search(doc_type=...)` filters by kind. deriva-mcp-core#2
+(`index_table_data` doc_type parameter) no longer blocks anything
+here -- it remains open for plugins that use that path. Rows
+indexed before the tags shipped carry the legacy `catalog-data`
+doc_type until re-indexed (read-through refresh / reindex tools).
 
 **Boundary rules.** This plugin **never** duplicates anything that lives in
 `deriva-mcp-core`:

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -251,17 +251,20 @@ during the v1.0 polish sprint -- `rag_search` now filters `data:` sources by
 user_id symmetrically with the schema-source filter, closing the cross-user
 read leak. The plugin no longer carries a TODO marker for it.
 
-Still open:
+Resolved plugin-side (2026-06-12, issue #7):
 
-- **`index_table_data` hardcodes `doc_type="catalog-data"`**
-  ([deriva-mcp-core#2](https://github.com/informatics-isi-edu/deriva-mcp-core/issues/2);
-  `rag/data.py` lines 138, 142). Plugins cannot tag per-user catalog chunks
-  with a domain-specific doc_type, so `rag_search(doc_type="ml-dataset")`
-  cannot distinguish Dataset chunks from Workflow or Execution chunks. The
-  rendered Markdown header (`## Dataset: <RID>`) still tags chunks
-  inline for the LLM. Fix is a one-line `doc_type` parameter addition
-  upstream. The plugin marks the gap with `# TODO(upstream-rag-doctype)` at
-  the `index_table_data` call site in `resources/rag.py`.
+- **ML-kind doc_types on RAG chunks.** The gap originally tracked here
+  ([deriva-mcp-core#2](https://github.com/informatics-isi-edu/deriva-mcp-core/issues/2):
+  `index_table_data` hardcodes `doc_type="catalog-data"`) stopped
+  applying when v1.3 moved the plugin to direct `store.add` writes --
+  the doc_type became ours to set. Chunks now carry `ml-dataset` /
+  `ml-workflow` / `ml-execution` / `ml-vocab`, so
+  `rag_search(doc_type=...)` filters by kind. core#2 remains open
+  upstream for plugins that still use `index_table_data`. Rows indexed
+  before the tags shipped keep the legacy `catalog-data` doc_type
+  until re-indexed (read-through refresh or the reindex tools).
+
+Still open:
 
 - **No `on_data_change` lifecycle hook**
   ([deriva-mcp-core#3](https://github.com/informatics-isi-edu/deriva-mcp-core/issues/3)).

--- a/src/deriva_ml_mcp_plugin/prompts.py
+++ b/src/deriva_ml_mcp_plugin/prompts.py
@@ -860,9 +860,15 @@ executions that produced quality scores"), prefer ``rag_search`` over
 the paginated list tools:
 
     rag_search(query="...", doc_type="ml-docs")      -- search DerivaML docs
-    rag_search(query="...", doc_type="catalog-data") -- search per-user RAG
-                                                        index of Dataset /
-                                                        Workflow / Execution rows
+    rag_search(query="...", doc_type="ml-dataset")   -- Dataset rows only
+    rag_search(query="...", doc_type="ml-workflow")  -- Workflow rows only
+    rag_search(query="...", doc_type="ml-execution") -- Execution rows only
+    rag_search(query="...", doc_type="ml-vocab")     -- vocabulary terms only
+    rag_search(query="...")                          -- no filter: broadest recall
+                                                        (rows indexed before the
+                                                        ml-* tags shipped carry the
+                                                        legacy "catalog-data" tag
+                                                        until re-indexed)
 
 Reach for the paginated list tools (``deriva_ml_list_datasets``,
 ``deriva_ml_list_workflows``, ``deriva_ml_list_executions``,

--- a/src/deriva_ml_mcp_plugin/resources/rag.py
+++ b/src/deriva_ml_mcp_plugin/resources/rag.py
@@ -246,6 +246,21 @@ _DATASET_TOKEN = "dataset"
 _WORKFLOW_TOKEN = "workflow"
 _EXECUTION_TOKEN = "execution"
 
+# ML-kind doc_type per catalog table, carried on every chunk so
+# ``rag_search(doc_type="ml-dataset" | "ml-workflow" | "ml-execution")``
+# can filter to one kind (issue #7, resolved plugin-side). We write
+# chunks directly to the store -- core's hardcoded-doc_type
+# ``index_table_data`` path (deriva-mcp-core#2) is not on our write
+# path, so the tag is ours to set. The per-user ``data:`` source-name
+# filter in core's rag_search is independent of doc_type; ACL posture
+# is unchanged. Unknown tables fall back to the generic "catalog-data".
+_DOC_TYPE_BY_TABLE: dict[str, str] = {
+    "Dataset": "ml-dataset",
+    "Workflow": "ml-workflow",
+    "Execution": "ml-execution",
+}
+_VOCAB_DOC_TYPE = "ml-vocab"
+
 
 # Strong references to in-flight index-on-find background tasks. Without
 # this set the event loop may garbage-collect a pending task before it
@@ -549,17 +564,13 @@ async def _write_row_chunk(
         return 0
     chunks: list[Chunk] = []
     chunk_index = 0
-    # TODO(upstream-rag-doctype): tracked as deriva-mcp-core#2.
-    # Once chunks can carry a domain-specific doc_type, switch to
-    # "ml-dataset" / "ml-workflow" / "ml-execution" so
-    # rag_search(doc_type=...) can distinguish these from generic
-    # catalog-data chunks.
-    for c in chunk_markdown(rendered, source=source, doc_type="catalog-data"):
+    doc_type = _DOC_TYPE_BY_TABLE.get(table_name, "catalog-data")
+    for c in chunk_markdown(rendered, source=source, doc_type=doc_type):
         chunks.append(
             Chunk(
                 text=c.text,
                 source=source,
-                doc_type="catalog-data",
+                doc_type=doc_type,
                 section_heading=c.section_heading,
                 heading_hierarchy=c.heading_hierarchy,
                 chunk_index=chunk_index,
@@ -1047,17 +1058,12 @@ async def _write_vocab_chunks(
         rendered = serializer.serialize(vocab_table, term)
         if rendered is None:
             continue
-        # TODO(upstream-rag-doctype): tracked as deriva-mcp-core#2
-        # (https://github.com/informatics-isi-edu/deriva-mcp-core/issues/2).
-        # Once chunks can carry a domain-specific doc_type, switch to
-        # "ml-vocab" so rag_search(doc_type=...) can distinguish vocab
-        # term chunks from generic catalog-data chunks.
-        for c in chunk_markdown(rendered, source=source, doc_type="catalog-data"):
+        for c in chunk_markdown(rendered, source=source, doc_type=_VOCAB_DOC_TYPE):
             chunks.append(
                 Chunk(
                     text=c.text,
                     source=source,
-                    doc_type="catalog-data",
+                    doc_type=_VOCAB_DOC_TYPE,
                     section_heading=c.section_heading,
                     heading_hierarchy=c.heading_hierarchy,
                     chunk_index=chunk_index,

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -561,7 +561,10 @@ async def test_get_lineage_error_path_workflow_rid(execution_ctx, capturing_mcp,
             hostname="h", catalog_id="1", rid="1-WF"
         )
     payload = json.loads(result)
-    assert payload == {"error": "Workflow RIDs are not lineage-shaped", "error_type": "RuntimeError"}
+    assert payload == {
+        "error": "Workflow RIDs are not lineage-shaped",
+        "error_type": "RuntimeError",
+    }
     assert mock_audit.call_count == 0
 
 

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -839,9 +839,7 @@ def test_reindex_execution_logs_concise_message_for_legacy_status_valueerror(cap
     from deriva_ml_mcp_plugin.resources import rag as rag_module
 
     fake_ml = MagicMock()
-    fake_ml.lookup_execution.side_effect = ValueError(
-        "'Completed' is not a valid ExecutionStatus"
-    )
+    fake_ml.lookup_execution.side_effect = ValueError("'Completed' is not a valid ExecutionStatus")
 
     with (
         patch.object(rag_module, "get_rag_store", return_value=MagicMock()),
@@ -928,7 +926,7 @@ def test_write_vocab_chunks_deletes_then_adds() -> None:
     assert fake_store.add.await_count == 1
     chunks = fake_store.add.await_args.args[0]
     assert all(c.source == "vocab:h:1:s.t" for c in chunks)
-    assert all(c.doc_type == "catalog-data" for c in chunks)
+    assert all(c.doc_type == "ml-vocab" for c in chunks)
 
 
 def test_write_vocab_chunks_empty_terms_drains_only() -> None:
@@ -996,7 +994,7 @@ def test_write_row_chunk_deletes_then_adds() -> None:
     assert fake_store.add.await_count == 1
     chunks = fake_store.add.await_args.args[0]
     assert all(c.source == "data:h:1:userA:dataset:1-DSAA" for c in chunks)
-    assert all(c.doc_type == "catalog-data" for c in chunks)
+    assert all(c.doc_type == "ml-dataset" for c in chunks)
 
 
 def test_write_row_chunk_serializer_returns_none_drains_only() -> None:
@@ -1483,3 +1481,42 @@ def test_index_rows_on_find_no_running_loop_is_noop() -> None:
 
     # Not inside asyncio.run -> no running loop. Must not raise.
     rag_module._index_rows_on_find("h", "1", rag_module._DATASET_TOKEN, [{"rid": "1-AAAA"}])
+
+
+def test_write_row_chunk_doc_type_per_kind() -> None:
+    """Row chunks carry the ML-kind doc_type so rag_search(doc_type=...) can filter.
+
+    Plugin-side resolution of issue #7: we write chunks directly to the
+    store (not via core's index_table_data), so the doc_type is ours to
+    set -- no upstream change needed. The per-user ``data:`` source-name
+    filter is independent of doc_type, so ACL posture is unchanged.
+    """
+    from deriva_ml_mcp_plugin.resources.rag import (
+        _DatasetSerializer,
+        _ExecutionSerializer,
+        _WorkflowSerializer,
+        _write_row_chunk,
+    )
+
+    cases = [
+        ("Dataset", {"rid": "1-A", "name": "x"}, _DatasetSerializer(), "ml-dataset"),
+        ("Workflow", {"rid": "1-B", "name": "y"}, _WorkflowSerializer(), "ml-workflow"),
+        (
+            "Execution",
+            {"rid": "1-C", "workflow_rid": "1-B", "status": "Created"},
+            _ExecutionSerializer(),
+            "ml-execution",
+        ),
+    ]
+    for table_name, row, serializer, expected in cases:
+        fake_store = MagicMock()
+        fake_store.delete_source = AsyncMock()
+        fake_store.add = AsyncMock()
+        _run(
+            _write_row_chunk(fake_store, f"data:h:1:u:t:{row['rid']}", table_name, row, serializer)
+        )
+        chunks = fake_store.add.await_args.args[0]
+        assert chunks, f"{table_name}: no chunks written"
+        assert all(c.doc_type == expected for c in chunks), (
+            f"{table_name}: expected doc_type {expected!r}"
+        )


### PR DESCRIPTION
Closes #7 (re-scoped).

## The unlock

#7 tracked [deriva-mcp-core#2](https://github.com/informatics-isi-edu/deriva-mcp-core/issues/2) (`index_table_data` needs a `doc_type` param) as the blocker for kind-filtered semantic search. **The premise went stale in v1.3**: this plugin writes chunks directly to the vector store, so the doc_type has been ours to set all along. Core's `rag_search` passes `doc_type` through as a plain metadata filter (verified — the enricher path already uses custom values), and the per-user `data:` source-name filter is independent of doc_type, so ACL posture is unchanged.

## Change

Chunks are now tagged by ML kind — `ml-dataset` / `ml-workflow` / `ml-execution` / `ml-vocab` (unknown tables fall back to `catalog-data`) — enabling:

```
rag_search(query="...", doc_type="ml-dataset")    # Dataset rows only
rag_search(query="...", doc_type="ml-execution")  # Execution rows only
...
```

The getting-started prompt's semantic-discovery section lists the new filters with the migration note: rows indexed before this change keep the legacy `catalog-data` tag until re-indexed (read-through refresh on list/get, or the reindex tools).

`TODO(upstream-rag-doctype)` markers removed; CLAUDE.md + `docs/coverage.md` updated (core#2 stays open upstream for plugins that use `index_table_data`; this plugin no longer depends on it). Also formats `tests/test_execution.py` (drift left by the #74 sweep).

## Verification

391 tests pass (+1 per-kind doc_type test, TDD'd red→green; 2 existing assertions updated). ruff check + format clean across src and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)