### PR TITLE
chore(deps): track deriva-ml 1.49.0 in the lockfile

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -691,8 +691,8 @@ dependencies = [
 
 [[package]]
 name = "deriva-ml"
-version = "1.48.0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#0cf72e0929cc389670240b5cc71f7f611cc19dcb" }
+version = "1.49.0"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#73e2f8ff38dd37f44826facfddd6e23626b10695" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
deriva-ml advanced **1.48.0 → 1.49.0**. This refreshes the lockfile to the latest release.

## What changed upstream

- #305/#306 MINID download spec emits Format-B rid-set processors (bag-spec internals)
- #304 snapshot schema-validation fix (validate reused schema against the catalog for pre-migration snapshots)

## Impact on this plugin

**None breaking** — no public method signature changes for any API the plugin calls.

## Pin policy

`>=1.47,<2.0` floor unchanged (nothing the plugin calls requires 1.49); the lock tracks the latest release so the deployed server picks up the fixes on next rebuild.

## Verification

Synced to 1.49.0, full suite **409 passed**, ruff clean. Lock-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)