### PR TITLE
chore(deps): track deriva-ml 1.54.0 in the lockfile

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -691,8 +691,8 @@ dependencies = [
 
 [[package]]
 name = "deriva-ml"
-version = "1.51.16"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#96fcb9607493028d0052fd9f15a0a39517601b25" }
+version = "1.54.0"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#f523eece10bd6752f638225dff53dfa37b7aacc0" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
Refreshes the lockfile to the latest deriva-ml release, **1.51.16 → 1.54.0**.

## Span

- `add_files` / directory-ingest refinements: root `Directory_Dataset.Path` stores basename (not `.`), `is_source_root` accessor, O(1) single `Dataset_Execution` input edge (was N per-file `File_Execution`), nameable ingest root (`root_name`).
- **`lookup_lineage` correctness + perf wave:** member-producer seeding (closes a lineage gap), consumed-version resolution, server-side membership join to avoid URL-length 404s, self-parent cycle guard, bounded `Dataset_Version` fetch (no full-table scan per node).

## Impact: none breaking — net win

`deriva_ml_get_lineage` and the `lineage-forward` resource call `lookup_lineage` directly, so they inherit the lineage fixes for free. Public surface only **added** `is_source_root`; nothing the plugin calls changed signature.

## Verification

Synced to 1.54.0, full suite **409 passed**, ruff clean, lock-only diff. Pin floor stays `>=1.47,<2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)