### PR TITLE
feat(asset): deriva_ml_create_asset_table — canonical asset shape over MCP (closes #15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ src/deriva_ml_mcp_plugin/
 ├── prompts.py           # 3 MCP prompts (deriva_ml_concepts /
 │                        #   _getting_started / _primer) + the
 │                        #   deriva_ml_primer + deriva_ml_get_guide orientation tools
-├── tools/               # Per-domain tool modules (47 tools total)
+├── tools/               # Per-domain tool modules (48 tools total)
 │   ├── dataset/         #   19 tools, split into focused submodules:
 │   │   ├── __init__.py  #     register aggregator + helper re-exports
 │   │   ├── read.py      #     11 read tools + shared helpers
@@ -35,7 +35,7 @@ src/deriva_ml_mcp_plugin/
 │   ├── feature.py       #    5 tools
 │   ├── workflow.py      #    5 tools
 │   ├── execution/       #    8 read-only tools (lifecycle is local Python)
-│   ├── asset.py         #    4 tools
+│   ├── asset.py         #    5 tools
 │   ├── vocabulary.py    #    1 tool (deriva_ml_create_vocabulary)
 │   ├── maintenance.py   #    2 tools (reindex_vocabularies, reindex_rows)
 │   └── resolve.py       #    1 tool (deriva_ml_describe_rid -- RID -> kind + routing)

--- a/src/deriva_ml_mcp_plugin/_response_models.py
+++ b/src/deriva_ml_mcp_plugin/_response_models.py
@@ -1217,6 +1217,22 @@ class UpdateAssetResponse(BaseModel):
     updated_fields: list[str]
 
 
+class CreateAssetTableResponse(BaseModel):
+    """Response from ``deriva_ml_create_asset_table``.
+
+    ``columns`` is the final column-name list of the created table
+    (system + standard hatrac + any additional domain columns), so the
+    caller can confirm the shape without a follow-up read.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    status: Literal["created"]
+    schema_: str = Field(alias="schema")
+    asset_table: str
+    columns: list[str]
+
+
 class CreateWorkflowResponse(BaseModel):
     """Response from ``deriva_ml_create_workflow``.
 

--- a/src/deriva_ml_mcp_plugin/prompts.py
+++ b/src/deriva_ml_mcp_plugin/prompts.py
@@ -4,7 +4,7 @@ These are MCP prompts (registered via ``@ctx.prompt(...)``), not Python
 docstrings. FastMCP surfaces them through the MCP ``prompts/list`` and
 ``prompts/get`` endpoints so an LLM client can pull them up by name at
 the start of a conversation -- they are the cold-start anchor for the
-plugin's 47 tools and 19 resources.
+plugin's 48 tools and 19 resources.
 
 The two prompts complement the four built-in core prompts shipped by
 ``deriva-mcp-core`` (``query_guide``, ``entity_guide``,
@@ -677,7 +677,7 @@ you're driving the library directly from a notebook or skill.
 
 THE FIVE ML DOMAINS
 -------------------
-Forty-one of the 47 tools are organized into five domain modules. The
+Forty-two of the 48 tools are organized into five domain modules. The
 other six: the catalog-maintenance tools
 ``deriva_ml_create_vocabulary``, ``deriva_ml_reindex_vocabularies``,
 ``deriva_ml_reindex_rows``; the cross-domain
@@ -735,12 +735,14 @@ for the wire name.
                   Claude Code clients also have the deriva-ml-skills
                   ``execution-lifecycle`` skill.
 
-    asset      -- 4 tools. File-backed catalog rows (images, model
+    asset      -- 5 tools. File-backed catalog rows (images, model
                   weights, etc.) -- catalog-state operations only.
                   File I/O (upload/download) runs in local Python; for
                   the how-to, ``rag_search(query="asset upload download",
                   doc_type="ml-docs")`` (user-guide/assets.md). Verbs:
-                  list_assets / find_assets / lookup / update. For "what
+                  list_assets / find_assets / lookup / update /
+                  create_asset_table (canonical hatrac shape +
+                  Asset_Type/Execution associations in one call). For "what
                   asset tables exist in a schema?" use the
                   deriva-ml/assets/{schema} resource (no dedicated tool).
 
@@ -1290,7 +1292,7 @@ and ``description``. There is no compat shim; update any references.
 
 THE MENU
 --------
-Quick orientation: 47 tools -- 41 across the 5 ML domains (dataset,
+Quick orientation: 48 tools -- 42 across the 5 ML domains (dataset,
 feature, workflow, execution, asset) plus 3 catalog-maintenance tools
 (create_vocabulary, reindex_vocabularies, reindex_rows), the
 cross-domain describe_rid, and the orientation pair (primer,

--- a/src/deriva_ml_mcp_plugin/tools/asset.py
+++ b/src/deriva_ml_mcp_plugin/tools/asset.py
@@ -2,7 +2,7 @@
 
 Read tools: ``deriva_ml_list_assets``, ``deriva_ml_find_assets``,
 ``deriva_ml_lookup_asset``.
-Mutation tools: ``deriva_ml_update_asset``.
+Mutation tools: ``deriva_ml_update_asset``, ``deriva_ml_create_asset_table``.
 
 Asset table discovery is exposed through the
 ``deriva://catalog/{h}/{c}/deriva-ml/assets/{schema}`` resource (in
@@ -79,6 +79,7 @@ from deriva_ml_mcp_plugin._response_models import (
     AssetExecutionRef,
     AssetListResponse,
     AssetSummary,
+    CreateAssetTableResponse,
     PreflightCountResponse,
     UpdateAssetResponse,
 )
@@ -698,4 +699,143 @@ def register(ctx: PluginContext) -> None:
                     "removed_done": removed_done,
                     "updated_fields": updated_fields,
                 },
+            )
+
+    @ctx.tool(mutates=True)
+    async def deriva_ml_create_asset_table(
+        hostname: str,
+        catalog_id: str,
+        asset_name: str,
+        additional_columns: list[dict[str, Any]] | None = None,
+        comment: str | None = None,
+        schema: str | None = None,
+        use_hatrac: bool = True,
+        update_navbar: bool = True,
+    ) -> str:
+        """Create a new asset table with the canonical DerivaML asset shape.
+
+        One call builds everything an asset table needs, so the shape can
+        never drift from the canonical form (the result always satisfies
+        ``model.is_asset``): the five standard hatrac columns (``URL``,
+        ``Filename``, ``Length``, ``MD5``, ``Description``), the
+        ``<name>_Asset_Type`` tag association, the ``<name>_Execution``
+        association carrying the ``Asset_Role`` FK that the execution
+        upload machinery writes, and the standard Chaise display
+        annotations. Use THIS (not the generic ``create_table``) for any
+        file-backed table -- the manual hatrac recipe is verbose and easy
+        to get subtly wrong.
+
+        Table creation is catalog-state work and belongs on this surface;
+        uploading FILES into the new table remains local-Python territory
+        (see the module scope note / ``rag_search("asset upload download",
+        doc_type="ml-docs")``).
+
+        Args:
+            asset_name: Name for the new asset table. Must be a valid SQL
+                identifier (e.g. ``"Scan_File"``).
+            additional_columns: Optional domain-specific columns appended
+                to the standard hatrac shape. Each entry is a dict:
+                ``{"name": str (required), "type": str (required -- a
+                BuiltinTypes name like "text", "int4", "float8",
+                "boolean", "date", "timestamptz", "markdown"),
+                "nullok": bool (default true), "comment": str}``.
+            comment: Description of the asset table's purpose.
+            schema: Schema to create the table in. ``None`` (default)
+                means the catalog's domain schema.
+            use_hatrac: When true (default) the ``URL`` column is wired
+                with the Hatrac upload template (Chaise's file-upload UI
+                deposits bytes into Hatrac). False yields a plain-string
+                URL column for assets whose bytes live elsewhere.
+            update_navbar: If true (default), refresh the navigation bar
+                to include the new table. Set false during batch
+                creation, then apply catalog annotations once at the end
+                via the Python API (``ml.apply_catalog_annotations()``).
+
+        Returns:
+            JSON string ``{"status": "created", "schema", "asset_table",
+            "columns": [<all column names>]}``. Supplying an unknown
+            column ``type`` returns ``{"error": ...}`` naming the valid
+            type names, without touching the catalog.
+
+        Raises:
+            RuntimeError: Wrapped as ``{"error": ...}``, propagated from
+                ``deriva_ml.DerivaML.create_asset_table`` (e.g. table
+                already exists, unknown schema).
+
+        Example:
+            ``{"status": "created", "schema": "eye-ai", "asset_table":
+            "Scan_File", "columns": ["RID", "URL", "Filename", "Length",
+            "MD5", "Description", "Scanner_Model"]}``.
+        """
+        # Map LLM-friendly column dicts to deriva-ml ColumnDefinitions
+        # BEFORE touching the catalog, so a bad type name costs nothing.
+        from deriva_ml.core.definitions import BuiltinTypes, ColumnDefinition
+
+        column_defs = []
+        for spec in additional_columns or []:
+            name = spec.get("name")
+            type_name = spec.get("type")
+            if not name or not type_name:
+                return json.dumps(
+                    {"error": "each additional_columns entry requires 'name' and 'type'"}
+                )
+            try:
+                col_type = BuiltinTypes[type_name]
+            except KeyError:
+                valid = ", ".join(t.name for t in BuiltinTypes)
+                return json.dumps(
+                    {
+                        "error": (
+                            f"unknown column type {type_name!r} for column {name!r}; "
+                            f"valid types: {valid}"
+                        )
+                    }
+                )
+            column_defs.append(
+                ColumnDefinition(
+                    name=name,
+                    type=col_type,
+                    nullok=spec.get("nullok", True),
+                    comment=spec.get("comment"),
+                )
+            )
+
+        try:
+            with deriva_call():
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive (table + two association
+                # creates plus optional navbar annotation apply).
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+
+                def _create():
+                    return ml.create_asset_table(
+                        asset_name,
+                        additional_columns=column_defs,
+                        comment=comment,
+                        schema=schema,
+                        use_hatrac=use_hatrac,
+                        update_navbar=update_navbar,
+                    )
+
+                table = await asyncio.to_thread(_create)
+            audit_event(
+                "deriva_ml_create_asset_table",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                asset_name=asset_name,
+                schema=table.schema.name,
+            )
+            return CreateAssetTableResponse(
+                status="created",
+                schema_=table.schema.name,
+                asset_table=table.name,
+                columns=[c.name for c in table.columns],
+            ).model_dump_json(by_alias=True)
+        except Exception as exc:
+            return _error_envelope(
+                exc,
+                operation="create_asset_table",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                asset_name=asset_name,
             )

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -678,3 +678,94 @@ async def test_update_asset_partial_remove_failure_surfaces_progress(
     assert failed
     assert failed[0].kwargs["added_done"] == ["NewTag"]
     assert failed[0].kwargs["removed_done"] == ["A"]
+
+
+# ---------------------------------------------------------------------------
+# create_asset_table (plugin#15 -- thin wrapper over deriva-ml#292)
+# ---------------------------------------------------------------------------
+
+
+def _make_created_table_mock(name="Scan_File", schema="domain"):
+    t = MagicMock()
+    t.name = name
+    t.schema.name = schema
+    cols = []
+    for cname in ("RID", "URL", "Filename", "Length", "MD5", "Description", "Scanner_Model"):
+        c = MagicMock()
+        c.name = cname
+        cols.append(c)
+    t.columns = cols
+    return t
+
+
+async def test_create_asset_table_success_maps_columns_and_audits(
+    asset_ctx, capturing_mcp, mock_ml
+):
+    """Success: additional_columns dicts map to ColumnDefinition; audit fires."""
+    mock_ml.create_asset_table.return_value = _make_created_table_mock()
+
+    with _patch_asset_audit() as mock_audit:
+        out = json.loads(
+            await capturing_mcp.tools["deriva_ml_create_asset_table"](
+                hostname="h",
+                catalog_id="1",
+                asset_name="Scan_File",
+                additional_columns=[
+                    {"name": "Scanner_Model", "type": "text", "comment": "Device model"},
+                ],
+                comment="Raw scanner output files.",
+            )
+        )
+
+    assert out["status"] == "created"
+    assert out["asset_table"] == "Scan_File"
+    assert out["schema"] == "domain"
+    assert "Scanner_Model" in out["columns"]
+    assert "URL" in out["columns"]
+
+    mock_ml.create_asset_table.assert_called_once()
+    kwargs = mock_ml.create_asset_table.call_args.kwargs
+    assert kwargs["comment"] == "Raw scanner output files."
+    (coldef,) = kwargs["additional_columns"]
+    assert coldef.name == "Scanner_Model"
+    assert coldef.type.name == "text"
+    assert coldef.comment == "Device model"
+
+    success = _success_calls(mock_audit, "deriva_ml_create_asset_table")
+    assert success
+    assert success[0].kwargs["asset_name"] == "Scan_File"
+
+
+async def test_create_asset_table_invalid_column_type_returns_error(
+    asset_ctx, capturing_mcp, mock_ml
+):
+    """A bad additional_columns type name errors WITHOUT touching the catalog."""
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_create_asset_table"](
+            hostname="h",
+            catalog_id="1",
+            asset_name="Scan_File",
+            additional_columns=[{"name": "X", "type": "varchar"}],
+        )
+    )
+    assert "error" in out
+    assert "varchar" in out["error"]
+    mock_ml.create_asset_table.assert_not_called()
+
+
+async def test_create_asset_table_failure_emits_failed_audit(asset_ctx, capturing_mcp, mock_ml):
+    """A deriva-ml failure lands as the error envelope + failed audit event."""
+    mock_ml.create_asset_table.side_effect = RuntimeError("Table Scan_File already exist")
+
+    with _patch_asset_audit() as mock_audit:
+        out = json.loads(
+            await capturing_mcp.tools["deriva_ml_create_asset_table"](
+                hostname="h", catalog_id="1", asset_name="Scan_File"
+            )
+        )
+    assert out == {
+        "error": "Table Scan_File already exist",
+        "error_type": "RuntimeError",
+    }
+    failed = _success_calls(mock_audit, "deriva_ml_create_asset_table_failed")
+    assert failed

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -120,6 +120,9 @@ _EXECUTION_TOOLS = frozenset(
 # ``list_assets`` calls plus client-side filtering.
 _ASSET_TOOLS = frozenset(
     {
+        # plugin#15: thin wrapper over DerivaML.create_asset_table
+        # (deriva-ml#292) -- canonical asset shape in one call.
+        "deriva_ml_create_asset_table",
         "deriva_ml_list_assets",
         "deriva_ml_find_assets",
         "deriva_ml_lookup_asset",

--- a/uv.lock
+++ b/uv.lock
@@ -691,8 +691,8 @@ dependencies = [
 
 [[package]]
 name = "deriva-ml"
-version = "1.45.0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#5158d8f93043011f23b7ac2c0275479aadeb2a14" }
+version = "1.46.1.post1+g211f6534a"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#211f6534afebcb4c84d80c9545eb47df4a6192ba" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
Closes #15. Completes the Round A pipeline: deriva-ml#74 → [deriva-ml#292](https://github.com/informatics-isi-edu/deriva-ml/pull/292) (merged) → this wrapper.

## What

`deriva_ml_create_asset_table(hostname, catalog_id, asset_name, additional_columns=None, comment=None, schema=None, use_hatrac=True, update_navbar=True)` — one call creates the canonical asset shape (5 hatrac columns, `Asset_Type` tag association, `Execution` association with `Asset_Role` FK, Chaise annotations). The result always satisfies `model.is_asset`.

- **LLM-friendly columns**: `additional_columns` takes dicts (`{"name","type","nullok","comment"}`), mapped to `ColumnDefinition`s **before** any catalog call — an unknown type returns `{"error": ...}` listing valid `BuiltinTypes` with zero catalog cost.
- `mutates=True`, audit events `deriva_ml_create_asset_table` / `_failed`.
- New `CreateAssetTableResponse` (`extra="forbid"`); the returned column list confirms the shape without a follow-up read.
- Boundary kept: table creation is catalog-state (in scope); file upload stays local-Python.

## Verification

- 3 new tests (TDD red→green): success + column mapping + success audit; invalid-type preflight rejection (catalog untouched); failure envelope + failed audit. **394 total pass.**
- `_ASSET_TOOLS` frozenset, prompt counts (48 tools / asset 5), CLAUDE.md tree updated in lockstep.
- `uv.lock` bumped to deriva-ml @ `211f6534` (carries the library method); runtime presence verified.

## Release note

Deployments install deriva-ml `@main` so this works on the next rebuild; for a pinned release, cut deriva-ml `v1.47.0` first, then this plugin's minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)