### PR TITLE
feat(tools): Round B impact-analysis wrappers (find_datasets/features_referencing)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,13 +26,13 @@ src/deriva_ml_mcp_plugin/
 ├── prompts.py           # 3 MCP prompts (deriva_ml_concepts /
 │                        #   _getting_started / _primer) + the
 │                        #   deriva_ml_primer + deriva_ml_get_guide orientation tools
-├── tools/               # Per-domain tool modules (48 tools total)
-│   ├── dataset/         #   19 tools, split into focused submodules:
+├── tools/               # Per-domain tool modules (50 tools total)
+│   ├── dataset/         #   20 tools, split into focused submodules:
 │   │   ├── __init__.py  #     register aggregator + helper re-exports
-│   │   ├── read.py      #     11 read tools + shared helpers
+│   │   ├── read.py      #     12 read tools + shared helpers
 │   │   ├── mutate.py    #     7 mutation tools
 │   │   └── complex.py   #     1 complex tool (denormalize)
-│   ├── feature.py       #    5 tools
+│   ├── feature.py       #    6 tools
 │   ├── workflow.py      #    5 tools
 │   ├── execution/       #    8 read-only tools (lifecycle is local Python)
 │   ├── asset.py         #    5 tools

--- a/src/deriva_ml_mcp_plugin/_response_models.py
+++ b/src/deriva_ml_mcp_plugin/_response_models.py
@@ -254,6 +254,38 @@ class DatasetListResponse(_PaginationFields):
     datasets: list[DatasetSummary]
 
 
+class DatasetReferenceEntry(BaseModel):
+    """One dataset that references a table.
+
+    Wire mirror of ``deriva_ml.DatasetReference`` (constructed via
+    ``model_dump()`` so library-side field additions fail loudly under
+    ``extra="forbid"`` instead of silently changing the wire shape).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_rid: str
+    element_table: str
+    member_count: int
+
+
+class DatasetReferencesResponse(BaseModel):
+    """Response for ``deriva_ml_find_datasets_referencing``.
+
+    ``column`` echoes the request filter (``null`` when the caller did
+    not narrow to a column). ``count == 0`` with an empty ``references``
+    list is the normal "nothing references this table" answer, not an
+    error.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    table: str
+    column: str | None = None
+    count: int
+    references: list[DatasetReferenceEntry]
+
+
 class DatasetMemberRef(BaseModel):
     """One dataset member: ``{"table": str, "rid": str}`` flat shape."""
 
@@ -670,6 +702,39 @@ class FeatureListResponse(_PaginationFields):
     """Paginated list of Features. Produced by ``_list_features_impl``."""
 
     features: list[FeatureSummary]
+
+
+class FeatureReferenceEntry(BaseModel):
+    """One feature definition that references a table.
+
+    Wire mirror of ``deriva_ml.FeatureReference`` (constructed via
+    ``model_dump()`` so library-side field additions fail loudly under
+    ``extra="forbid"`` instead of silently changing the wire shape).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    feature_name: str
+    target_table: str
+    feature_table: str
+    referencing_columns: list[str]
+
+
+class FeatureReferencesResponse(BaseModel):
+    """Response for ``deriva_ml_find_features_referencing``.
+
+    ``column`` echoes the request filter (``null`` when the caller did
+    not narrow to a column). ``count == 0`` with an empty ``references``
+    list is the normal "no feature references this table" answer, not
+    an error.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    table: str
+    column: str | None = None
+    count: int
+    references: list[FeatureReferenceEntry]
 
 
 class FeatureValueRecord(BaseModel):

--- a/src/deriva_ml_mcp_plugin/prompts.py
+++ b/src/deriva_ml_mcp_plugin/prompts.py
@@ -4,7 +4,7 @@ These are MCP prompts (registered via ``@ctx.prompt(...)``), not Python
 docstrings. FastMCP surfaces them through the MCP ``prompts/list`` and
 ``prompts/get`` endpoints so an LLM client can pull them up by name at
 the start of a conversation -- they are the cold-start anchor for the
-plugin's 48 tools and 19 resources.
+plugin's 50 tools and 19 resources.
 
 The two prompts complement the four built-in core prompts shipped by
 ``deriva-mcp-core`` (``query_guide``, ``entity_guide``,
@@ -677,7 +677,7 @@ you're driving the library directly from a notebook or skill.
 
 THE FIVE ML DOMAINS
 -------------------
-Forty-two of the 48 tools are organized into five domain modules. The
+Forty-four of the 50 tools are organized into five domain modules. The
 other six: the catalog-maintenance tools
 ``deriva_ml_create_vocabulary``, ``deriva_ml_reindex_vocabularies``,
 ``deriva_ml_reindex_rows``; the cross-domain
@@ -690,18 +690,20 @@ the ``deriva_ml_create_dataset`` tool). The bare verbs below name the
 concept; prepend ``deriva_ml_`` (and append the noun where natural)
 for the wire name.
 
-    dataset    -- 19 tools. Curated bundles of catalog rows (image
+    dataset    -- 20 tools. Curated bundles of catalog rows (image
                   collections, training subsets, splits). Verbs:
                   list / get / list_members / list_relations /
-                  list_element_types / create / delete / add_members /
+                  list_element_types / find_datasets_referencing /
+                  create / delete / add_members /
                   delete_members / update / add_element_type / release /
                   get_dataset_spec / bag_info / denormalize /
                   validate_dataset_specs / validate_execution_configuration /
                   validate_config_file / bootstrap_config.
 
-    feature    -- 5 tools. Per-row labels, scores, and asset attachments
+    feature    -- 6 tools. Per-row labels, scores, and asset attachments
                   attached to a target table. Verbs: list / get /
-                  list_feature_values / create / delete.
+                  list_feature_values / find_features_referencing /
+                  create / delete.
                   Writing feature VALUES (add_feature_values) is a
                   user-local Python operation -- see the execution
                   domain note below.
@@ -934,6 +936,9 @@ COMMON TASKS -> WHERE TO LOOK
     "upload / fetch a file"        exe.asset_file_path / exe.download_asset
                                    (local); rag_search "asset upload download"
     "which runs used dataset X?"   find_dataset_executions / get_lineage
+    "will changing table X break   find_datasets_referencing +
+     anything?"                    find_features_referencing (impact
+                                   analysis before schema evolution)
     "why is my run failing?"       rag_search "troubleshoot execution",
                                    doc_type="ml-docs"
 
@@ -1292,7 +1297,7 @@ and ``description``. There is no compat shim; update any references.
 
 THE MENU
 --------
-Quick orientation: 48 tools -- 42 across the 5 ML domains (dataset,
+Quick orientation: 50 tools -- 44 across the 5 ML domains (dataset,
 feature, workflow, execution, asset) plus 3 catalog-maintenance tools
 (create_vocabulary, reindex_vocabularies, reindex_rows), the
 cross-domain describe_rid, and the orientation pair (primer,

--- a/src/deriva_ml_mcp_plugin/tools/dataset/read.py
+++ b/src/deriva_ml_mcp_plugin/tools/dataset/read.py
@@ -1,8 +1,9 @@
 """Read-only dataset tools and shared dataset helpers.
 
-This submodule houses the 11 read tools (``deriva_ml_list_datasets``,
+This submodule houses the 12 read tools (``deriva_ml_list_datasets``,
 ``deriva_ml_get_dataset``, ``deriva_ml_list_dataset_members``,
 ``deriva_ml_list_dataset_relations``, ``deriva_ml_list_dataset_element_types``,
+``deriva_ml_find_datasets_referencing``,
 ``deriva_ml_bag_info``, ``deriva_ml_get_dataset_spec``,
 ``deriva_ml_validate_dataset_specs``,
 ``deriva_ml_validate_execution_configuration``,
@@ -54,6 +55,8 @@ from deriva_ml_mcp_plugin._response_models import (
     DatasetListResponse,
     DatasetMemberRef,
     DatasetMembersSummaryResponse,
+    DatasetReferenceEntry,
+    DatasetReferencesResponse,
     DatasetRelationsResponse,
     DatasetSummary,
     DatasetVersionEntry,
@@ -803,6 +806,72 @@ def register(ctx: PluginContext) -> None:
             return _error_envelope(
                 exc,
                 operation="list_dataset_element_types",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,
+            )
+
+    @ctx.tool(mutates=False)
+    async def deriva_ml_find_datasets_referencing(
+        hostname: str,
+        catalog_id: str,
+        table: str,
+        column: str | None = None,
+    ) -> str:
+        """Find datasets that contain members from a given table.
+
+        Impact analysis for schema evolution: before altering or
+        dropping a table (or one of its columns), ask which datasets
+        would be affected. This is the reverse direction of
+        ``deriva_ml_list_dataset_element_types`` -- that tool says
+        "which tables CAN be dataset members"; this one says "which
+        datasets DO hold members of this table right now".
+
+        Args:
+            table: Name of the table to check (e.g. ``"Image"``).
+            column: Optional column name. When set, only report
+                datasets whose association with ``table`` involves this
+                column. When None (default), any reference counts.
+
+        Returns:
+            JSON string ``{"table", "column", "count", "references":
+            [{"dataset_rid", "element_table", "member_count"}, ...]}``.
+            ``count == 0`` with empty ``references`` means no dataset
+            currently holds members of this table -- a normal answer,
+            not an error.
+
+        Raises:
+            DerivaMLException: Wrapped as ``{"error": ...}`` -- e.g.
+                when ``table`` does not exist in the catalog.
+
+        Example:
+            ``{"table": "Image", "column": null, "count": 2,
+            "references": [{"dataset_rid": "1-AAAA", "element_table":
+            "Image", "member_count": 550}, {"dataset_rid": "1-BBBB",
+            "element_table": "Image", "member_count": 110}]}``
+        """
+        try:
+            with deriva_call():
+                # Run the synchronous deriva-ml calls in a thread pool
+                # so the event loop stays responsive.
+                # ``find_datasets_referencing`` does a bulk fetch over
+                # the association table. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in
+                # threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                refs = await asyncio.to_thread(
+                    partial(ml.find_datasets_referencing, table, column=column)
+                )
+            return DatasetReferencesResponse(
+                table=table,
+                column=column,
+                count=len(refs),
+                references=[DatasetReferenceEntry(**r.model_dump()) for r in refs],
+            ).model_dump_json(by_alias=True)
+        except Exception as exc:
+            return _error_envelope(
+                exc,
+                operation="find_datasets_referencing",
                 hostname=hostname,
                 catalog_id=catalog_id,
                 audit=False,

--- a/src/deriva_ml_mcp_plugin/tools/feature.py
+++ b/src/deriva_ml_mcp_plugin/tools/feature.py
@@ -1,6 +1,7 @@
 """Feature domain tools for deriva-ml-mcp-plugin.
 
-Read tools: ``deriva_ml_list_features``, ``deriva_ml_get_feature``, ``deriva_ml_list_feature_values``.
+Read tools: ``deriva_ml_list_features``, ``deriva_ml_get_feature``,
+``deriva_ml_list_feature_values``, ``deriva_ml_find_features_referencing``.
 Mutation tools: ``deriva_ml_create_feature``, ``deriva_ml_delete_feature``.
 
 v0.5.0 removed ``deriva_ml_add_feature_values`` -- writing feature
@@ -23,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
 
 from deriva_mcp_core import deriva_call
@@ -47,6 +49,8 @@ from deriva_ml_mcp_plugin._response_models import (
     CreateFeatureResponse,
     DeleteFeatureResponse,
     FeatureListResponse,
+    FeatureReferenceEntry,
+    FeatureReferencesResponse,
     FeatureSummary,
     FeatureValueListResponse,
     FeatureValueRecord,
@@ -301,6 +305,77 @@ def register(ctx: PluginContext) -> None:
             return _error_envelope(
                 exc,
                 operation="list_features",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,
+            )
+
+    @ctx.tool(mutates=False)
+    async def deriva_ml_find_features_referencing(
+        hostname: str,
+        catalog_id: str,
+        table: str,
+        column: str | None = None,
+    ) -> str:
+        """Find feature definitions whose association table references a table.
+
+        Impact analysis for schema evolution: a feature's association
+        table carries foreign keys to its target table, its vocabulary
+        (term) tables, and its asset tables. Before altering or
+        dropping any of those tables (or one of their columns), ask
+        which feature definitions would be affected. This is the
+        reverse direction of ``deriva_ml_list_features`` -- that tool
+        says "which features are defined ON this target table"; this
+        one says "which features REFER TO this table from any FK role
+        (target, vocabulary, or asset)".
+
+        Args:
+            table: Name of the table to check (e.g. a vocabulary table
+                like ``"ImageQuality"`` or an asset table).
+            column: Optional column name on ``table``. When set, only
+                report features whose FK references this specific
+                column. When None (default), any referenced column
+                counts.
+
+        Returns:
+            JSON string ``{"table", "column", "count", "references":
+            [{"feature_name", "target_table", "feature_table",
+            "referencing_columns"}, ...]}``. ``count == 0`` with empty
+            ``references`` means no feature references this table -- a
+            normal answer, not an error.
+
+        Raises:
+            DerivaMLException: Wrapped as ``{"error": ...}`` -- e.g.
+                when ``table`` does not exist in the catalog.
+
+        Example:
+            ``{"table": "ImageQuality", "column": null, "count": 1,
+            "references": [{"feature_name": "Quality", "target_table":
+            "Image", "feature_table": "Execution_Image_Quality",
+            "referencing_columns": ["ImageQuality"]}]}``
+        """
+        try:
+            with deriva_call():
+                # Run the synchronous deriva-ml calls in a thread pool
+                # so the event loop stays responsive.
+                # ``find_features_referencing`` walks every feature
+                # definition's FK set. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in
+                # threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                refs = await asyncio.to_thread(
+                    partial(ml.find_features_referencing, table, column=column)
+                )
+            return FeatureReferencesResponse(
+                table=table,
+                column=column,
+                count=len(refs),
+                references=[FeatureReferenceEntry(**r.model_dump()) for r in refs],
+            ).model_dump_json(by_alias=True)
+        except Exception as exc:
+            return _error_envelope(
+                exc,
+                operation="find_features_referencing",
                 hostname=hostname,
                 catalog_id=catalog_id,
                 audit=False,

--- a/tests/test_dataset_read.py
+++ b/tests/test_dataset_read.py
@@ -981,3 +981,54 @@ async def test_bootstrap_config_error_path(dataset_ctx, capturing_mcp, mock_ml) 
     result = await capturing_mcp.tools["deriva_ml_bootstrap_config"](hostname="h", catalog_id="1")
     out = json.loads(result)
     assert out == {"error": "cannot connect", "error_type": "RuntimeError"}
+
+
+# ---------------------------------------------------------------------------
+# find_datasets_referencing (plugin#25 -- Round B wrapper over deriva-ml#294)
+# ---------------------------------------------------------------------------
+
+
+async def test_find_datasets_referencing_success(dataset_ctx, capturing_mcp, mock_ml):
+    """Wrapper maps library DatasetReference models to the wire shape."""
+    from deriva_ml import DatasetReference
+
+    mock_ml.find_datasets_referencing.return_value = [
+        DatasetReference(dataset_rid="1-AAAA", element_table="Image", member_count=550),
+        DatasetReference(dataset_rid="1-BBBB", element_table="Image", member_count=110),
+    ]
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_datasets_referencing"](
+            hostname="h", catalog_id="1", table="Image"
+        )
+    )
+    assert out["table"] == "Image"
+    assert out["column"] is None
+    assert out["count"] == 2
+    assert out["references"][0] == {
+        "dataset_rid": "1-AAAA",
+        "element_table": "Image",
+        "member_count": 550,
+    }
+    mock_ml.find_datasets_referencing.assert_called_once_with("Image", column=None)
+
+
+async def test_find_datasets_referencing_empty(dataset_ctx, capturing_mcp, mock_ml):
+    """Unreferenced table -> count 0, empty references (not an error)."""
+    mock_ml.find_datasets_referencing.return_value = []
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_datasets_referencing"](
+            hostname="h", catalog_id="1", table="Observation", column="URL"
+        )
+    )
+    assert out == {"table": "Observation", "column": "URL", "count": 0, "references": []}
+
+
+async def test_find_datasets_referencing_error_envelope(dataset_ctx, capturing_mcp, mock_ml):
+    """Unknown table propagates as the standard error envelope."""
+    mock_ml.find_datasets_referencing.side_effect = RuntimeError("Table FooBar not found")
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_datasets_referencing"](
+            hostname="h", catalog_id="1", table="FooBar"
+        )
+    )
+    assert out == {"error": "Table FooBar not found", "error_type": "RuntimeError"}

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -747,3 +747,55 @@ async def test_delete_feature_failure_emits_failed_audit(feature_ctx, capturing_
     failed = _success_calls(mock_audit, "deriva_ml_delete_feature_failed")
     assert failed
     assert failed[0].kwargs["error_type"] == "RuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# find_features_referencing (plugin#25 -- Round B wrapper over deriva-ml#294)
+# ---------------------------------------------------------------------------
+
+
+async def test_find_features_referencing_success(feature_ctx, capturing_mcp, mock_ml):
+    """Wrapper maps library FeatureReference models to the wire shape."""
+    from deriva_ml import FeatureReference
+
+    mock_ml.find_features_referencing.return_value = [
+        FeatureReference(
+            feature_name="Quality",
+            target_table="Image",
+            feature_table="Execution_Image_Quality",
+            referencing_columns=["ImageQuality"],
+        ),
+    ]
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_features_referencing"](
+            hostname="h", catalog_id="1", table="ImageQuality"
+        )
+    )
+    assert out["table"] == "ImageQuality"
+    assert out["count"] == 1
+    assert out["references"][0]["feature_name"] == "Quality"
+    assert out["references"][0]["referencing_columns"] == ["ImageQuality"]
+    mock_ml.find_features_referencing.assert_called_once_with("ImageQuality", column=None)
+
+
+async def test_find_features_referencing_column_narrows(feature_ctx, capturing_mcp, mock_ml):
+    """column= is forwarded to the library method."""
+    mock_ml.find_features_referencing.return_value = []
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_features_referencing"](
+            hostname="h", catalog_id="1", table="Image", column="RID"
+        )
+    )
+    assert out == {"table": "Image", "column": "RID", "count": 0, "references": []}
+    mock_ml.find_features_referencing.assert_called_once_with("Image", column="RID")
+
+
+async def test_find_features_referencing_error_envelope(feature_ctx, capturing_mcp, mock_ml):
+    """Unknown table propagates as the standard error envelope."""
+    mock_ml.find_features_referencing.side_effect = RuntimeError("Table FooBar not found")
+    out = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_features_referencing"](
+            hostname="h", catalog_id="1", table="FooBar"
+        )
+    )
+    assert out == {"error": "Table FooBar not found", "error_type": "RuntimeError"}

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -27,6 +27,9 @@ _DATASET_TOOLS = frozenset(
         "deriva_ml_list_dataset_members",
         "deriva_ml_list_dataset_relations",
         "deriva_ml_list_dataset_element_types",
+        # Round B (plugin#25): reverse-lookup impact analysis over
+        # deriva-ml's find_datasets_referencing.
+        "deriva_ml_find_datasets_referencing",
         "deriva_ml_bag_info",
         "deriva_ml_get_dataset_spec",
         # v3.3: cheap metadata-only pre-flight validators (see deriva-ml ADR-0002).
@@ -61,6 +64,9 @@ _FEATURE_TOOLS = frozenset(
         "deriva_ml_list_features",
         "deriva_ml_get_feature",
         "deriva_ml_list_feature_values",
+        # Round B (plugin#25): reverse-lookup impact analysis over
+        # deriva-ml's find_features_referencing.
+        "deriva_ml_find_features_referencing",
         # Mutation tools (catalog-state only -- feature definition).
         # deriva_ml_add_feature_values was removed in v0.5.0 because
         # feature staging writes to a per-process SQLite manifest; the

--- a/uv.lock
+++ b/uv.lock
@@ -691,8 +691,8 @@ dependencies = [
 
 [[package]]
 name = "deriva-ml"
-version = "1.46.1.post1+g211f6534a"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#211f6534afebcb4c84d80c9545eb47df4a6192ba" }
+version = "1.46.1.post2+gdc69017f5"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#dc69017f5aba1a9cf55b79b5b79ee55eb7f6987f" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
Closes #25.

Thin `mutates=False` wrappers over the deriva-ml Round B library methods (informatics-isi-edu/deriva-ml#294, merged):

- **`deriva_ml_find_datasets_referencing(hostname, catalog_id, table, column=None)`** (`tools/dataset/read.py`) — which datasets currently hold members of a table. Reverse direction of `deriva_ml_list_dataset_element_types`.
- **`deriva_ml_find_features_referencing(hostname, catalog_id, table, column=None)`** (`tools/feature.py`) — which feature definitions reference a table from any FK role (target / vocabulary / asset).

Both answer the schema-evolution question "will changing table X break anything?" before a destructive change.

## Wire shape

`{"table", "column", "count", "references": [...]}` — `count == 0` with empty `references` is the normal "nothing references this" answer, not an error. New Pydantic models (`extra="forbid"`) mirror the library's `DatasetReference` / `FeatureReference` via `model_dump()` so upstream field drift fails loudly at construction.

## Sweeps

- Prompt counts 48 → 50 (`dataset` 19 → 20, `feature` 5 → 6); domain verb lists; new COMMON TASKS row.
- `tests/test_plugin.py` frozenset pins, module docstring rosters, CLAUDE.md tree.
- `uv.lock` bumped to deriva-ml main (carries #294).

## Tests

6 new (success mapping with real library models, empty-result, `column=` forwarding, error envelope ×2). Full suite: **400 passed**, ruff clean.

Round C (#26) stays blocked on deriva-ml#296 (still open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)