### PR TITLE
chore(deps): track deriva-ml 1.51.16 in the lockfile

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -691,8 +691,8 @@ dependencies = [
 
 [[package]]
 name = "deriva-ml"
-version = "1.51.5"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#eacbae2adcc8a957892f67a70f7d752f93c247f1" }
+version = "1.51.16"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#96fcb9607493028d0052fd9f15a0a39517601b25" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
Refreshes the lockfile to the latest deriva-ml release, **1.51.5 → 1.51.16**.

## Span

`add_files` / directory-dataset features (#345/#346/#348/#349), `resolve_rids` URL-overflow chunking for large RID sets (#347), cache/storage walk perf (#342/#343), an `ERMrest_RID_Lease` write-policy fix (#344), and a Chaise default-annotation feature (#341).

## Impact: none breaking

Public surface only **added** methods (`Dataset.is_directory` / `.source_directory` plus internal helpers); nothing the plugin calls changed signature or was removed.

## Verification

Synced to 1.51.16, full suite **409 passed**, ruff clean, lock-only diff. Pin floor stays `>=1.47,<2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)