### PR TITLE
feat(execution): Round C wrappers -- find_executions_consuming + multirun_status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ src/deriva_ml_mcp_plugin/
 ├── prompts.py           # 3 MCP prompts (deriva_ml_concepts /
 │                        #   _getting_started / _primer) + the
 │                        #   deriva_ml_primer + deriva_ml_get_guide orientation tools
-├── tools/               # Per-domain tool modules (50 tools total)
+├── tools/               # Per-domain tool modules (52 tools total)
 │   ├── dataset/         #   20 tools, split into focused submodules:
 │   │   ├── __init__.py  #     register aggregator + helper re-exports
 │   │   ├── read.py      #     12 read tools + shared helpers
@@ -34,13 +34,13 @@ src/deriva_ml_mcp_plugin/
 │   │   └── complex.py   #     1 complex tool (denormalize)
 │   ├── feature.py       #    6 tools
 │   ├── workflow.py      #    5 tools
-│   ├── execution/       #    8 read-only tools (lifecycle is local Python)
+│   ├── execution/       #   10 read-only tools (lifecycle is local Python)
 │   ├── asset.py         #    5 tools
 │   ├── vocabulary.py    #    1 tool (deriva_ml_create_vocabulary)
 │   ├── maintenance.py   #    2 tools (reindex_vocabularies, reindex_rows)
 │   └── resolve.py       #    1 tool (deriva_ml_describe_rid -- RID -> kind + routing)
 └── resources/           # MCP resources + per-user RAG
-    ├── ml.py            #   19 resources (16 catalog-scoped under
+    ├── ml.py            #   21 resources (18 catalog-scoped under
     │                    #   deriva://catalog/{h}/{c}/deriva-ml/... + 3 static)
     └── rag.py           #   1 GitHub doc source +
                          #   read-through per-user-per-RID writers (Dataset/Workflow/Execution,

--- a/src/deriva_ml_mcp_plugin/_response_models.py
+++ b/src/deriva_ml_mcp_plugin/_response_models.py
@@ -675,6 +675,38 @@ class ExecutionParentsResponse(BaseModel):
     parents: list[ExecutionSummary]
 
 
+class ExecutionConsumersResponse(BaseModel):
+    """Response for ``deriva_ml_find_executions_consuming`` (forward lineage).
+
+    ``count == 0`` with an empty ``consumers`` list means no RECORDED
+    consumption -- the "is it safe to delete this?" green light, not an
+    error. Producers are not consumers and are excluded.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    rid: str
+    count: int
+    consumers: list[ExecutionSummary]
+
+
+class MultirunStatusResponse(BaseModel):
+    """Response for ``deriva_ml_multirun_status``.
+
+    Wire mirror of ``deriva_ml``'s ``MultirunStatusSummary``
+    (constructed via ``model_dump()`` so library-side field additions
+    fail loudly under ``extra="forbid"``). ``counts`` maps status name
+    to execution count; null catalog statuses are counted under
+    ``"Created"`` by the library.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_rid: str
+    counts: dict[str, int]
+    total: int
+
+
 # ---------------------------------------------------------------------------
 # Feature response models
 # ---------------------------------------------------------------------------

--- a/src/deriva_ml_mcp_plugin/prompts.py
+++ b/src/deriva_ml_mcp_plugin/prompts.py
@@ -4,7 +4,7 @@ These are MCP prompts (registered via ``@ctx.prompt(...)``), not Python
 docstrings. FastMCP surfaces them through the MCP ``prompts/list`` and
 ``prompts/get`` endpoints so an LLM client can pull them up by name at
 the start of a conversation -- they are the cold-start anchor for the
-plugin's 50 tools and 19 resources.
+plugin's 52 tools and 21 resources.
 
 The two prompts complement the four built-in core prompts shipped by
 ``deriva-mcp-core`` (``query_guide``, ``entity_guide``,
@@ -677,7 +677,7 @@ you're driving the library directly from a notebook or skill.
 
 THE FIVE ML DOMAINS
 -------------------
-Forty-four of the 50 tools are organized into five domain modules. The
+Forty-six of the 52 tools are organized into five domain modules. The
 other six: the catalog-maintenance tools
 ``deriva_ml_create_vocabulary``, ``deriva_ml_reindex_vocabularies``,
 ``deriva_ml_reindex_rows``; the cross-domain
@@ -712,13 +712,19 @@ for the wire name.
                   URL + checksum + workflow_type). Verbs: list / get /
                   find_workflow_by_url / create / update.
 
-    execution  -- 8 tools (read-only). A single run of a workflow
+    execution  -- 10 tools (read-only). A single run of a workflow
                   against datasets and assets. The MCP surface for
                   executions is observational only: list / get /
                   find_workflow_executions / find_dataset_executions /
                   list_execution_children /
                   list_execution_parents / find_experiments /
-                  get_lineage. ``find_dataset_executions`` answers
+                  get_lineage / find_executions_consuming /
+                  multirun_status. ``find_executions_consuming`` is
+                  forward lineage ("what consumed this dataset/asset?"
+                  -- the "safe to delete?" check); ``multirun_status``
+                  aggregates status counts across one workflow's
+                  executions ("is the sweep done?").
+                  ``find_dataset_executions`` answers
                   "which runs used this dataset?" -- role is derived
                   relationally (input = a Dataset_Execution edge,
                   output = Dataset_Version authorship), never from a
@@ -809,6 +815,12 @@ The full read-only resource family:
                                                     ``metadata``) + experiment
     deriva://catalog/{h}/{c}/deriva-ml/lineage/{rid}    -- provenance chain for any artifact
                                                     (Dataset, Asset, Feature value, Execution)
+    deriva://catalog/{h}/{c}/deriva-ml/lineage-forward/{rid}
+                                                 -- forward lineage: executions that CONSUMED
+                                                    this Dataset/asset (empty = safe to delete)
+    deriva://catalog/{h}/{c}/deriva-ml/workflow/{rid}/multirun-status
+                                                 -- status counts across one workflow's
+                                                    executions ("is the sweep done?")
     deriva://catalog/{h}/{c}/deriva-ml/features/{table} -- features defined on one table
     deriva://catalog/{h}/{c}/deriva-ml/asset/{rid}      -- one asset + bundled executions
     deriva://catalog/{h}/{c}/deriva-ml/assets/{schema}  -- asset tables in one schema
@@ -853,6 +865,8 @@ resource cannot express (status, workflow, deleted-only, etc.).
     deriva://catalog/{h}/{c}/deriva-ml/assets/{schema}            deriva_ml_list_assets (schema-scoped)
     deriva://catalog/{h}/{c}/deriva-ml/asset/{rid}                (no list tool -- one-RID only)
     deriva://catalog/{h}/{c}/deriva-ml/lineage/{rid}              deriva_ml_get_lineage
+    deriva://catalog/{h}/{c}/deriva-ml/lineage-forward/{rid}      deriva_ml_find_executions_consuming
+    deriva://catalog/{h}/{c}/deriva-ml/workflow/{rid}/multirun-status  deriva_ml_multirun_status
     deriva://catalog/{h}/{c}/deriva-ml/vocabularies/{schema}      list_vocabulary_terms (core; per-table)
 
 Write tools (create / update / commit / abort / start / add_members /
@@ -976,6 +990,10 @@ start at step 3.
     which runs used / produced a dataset   deriva_ml_find_dataset_executions /
                                            deriva_ml_get_lineage
     executions of a workflow               deriva_ml_find_workflow_executions
+    what CONSUMED this dataset/asset       deriva_ml_find_executions_consuming(rid)
+      ("safe to delete?")                  -- forward complement of get_lineage
+    is the sweep done? (status counts      deriva_ml_multirun_status(workflow_rid)
+      across one workflow's runs)          -- NOT list_executions + count client-side
     feature values a run produced          deriva_ml_list_feature_values(
                                              ..., execution_rids=[rid])
                                            -- NOT a raw query on the feature
@@ -1297,11 +1315,11 @@ and ``description``. There is no compat shim; update any references.
 
 THE MENU
 --------
-Quick orientation: 50 tools -- 44 across the 5 ML domains (dataset,
+Quick orientation: 52 tools -- 46 across the 5 ML domains (dataset,
 feature, workflow, execution, asset) plus 3 catalog-maintenance tools
 (create_vocabulary, reindex_vocabularies, reindex_rows), the
 cross-domain describe_rid, and the orientation pair (primer,
-deriva_ml_get_guide) -- + 19 read-only resources (16 catalog-scoped under the
+deriva_ml_get_guide) -- + 21 read-only resources (18 catalog-scoped under the
 ``deriva://catalog/{h}/{c}/deriva-ml/...`` URI prefix + 3 static
 cold-start) + GitHub doc sources indexed for RAG (``deriva-ml-docs``,
 ``deriva-ml-mcp-plugin-docs``) + per-user RAG indexes that

--- a/src/deriva_ml_mcp_plugin/resources/ml.py
+++ b/src/deriva_ml_mcp_plugin/resources/ml.py
@@ -29,6 +29,8 @@ Resources registered:
     deriva://catalog/{hostname}/{catalog_id}/deriva-ml/executions
     deriva://catalog/{hostname}/{catalog_id}/deriva-ml/execution/{execution_rid}
     deriva://catalog/{hostname}/{catalog_id}/deriva-ml/lineage/{rid}
+    deriva://catalog/{hostname}/{catalog_id}/deriva-ml/lineage-forward/{rid}
+    deriva://catalog/{hostname}/{catalog_id}/deriva-ml/workflow/{workflow_rid}/multirun-status
     deriva://catalog/{hostname}/{catalog_id}/deriva-ml/features/{table_name}
     deriva://catalog/{hostname}/{catalog_id}/deriva-ml/asset/{asset_rid}
     deriva://catalog/{hostname}/{catalog_id}/deriva-ml/assets/{schema}
@@ -82,9 +84,11 @@ from deriva_ml_mcp_plugin.tools.dataset import (
     _list_datasets_impl,
 )
 from deriva_ml_mcp_plugin.tools.execution import (
+    _find_executions_consuming_impl,
     _get_execution_detail_impl,
     _get_lineage_impl,
     _list_executions_impl,
+    _multirun_status_impl,
 )
 from deriva_ml_mcp_plugin.tools.feature import _list_features_impl
 from deriva_ml_mcp_plugin.tools.workflow import _get_workflow_impl, _list_workflows_impl
@@ -679,6 +683,57 @@ def register(ctx: PluginContext) -> None:
             return _error_envelope(
                 exc,
                 operation="resource_ml_lineage",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,
+            )
+
+    @ctx.resource("deriva://catalog/{hostname}/{catalog_id}/deriva-ml/lineage-forward/{rid}")
+    async def ml_lineage_forward(hostname: str, catalog_id: str, rid: str) -> str:
+        """Forward lineage: the executions that CONSUMED the given
+        Dataset or asset as an input.
+
+        Same shape as the ``deriva_ml_find_executions_consuming`` tool
+        -- the resource and tool share an internal helper so the two
+        cannot drift. The forward complement of the ``lineage/{rid}``
+        resource (which walks backward to producers). An empty
+        ``consumers`` list means no RECORDED consumption.
+        """
+        try:
+            with deriva_call():
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                payload = await asyncio.to_thread(_find_executions_consuming_impl, ml, rid)
+            return payload.model_dump_json(by_alias=True)
+        except Exception as exc:  # noqa: BLE001
+            return _error_envelope(
+                exc,
+                operation="resource_ml_lineage_forward",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,
+            )
+
+    @ctx.resource(
+        "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/workflow/{workflow_rid}/multirun-status"
+    )
+    async def ml_workflow_multirun_status(hostname: str, catalog_id: str, workflow_rid: str) -> str:
+        """Status counts across all executions of one workflow.
+
+        Same shape as the ``deriva_ml_multirun_status`` tool -- the
+        resource and tool share an internal helper so the two cannot
+        drift. The "is the sweep done?" snapshot for multirun
+        experiments; null catalog statuses are counted under
+        ``"Created"``.
+        """
+        try:
+            with deriva_call():
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                payload = await asyncio.to_thread(_multirun_status_impl, ml, workflow_rid)
+            return payload.model_dump_json(by_alias=True)
+        except Exception as exc:  # noqa: BLE001
+            return _error_envelope(
+                exc,
+                operation="resource_ml_workflow_multirun_status",
                 hostname=hostname,
                 catalog_id=catalog_id,
                 audit=False,

--- a/src/deriva_ml_mcp_plugin/tools/execution/__init__.py
+++ b/src/deriva_ml_mcp_plugin/tools/execution/__init__.py
@@ -80,9 +80,11 @@ from deriva_ml_mcp_plugin.ml_context import get_ml
 # ``from deriva_ml_mcp_plugin.tools.execution import _list_executions_impl, ...``
 # is preserved here so the resource modules don't need to change.
 from deriva_ml_mcp_plugin.tools.execution.read import (
+    _find_executions_consuming_impl,
     _get_execution_detail_impl,
     _get_lineage_impl,
     _list_executions_impl,
+    _multirun_status_impl,
     _summarize_execution,
 )
 
@@ -94,9 +96,11 @@ __all__ = [
     "audit_event",
     "get_ml",
     "register",
+    "_find_executions_consuming_impl",
     "_get_execution_detail_impl",
     "_get_lineage_impl",
     "_list_executions_impl",
+    "_multirun_status_impl",
     "_summarize_execution",
 ]
 

--- a/src/deriva_ml_mcp_plugin/tools/execution/read.py
+++ b/src/deriva_ml_mcp_plugin/tools/execution/read.py
@@ -1,12 +1,14 @@
 """Read-only execution tools and shared execution helpers.
 
-This submodule houses the 8 read tools (``deriva_ml_list_executions``,
+This submodule houses the 10 read tools (``deriva_ml_list_executions``,
 ``deriva_ml_get_execution``, ``deriva_ml_find_workflow_executions``,
 ``deriva_ml_find_dataset_executions``, ``deriva_ml_find_experiments``,
 ``deriva_ml_list_execution_children``, ``deriva_ml_list_execution_parents``,
-``deriva_ml_get_lineage``) plus the shared helpers
+``deriva_ml_get_lineage``, ``deriva_ml_find_executions_consuming``,
+``deriva_ml_multirun_status``) plus the shared helpers
 (``_summarize_execution``, ``_list_executions_impl``,
-``_get_execution_detail_impl``, ``_get_lineage_impl``) that the
+``_get_execution_detail_impl``, ``_get_lineage_impl``,
+``_find_executions_consuming_impl``, ``_multirun_status_impl``) that the
 read tools and the ``resources/ml.py`` / ``resources/rag.py`` modules
 consume to keep tool / resource shapes in sync.
 
@@ -49,6 +51,7 @@ from deriva_ml_mcp_plugin._response_models import (
     DatasetExecutionSummary,
     ExecutionAssetRef,
     ExecutionChildrenResponse,
+    ExecutionConsumersResponse,
     ExecutionDetail,
     ExecutionExperiment,
     ExecutionInputDatasetRef,
@@ -57,6 +60,7 @@ from deriva_ml_mcp_plugin._response_models import (
     ExecutionOutputs,
     ExecutionParentsResponse,
     ExecutionSummary,
+    MultirunStatusResponse,
     PreflightCountResponse,
 )
 
@@ -1487,6 +1491,168 @@ def register(ctx: PluginContext) -> None:
                 catalog_id=catalog_id,
                 audit=False,
             )
+
+    @ctx.tool(mutates=False)
+    async def deriva_ml_find_executions_consuming(
+        hostname: str,
+        catalog_id: str,
+        rid: str,
+    ) -> str:
+        """Forward lineage: find the executions that CONSUMED an artifact.
+
+        The forward complement of ``deriva_ml_get_lineage`` (which walks
+        backward from an artifact to its producers). Given a Dataset or
+        asset RID, returns the executions that took it as an INPUT --
+        the "is it safe to delete / modify this?" question. An empty
+        result means no RECORDED consumption (producers are not
+        consumers and are excluded).
+
+        Dispatch is by resolved RID kind: Dataset RIDs follow input
+        ``Dataset_Execution`` edges; asset RIDs follow the asset's
+        ``<Asset>_Execution`` association with ``Asset_Role="Input"``.
+        Other RID kinds (workflows, vocabulary terms, plain entities)
+        are not consumption-shaped and return an error envelope.
+
+        Args:
+            rid: RID of a Dataset or an asset-table row.
+
+        Returns:
+            JSON string ``{"rid", "count", "consumers": [execution
+            summary, ...]}`` where each summary carries ``rid`` /
+            ``workflow_rid`` / ``status`` / ``description`` / timing
+            fields. ``count == 0`` with empty ``consumers`` is the
+            normal "nothing consumed this" answer, not an error.
+
+        Raises:
+            DerivaMLException: Wrapped as ``{"error": ...}`` -- e.g.
+                when ``rid`` does not exist or is not a Dataset/asset.
+
+        Example:
+            ``{"rid": "1-DS01", "count": 2, "consumers": [{"rid":
+            "1-EXEC-A", "workflow_rid": "1-WF01", "status": "Uploaded",
+            ...}, ...]}``
+        """
+        try:
+            with deriva_call():
+                # Run the synchronous deriva-ml calls in a thread pool
+                # so the event loop stays responsive.
+                # ``find_executions_consuming`` resolves the RID and
+                # walks association edges. See deriva-mcp-core
+                # plugin-authoring-guide.md §"Synchronous work in
+                # threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                payload = await asyncio.to_thread(_find_executions_consuming_impl, ml, rid)
+            return payload.model_dump_json(by_alias=True)
+        except Exception as exc:
+            return _error_envelope(
+                exc,
+                operation="find_executions_consuming",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,
+            )
+
+    @ctx.tool(mutates=False)
+    async def deriva_ml_multirun_status(
+        hostname: str,
+        catalog_id: str,
+        workflow_rid: str,
+    ) -> str:
+        """Status counts across all executions of one workflow, in one call.
+
+        The "is the sweep done?" question for multirun experiments:
+        instead of paginating ``deriva_ml_list_executions`` and counting
+        client-side, this aggregates the ``Status`` column server-side
+        and returns one small summary. Null catalog statuses are counted
+        under ``"Created"``, matching ``deriva_ml_get_execution``'s read
+        contract.
+
+        Args:
+            workflow_rid: RID of the workflow to summarize.
+
+        Returns:
+            JSON string ``{"workflow_rid", "counts": {<status>: N, ...},
+            "total"}``. ``total == 0`` with empty ``counts`` means the
+            workflow has no executions yet.
+
+        Raises:
+            DerivaMLException: Wrapped as ``{"error": ...}`` when
+                ``workflow_rid`` is not a workflow.
+
+        Example:
+            ``{"workflow_rid": "1-WF01", "counts": {"Uploaded": 18,
+            "Running": 2, "Failed": 1}, "total": 21}``
+        """
+        try:
+            with deriva_call():
+                # Run the synchronous deriva-ml calls in a thread pool
+                # so the event loop stays responsive.
+                # ``multirun_status_summary`` is a single aggregation
+                # query. See deriva-mcp-core plugin-authoring-guide.md
+                # §"Synchronous work in threads".
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                payload = await asyncio.to_thread(_multirun_status_impl, ml, workflow_rid)
+            return payload.model_dump_json(by_alias=True)
+        except Exception as exc:
+            return _error_envelope(
+                exc,
+                operation="multirun_status",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,
+            )
+
+
+def _find_executions_consuming_impl(ml: Any, rid: str) -> ExecutionConsumersResponse:
+    """Shared helper: tool ``deriva_ml_find_executions_consuming`` and resource
+    ``deriva://catalog/{h}/{c}/deriva-ml/lineage-forward/{rid}`` both call
+    this so their payloads cannot drift.
+
+    Wraps ``ml.find_executions_consuming(rid)`` and maps each consuming
+    ``ExecutionRecord`` through ``_summarize_execution``.
+
+    Args:
+        ml: The ``DerivaML`` instance bound to the catalog.
+        rid: RID of a Dataset or an asset-table row.
+
+    Returns:
+        ``ExecutionConsumersResponse`` -- see
+        ``deriva_ml_mcp_plugin._response_models``.
+
+    Example:
+        >>> _find_executions_consuming_impl(ml, "1-DS01")  # doctest: +SKIP
+    """
+    records = ml.find_executions_consuming(rid)
+    return ExecutionConsumersResponse(
+        rid=rid,
+        count=len(records),
+        consumers=[_summarize_execution(r) for r in records],
+    )
+
+
+def _multirun_status_impl(ml: Any, workflow_rid: str) -> MultirunStatusResponse:
+    """Shared helper: tool ``deriva_ml_multirun_status`` and resource
+    ``deriva://catalog/{h}/{c}/deriva-ml/workflow/{workflow_rid}/multirun-status``
+    both call this so their payloads cannot drift.
+
+    Wraps ``ml.multirun_status_summary(workflow_rid)`` and re-validates
+    the library's ``MultirunStatusSummary`` into the wire model via
+    ``model_dump()`` (library-side field drift fails loudly under
+    ``extra="forbid"``).
+
+    Args:
+        ml: The ``DerivaML`` instance bound to the catalog.
+        workflow_rid: RID of the workflow to summarize.
+
+    Returns:
+        ``MultirunStatusResponse`` -- see
+        ``deriva_ml_mcp_plugin._response_models``.
+
+    Example:
+        >>> _multirun_status_impl(ml, "1-WF01")  # doctest: +SKIP
+    """
+    summary = ml.multirun_status_summary(workflow_rid)
+    return MultirunStatusResponse(**summary.model_dump())
 
 
 def _get_lineage_impl(ml: Any, rid: str, depth: int | None, max_executions: int) -> Any:

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -783,3 +783,90 @@ async def test_get_execution_preserves_workflow_rid_when_present(
     )
     payload = json.loads(result)
     assert payload["workflow_rid"] == "1-WF-DIRECT"
+
+
+# ---------------------------------------------------------------------------
+# find_executions_consuming (plugin#26 -- Round C wrapper over deriva-ml#296)
+# ---------------------------------------------------------------------------
+
+
+async def test_find_executions_consuming_success(execution_ctx, capturing_mcp, mock_ml):
+    """Forward lineage: consuming ExecutionRecords map to ExecutionSummary."""
+    mock_ml.find_executions_consuming.return_value = [
+        _make_execution_record_mock(rid="1-EXEC-A"),
+        _make_execution_record_mock(rid="1-EXEC-B"),
+    ]
+    payload = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_executions_consuming"](
+            hostname="h", catalog_id="1", rid="1-DS"
+        )
+    )
+    assert payload["rid"] == "1-DS"
+    assert payload["count"] == 2
+    assert [c["rid"] for c in payload["consumers"]] == ["1-EXEC-A", "1-EXEC-B"]
+    mock_ml.find_executions_consuming.assert_called_once_with("1-DS")
+
+
+async def test_find_executions_consuming_empty(execution_ctx, capturing_mcp, mock_ml):
+    """No recorded consumption -> count 0, empty consumers (not an error)."""
+    mock_ml.find_executions_consuming.return_value = []
+    payload = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_executions_consuming"](
+            hostname="h", catalog_id="1", rid="1-ASSET"
+        )
+    )
+    assert payload == {"rid": "1-ASSET", "count": 0, "consumers": []}
+
+
+async def test_find_executions_consuming_error_envelope(execution_ctx, capturing_mcp, mock_ml):
+    """Non-consumable RID kinds propagate as the standard error envelope."""
+    mock_ml.find_executions_consuming.side_effect = RuntimeError(
+        "RID 1-WF is a Workflow; not consumption-shaped"
+    )
+    payload = json.loads(
+        await capturing_mcp.tools["deriva_ml_find_executions_consuming"](
+            hostname="h", catalog_id="1", rid="1-WF"
+        )
+    )
+    assert payload == {
+        "error": "RID 1-WF is a Workflow; not consumption-shaped",
+        "error_type": "RuntimeError",
+    }
+
+
+# ---------------------------------------------------------------------------
+# multirun_status (plugin#26 -- Round C wrapper over deriva-ml#296)
+# ---------------------------------------------------------------------------
+
+
+async def test_multirun_status_success(execution_ctx, capturing_mcp, mock_ml):
+    """Status counts pass through from the library's MultirunStatusSummary."""
+    from deriva_ml.execution.execution_record import MultirunStatusSummary
+
+    mock_ml.multirun_status_summary.return_value = MultirunStatusSummary(
+        workflow_rid="1-WF01",
+        counts={"Uploaded": 18, "Running": 2, "Failed": 1},
+        total=21,
+    )
+    payload = json.loads(
+        await capturing_mcp.tools["deriva_ml_multirun_status"](
+            hostname="h", catalog_id="1", workflow_rid="1-WF01"
+        )
+    )
+    assert payload == {
+        "workflow_rid": "1-WF01",
+        "counts": {"Uploaded": 18, "Running": 2, "Failed": 1},
+        "total": 21,
+    }
+    mock_ml.multirun_status_summary.assert_called_once_with("1-WF01")
+
+
+async def test_multirun_status_error_envelope(execution_ctx, capturing_mcp, mock_ml):
+    """Non-workflow RIDs propagate as the standard error envelope."""
+    mock_ml.multirun_status_summary.side_effect = RuntimeError("1-XX is not a workflow")
+    payload = json.loads(
+        await capturing_mcp.tools["deriva_ml_multirun_status"](
+            hostname="h", catalog_id="1", workflow_rid="1-XX"
+        )
+    )
+    assert payload == {"error": "1-XX is not a workflow", "error_type": "RuntimeError"}

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -112,6 +112,11 @@ _EXECUTION_TOOLS = frozenset(
         "deriva_ml_find_experiments",
         # v3.3: provenance traversal (data-flow walk; see deriva-ml ADR-0001).
         "deriva_ml_get_lineage",
+        # Round C (plugin#26): forward lineage + multirun status counts
+        # over deriva-ml's find_executions_consuming /
+        # multirun_status_summary.
+        "deriva_ml_find_executions_consuming",
+        "deriva_ml_multirun_status",
     }
 )
 
@@ -214,6 +219,11 @@ _ML_RESOURCE_URIS = frozenset(
         "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/vocabularies/{schema}/{vocab_name}",
         # v3.3 lineage resource (mirrors deriva_ml_get_lineage tool).
         "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/lineage/{rid}",
+        # Round C (plugin#26) forward-lineage + multirun-status resources
+        # (mirror deriva_ml_find_executions_consuming /
+        # deriva_ml_multirun_status; shared _impl helpers).
+        "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/lineage-forward/{rid}",
+        "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/workflow/{workflow_rid}/multirun-status",
         # v3.3 dataset-spec resource (mirrors deriva_ml_get_dataset_spec tool).
         "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/dataset/{dataset_rid}/spec",
         # bag-preview resource (mirrors deriva_ml_bag_info tool, current

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -189,6 +189,9 @@ def test_register_adds_all_resources(resource_ctx, capturing_mcp):
         "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/executions",
         "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/execution/{execution_rid}",
         "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/lineage/{rid}",
+        # Round C (plugin#26) forward-lineage + multirun-status resources.
+        "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/lineage-forward/{rid}",
+        "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/workflow/{workflow_rid}/multirun-status",
         "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/features/{table_name}",
         "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/asset/{asset_rid}",
         "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/assets/{schema}",
@@ -1411,3 +1414,74 @@ async def test_ml_asset_detail_omits_no_data(resource_ctx, capturing_mcp, mock_m
     assert out["description"] == ""
     assert out["executions"] == []
     assert out["asset_types"] == []
+
+
+# ---------------------------------------------------------------------------
+# deriva-ml/lineage-forward/{rid}  (plugin#26 -- Round C)
+# ---------------------------------------------------------------------------
+
+_LINEAGE_FORWARD_URI = "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/lineage-forward/{rid}"
+_MULTIRUN_STATUS_URI = (
+    "deriva://catalog/{hostname}/{catalog_id}/deriva-ml/workflow/{workflow_rid}/multirun-status"
+)
+
+
+async def test_ml_lineage_forward_success(resource_ctx, capturing_mcp, mock_ml):
+    """Same wire shape as the deriva_ml_find_executions_consuming tool."""
+    mock_ml.find_executions_consuming.return_value = [
+        _make_execution_record_mock(rid="1-EXEC-A"),
+    ]
+    out = json.loads(
+        await capturing_mcp.resources[_LINEAGE_FORWARD_URI](
+            hostname="h", catalog_id="1", rid="1-DS"
+        )
+    )
+    assert out["rid"] == "1-DS"
+    assert out["count"] == 1
+    assert out["consumers"][0]["rid"] == "1-EXEC-A"
+    mock_ml.find_executions_consuming.assert_called_once_with("1-DS")
+
+
+async def test_ml_lineage_forward_error_path_is_silent(resource_ctx, capturing_mcp, mock_ml):
+    mock_ml.find_executions_consuming.side_effect = RuntimeError("not consumption-shaped")
+    with patch("deriva_ml_mcp_plugin._helpers.audit_event") as mock_audit:
+        out = json.loads(
+            await capturing_mcp.resources[_LINEAGE_FORWARD_URI](
+                hostname="h", catalog_id="1", rid="1-WF"
+            )
+        )
+    assert out == {"error": "not consumption-shaped", "error_type": "RuntimeError"}
+    assert mock_audit.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# deriva-ml/workflow/{workflow_rid}/multirun-status  (plugin#26 -- Round C)
+# ---------------------------------------------------------------------------
+
+
+async def test_ml_multirun_status_success(resource_ctx, capturing_mcp, mock_ml):
+    """Same wire shape as the deriva_ml_multirun_status tool."""
+    from deriva_ml.execution.execution_record import MultirunStatusSummary
+
+    mock_ml.multirun_status_summary.return_value = MultirunStatusSummary(
+        workflow_rid="1-WF01", counts={"Uploaded": 3}, total=3
+    )
+    out = json.loads(
+        await capturing_mcp.resources[_MULTIRUN_STATUS_URI](
+            hostname="h", catalog_id="1", workflow_rid="1-WF01"
+        )
+    )
+    assert out == {"workflow_rid": "1-WF01", "counts": {"Uploaded": 3}, "total": 3}
+    mock_ml.multirun_status_summary.assert_called_once_with("1-WF01")
+
+
+async def test_ml_multirun_status_error_path_is_silent(resource_ctx, capturing_mcp, mock_ml):
+    mock_ml.multirun_status_summary.side_effect = RuntimeError("not a workflow")
+    with patch("deriva_ml_mcp_plugin._helpers.audit_event") as mock_audit:
+        out = json.loads(
+            await capturing_mcp.resources[_MULTIRUN_STATUS_URI](
+                hostname="h", catalog_id="1", workflow_rid="1-XX"
+            )
+        )
+    assert out == {"error": "not a workflow", "error_type": "RuntimeError"}
+    assert mock_audit.call_count == 0

--- a/uv.lock
+++ b/uv.lock
@@ -691,8 +691,8 @@ dependencies = [
 
 [[package]]
 name = "deriva-ml"
-version = "1.46.1.post2+gdc69017f5"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#dc69017f5aba1a9cf55b79b5b79ee55eb7f6987f" }
+version = "1.46.1.post3+g3826773a6"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#3826773a694f3dd32e814b4904466d124aa143c5" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
Closes #26. **Stacked on #81** (base = `feat/round-b-wrappers`); merge #81 first and this PR retargets to `main`.

Thin `mutates=False` wrappers over the deriva-ml Round C methods (informatics-isi-edu/deriva-ml#296, merged):

## Tools

- **`deriva_ml_find_executions_consuming(hostname, catalog_id, rid)`** — forward lineage: the executions that CONSUMED a Dataset/asset as input. The "is it safe to delete this?" check; empty result = no recorded consumption (producers excluded).
- **`deriva_ml_multirun_status(hostname, catalog_id, workflow_rid)`** — status counts across one workflow's executions in a single aggregation call ("is the sweep done?"). Null statuses count under `"Created"`, matching `get_execution`'s read contract.

## Sibling resources (dual-mode policy)

- `deriva://catalog/{h}/{c}/deriva-ml/lineage-forward/{rid}`
- `deriva://catalog/{h}/{c}/deriva-ml/workflow/{workflow_rid}/multirun-status`

Both share the new `_find_executions_consuming_impl` / `_multirun_status_impl` helpers with the tools, so the shapes cannot drift. The multirun resource nests under `workflow/{rid}/` following the `dataset/{rid}/members` sub-resource convention (the issue sketched flat URIs "subject to design review").

## Wire shapes

- `{"rid", "count", "consumers": [ExecutionSummary...]}` — consumers reuse the existing execution summary shape.
- `{"workflow_rid", "counts": {status: N}, "total"}` — mirrors the library's `MultirunStatusSummary` via `model_dump()` under `extra="forbid"`.

## Sweeps

- Prompts: 50 → 52 tools (execution 8 → 10), 19 → 21 resources (16 → 18 catalog-scoped); resource catalog, resource–tool pairing table, and the PROVENANCE ordered-strategy ladder gain the new rows ("what consumed this?" / "is the sweep done? — NOT list_executions + count client-side").
- Frozenset pins in `test_plugin.py` (tools + URIs), `test_resources.py` expected set, module docstrings, CLAUDE.md tree.

## Tests

9 new (tool success/empty/error for both; resource success + silent-error for both, using the real `MultirunStatusSummary` model). Full suite: **409 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)