### PR TITLE
chore(deps): track deriva-ml 1.48.0 in the lockfile

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -691,8 +691,8 @@ dependencies = [
 
 [[package]]
 name = "deriva-ml"
-version = "1.46.1.post3+g3826773a6"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#3826773a694f3dd32e814b4904466d124aa143c5" }
+version = "1.48.0"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#0cf72e0929cc389670240b5cc71f7f611cc19dcb" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
deriva-ml advanced **1.47.0 → 1.48.0** (with v1.47.1 in between). This refreshes the lockfile to the latest release.

## What changed upstream (deriva-ml #297–#303)

All dataset bag-export / denormalization internals plus deriva-py pin advances:

- #297 mark Execution/Workflow terminal in the bag-export walk
- #298 FK-traversal / bag-export reference manual (docs)
- #299 `DatasetBag.materialize()` for in-place materialization
- #300 client-side FK-reachability engine + descendant-walk/schema-refetch fixes
- #301 Format-B client-side bag generation (one clean CSV per table)
- #302/#303 deriva-py rid-set Accept-header + O(n²) fetch fixes

## Impact on this plugin

**None breaking.** I diffed every deriva-ml method the plugin calls — no signature changes. The one new public method, `list_dataset_children_rids`, is a RID-only perf variant of `list_dataset_children` (already surfaced via `deriva_ml_list_dataset_relations`); it's an internal bag-walk optimization, not new user-facing capability, so no new wrapper.

## Pin policy

The `>=1.47,<2.0` floor stays — nothing the plugin calls *requires* 1.48, so raising the floor would force installers up for no functional reason. The lock simply tracks the latest release so the deployed server picks up the bag-export correctness fixes (which improve `denormalize_dataset` / `bag_info` behavior).

## Verification

Synced to 1.48.0, full suite **409 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)