### PR TITLE
fix(deps): drop wheel-metadata deriva-py pin (fixes container build on deriva-ml 1.54.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,19 @@ dependencies = [
     # find_features_referencing (#294), find_executions_consuming /
     # multirun_status_summary (#296).
     "deriva-ml>=1.47,<2.0",
-    # Pin deriva-py to the `deriva-ml` branch in the built wheel metadata --
-    # not just in [tool.uv] (which is local-only and does not ship). Installers
-    # other than uv (pip, plain build envs) would otherwise resolve whatever
-    # version of `deriva` is on PyPI, which is incompatible with this plugin.
-    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@deriva-ml",
+    # NOTE: this plugin deliberately does NOT pin `deriva` (deriva-py).
+    # deriva-ml pins its own deriva-py via an immutable commit SHA (as of
+    # deriva-ml v1.54.0; it was a `@deriva-ml` branch before), and
+    # deriva-mcp-core declares `deriva` unpinned. A `deriva @ ...@deriva-ml`
+    # branch pin here used to be needed to beat core's old `@master` pin --
+    # but core dropped that, and once deriva-ml moved to a SHA the plugin's
+    # branch pin became a SECOND, conflicting URL for the same package. Under
+    # the deriva-docker container install (`uv pip install --no-sources`,
+    # which ignores [tool.uv] overrides), that surfaced as
+    # "Requirements contain conflicting URLs for package `deriva`" and broke
+    # the build. Letting deriva-ml drive the deriva-py version removes the
+    # conflict and the maintenance treadmill. Re-add a pin ONLY if a future
+    # conflict requires forcing a specific deriva-py here.
 ]
 
 [project.optional-dependencies]
@@ -79,8 +87,10 @@ system-certs = [
 deriva-ml = "deriva_ml_mcp_plugin.plugin:register"
 
 [tool.hatch.metadata]
-# Required so `deriva @ git+...` in [project.dependencies] is allowed in the
-# built wheel's METADATA. Without this, hatchling rejects the direct URL.
+# Kept on: deriva-ml (a [project.dependencies] entry) is itself a direct
+# git URL via [tool.uv.sources], and transitive direct-reference metadata
+# can still surface at build time. Harmless if every dep were on PyPI;
+# required the moment any direct URL is in play.
 allow-direct-references = true
 
 [tool.hatch.version]
@@ -93,13 +103,21 @@ version-file = "src/deriva_ml_mcp_plugin/_version.py"
 packages = ["src/deriva_ml_mcp_plugin"]
 
 [tool.uv]
-# Force uv to ignore deriva-mcp-core's `deriva @ ...@master` pin and use the
-# `deriva-ml` branch instead. The wheel METADATA already declares the
-# `deriva-ml` branch (see [project.dependencies]); this override only kicks
-# in for local `uv sync`/`uv run` to resolve the conflict between sibling
-# pins. Drop this once deriva-mcp-core moves off the `master` branch pin.
+# LOCAL-ONLY deriva-py reconciliation. This override does NOT ship in the
+# wheel (the built METADATA no longer pins `deriva` at all -- see the note in
+# [project.dependencies]). It exists solely so a local `uv sync` / `uv run`
+# resolves the sibling conflict: the `deriva-mcp-core` git source still drags
+# in `deriva-py@master`, while `deriva-ml` pins `deriva-py` to an immutable
+# SHA. Without this override, local resolution fails with conflicting URLs for
+# `deriva`. We align local dev to deriva-ml's pin (the SHA wins). Keep this in
+# lockstep with deriva-ml's deriva-py SHA on each bump; drop it entirely once
+# deriva-mcp-core stops sourcing deriva-py from `@master`.
+#
+# The container build does NOT use this (it runs `uv pip install --no-sources`,
+# which is why the [project.dependencies] pin -- not this override -- was the
+# thing that broke the container and had to be removed).
 override-dependencies = [
-    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@deriva-ml",
+    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@943bfa394c8246ae379b4a15b3f7b615d7da1fdd",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?rev=deriva-ml" }]
+overrides = [{ name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?rev=943bfa394c8246ae379b4a15b3f7b615d7da1fdd" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -658,7 +658,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?rev=deriva-ml#a8d42c80d96061a414428b36635bc3011e4437a9" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?rev=943bfa394c8246ae379b4a15b3f7b615d7da1fdd#943bfa394c8246ae379b4a15b3f7b615d7da1fdd" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },
@@ -720,7 +720,6 @@ dependencies = [
 name = "deriva-ml-mcp-plugin"
 source = { editable = "." }
 dependencies = [
-    { name = "deriva" },
     { name = "deriva-mcp-core" },
     { name = "deriva-ml" },
 ]
@@ -740,7 +739,6 @@ system-certs = [
 [package.metadata]
 requires-dist = [
     { name = "bump-my-version", marker = "extra == 'dev'" },
-    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?rev=deriva-ml" },
     { name = "deriva-mcp-core", git = "https://github.com/informatics-isi-edu/deriva-mcp-core.git" },
     { name = "deriva-ml", git = "https://github.com/informatics-isi-edu/deriva-ml.git" },
     { name = "pip-system-certs", marker = "extra == 'system-certs'", specifier = ">=5.3" },


### PR DESCRIPTION
## The break

The deriva-docker container rebuild (localhost target) fails on deriva-ml 1.54.0:

```
× Failed to resolve dependencies for `deriva-ml` (v1.54.0)
  ╰─▶ Requirements contain conflicting URLs for package `deriva`:
      - git+https://github.com/informatics-isi-edu/deriva-py@deriva-ml      (this plugin's pin)
      - git+https://github.com/informatics-isi-edu/deriva-py@943bfa39...     (deriva-ml 1.54.0's pin)
```

The container installs via `uv pip install --no-sources`, which ignores `[tool.uv]` overrides — so it sees two different git URLs for `deriva` and refuses.

## Root cause

The plugin's `[project.dependencies]` `deriva @ ...@deriva-ml` (branch) pin existed to beat deriva-mcp-core's old `deriva-py@master` pin. Core dropped that (its published dep is now bare `deriva`), so the pin lost its purpose — and the moment deriva-ml moved to an immutable SHA (v1.54.0) it became a conflicting second URL for the same package.

## Fix

- **Remove** the `deriva` pin from `[project.dependencies]` (wheel metadata) — let deriva-ml drive deriva-py. This is what fixes the container.
- **Keep** `[tool.uv] override-dependencies` (local-dev only, doesn't ship): deriva-mcp-core's git *source* still drags in `deriva-py@master`, so a local `uv sync` still needs the override. Re-aligned `@deriva-ml → @943bfa39` to match deriva-ml 1.54.0.

## Verification

Local `uv sync` resolves cleanly, full suite **409 passed**, ruff clean. Container build verified against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)