### PR TITLE
chore(deps): track deriva-ml 1.51.5 in the lockfile

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -691,8 +691,8 @@ dependencies = [
 
 [[package]]
 name = "deriva-ml"
-version = "1.49.0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#73e2f8ff38dd37f44826facfddd6e23626b10695" }
+version = "1.51.5"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#eacbae2adcc8a957892f67a70f7d752f93c247f1" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
deriva-ml advanced **1.48.0 → 1.51.5** (12 releases). The plugin's lock had been stuck at 1.48.0 — the 1.49.0 bump (#84) was never merged — so this jumps straight to current main.

## Substantive upstream work in the span

- `LocalFile` execution inputs + `add_files(asset_role=...)` (#333/#335/#337)
- the provenance contract: sentinels, no-input check, audit, adoption backfill (#331/#339)
- denormalize planner fixes — row_per cartesian kill, FK-reachable path unions, bridge-table suggestions (#318/#320/#323/#330)
- parallel bag fetch + `reachability_concurrency` (#309/#312/#313), `DatasetBag.materialize` concurrency default (#311)
- **`AssetSpec.asset_role` removal** (#335)
- several deriva-py pin advances (symlink/scoped-asset bag fixes)

## Impact on this plugin: none breaking

Diffed every deriva-ml method the plugin calls. Only one public method *added* (`summary`); nothing removed at the public-`def` level. The removed `AssetSpec.asset_role` is a config-construction attribute the plugin never builds (it does no execution authoring) — the plugin's `asset_role` usage is `ExecutionRecord.list_assets(asset_role=...)`, which is unchanged.

## Verification

Synced to 1.51.5, full suite **409 passed**, ruff clean. Lock-only diff. One new test warning is an upstream Pydantic V2 `class-based config` deprecation in deriva-ml's `core/definitions.py` — not a plugin issue (the plugin uses `ConfigDict` throughout); worth flagging upstream separately.

Pin floor stays `>=1.47,<2.0` (nothing the plugin calls requires a higher minimum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)