### PR TITLE
feat(auth): add deriva_ml_check_authentication tool (whoami pre-flight)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ src/deriva_ml_mcp_plugin/
 ├── prompts.py           # 3 MCP prompts (deriva_ml_concepts /
 │                        #   _getting_started / _primer) + the
 │                        #   deriva_ml_primer + deriva_ml_get_guide orientation tools
-├── tools/               # Per-domain tool modules (52 tools total)
+├── tools/               # Per-domain tool modules (53 tools total)
 │   ├── dataset/         #   20 tools, split into focused submodules:
 │   │   ├── __init__.py  #     register aggregator + helper re-exports
 │   │   ├── read.py      #     12 read tools + shared helpers
@@ -38,7 +38,8 @@ src/deriva_ml_mcp_plugin/
 │   ├── asset.py         #    5 tools
 │   ├── vocabulary.py    #    1 tool (deriva_ml_create_vocabulary)
 │   ├── maintenance.py   #    2 tools (reindex_vocabularies, reindex_rows)
-│   └── resolve.py       #    1 tool (deriva_ml_describe_rid -- RID -> kind + routing)
+│   ├── resolve.py       #    1 tool (deriva_ml_describe_rid -- RID -> kind + routing)
+│   └── auth.py          #    1 tool (deriva_ml_check_authentication -- whoami pre-flight)
 └── resources/           # MCP resources + per-user RAG
     ├── ml.py            #   21 resources (18 catalog-scoped under
     │                    #   deriva://catalog/{h}/{c}/deriva-ml/... + 3 static)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,12 @@ packages = ["src/deriva_ml_mcp_plugin"]
 # which is why the [project.dependencies] pin -- not this override -- was the
 # thing that broke the container and had to be removed).
 override-dependencies = [
-    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@943bfa394c8246ae379b4a15b3f7b615d7da1fdd",
+    # Lockstep with deriva-ml's deriva-py pin. deriva-ml 1.54.1 (#354,
+    # "pyproject packaging migration") moved its deriva-py pin to
+    # c93e71e (the deriva-py deriva-ml-branch tip); advance this to
+    # match on every deriva-ml bump that changes the pin, or local
+    # `uv sync` fails with conflicting URLs for `deriva`.
+    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@c93e71e480e2ef501ed58077e5fff3705bcdb5a1",
 ]
 
 [tool.uv.sources]

--- a/src/deriva_ml_mcp_plugin/_response_models.py
+++ b/src/deriva_ml_mcp_plugin/_response_models.py
@@ -1557,3 +1557,35 @@ class DescribeRidResponse(BaseModel):
     ]
     suggestion: str
     resource_uri: str | None = None
+
+
+class CheckAuthenticationResponse(BaseModel):
+    """Response for ``deriva_ml_check_authentication``.
+
+    Answers "can the MCP server authenticate to this catalog, and as
+    whom?" -- a pre-flight before catalog operations. ``authenticated``
+    is the boolean (server returned a session); ``identity`` is the
+    logged-in client dict (``id`` / ``display_name`` / ``email`` /
+    ``full_name`` / ``identities``) when authenticated, ``None``
+    otherwise. ``hostname`` / ``catalog_id`` echo the target so the
+    answer is self-describing.
+
+    Confirms *authentication* (the server knows who the credential
+    is), NOT *authorization* for any specific operation -- a write to a
+    read-only table can still be refused with a valid session. A
+    network/connection failure or a non-auth HTTP error is surfaced as
+    the standard ``{"error", "error_type"}`` envelope, NOT as
+    ``authenticated: false`` (which means specifically "reached the
+    server, no valid session").
+
+    ``identity`` is ``extra="allow"`` -- the server's client dict shape
+    is owned by the Deriva auth layer and may carry fields beyond the
+    documented five.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    authenticated: bool
+    identity: dict[str, Any] | None = None
+    hostname: str
+    catalog_id: str

--- a/src/deriva_ml_mcp_plugin/plugin.py
+++ b/src/deriva_ml_mcp_plugin/plugin.py
@@ -23,6 +23,7 @@ from deriva_ml_mcp_plugin import prompts as _ml_prompts
 from deriva_ml_mcp_plugin.resources import ml as _ml_resources
 from deriva_ml_mcp_plugin.resources import rag as _ml_rag
 from deriva_ml_mcp_plugin.tools import asset as _asset
+from deriva_ml_mcp_plugin.tools import auth as _auth
 from deriva_ml_mcp_plugin.tools import dataset as _dataset
 from deriva_ml_mcp_plugin.tools import execution as _execution
 from deriva_ml_mcp_plugin.tools import feature as _feature
@@ -92,6 +93,7 @@ def register(ctx: PluginContext) -> None:
     _vocabulary.register(ctx)
     _maintenance.register(ctx)
     _resolve.register(ctx)
+    _auth.register(ctx)
     _ml_resources.register(ctx)
     _ml_rag.register_rag_sources(ctx)
     _ml_prompts.register(ctx)

--- a/src/deriva_ml_mcp_plugin/prompts.py
+++ b/src/deriva_ml_mcp_plugin/prompts.py
@@ -4,7 +4,7 @@ These are MCP prompts (registered via ``@ctx.prompt(...)``), not Python
 docstrings. FastMCP surfaces them through the MCP ``prompts/list`` and
 ``prompts/get`` endpoints so an LLM client can pull them up by name at
 the start of a conversation -- they are the cold-start anchor for the
-plugin's 52 tools and 21 resources.
+plugin's 53 tools and 21 resources.
 
 The two prompts complement the four built-in core prompts shipped by
 ``deriva-mcp-core`` (``query_guide``, ``entity_guide``,
@@ -677,12 +677,14 @@ you're driving the library directly from a notebook or skill.
 
 THE FIVE ML DOMAINS
 -------------------
-Forty-six of the 52 tools are organized into five domain modules. The
-other six: the catalog-maintenance tools
+Forty-six of the 53 tools are organized into five domain modules. The
+other seven: the catalog-maintenance tools
 ``deriva_ml_create_vocabulary``, ``deriva_ml_reindex_vocabularies``,
-``deriva_ml_reindex_rows``; the cross-domain
+``deriva_ml_reindex_rows``; the two cross-domain tools
 ``deriva_ml_describe_rid`` (resolve a bare RID to its table and the
-right next tool); and the orientation pair ``deriva_ml_primer`` /
+right next tool) and ``deriva_ml_check_authentication`` (pre-flight:
+is the server authenticated to this catalog, and as whom?); and the
+orientation pair ``deriva_ml_primer`` /
 ``deriva_ml_get_guide`` (static text, no catalog I/O). Pick the domain first,
 then the verb. All actual tool names are prefixed
 ``deriva_ml_<verb>`` (e.g. the ``create`` verb under ``dataset`` is
@@ -933,6 +935,11 @@ COMMON TASKS -> WHERE TO LOOK
 -----------------------------
     Intent                         Tools / route
     ------------------------------ --------------------------------------------
+    "am I logged in? / can the     check_authentication(hostname, catalog_id)
+     server reach this catalog?"   -- pre-flight before catalog ops; returns
+                                   {authenticated, identity}. Distinguishes
+                                   "no session" from a connect error. Run it
+                                   first when ops 401 or a host is untested.
     "what's in this catalog?"      rag_search(doc_type="catalog-schema" |
                                    "catalog-data"); the deriva-ml/datasets and
                                    deriva-ml/workflows resources
@@ -1349,10 +1356,11 @@ and ``description``. There is no compat shim; update any references.
 
 THE MENU
 --------
-Quick orientation: 52 tools -- 46 across the 5 ML domains (dataset,
+Quick orientation: 53 tools -- 46 across the 5 ML domains (dataset,
 feature, workflow, execution, asset) plus 3 catalog-maintenance tools
-(create_vocabulary, reindex_vocabularies, reindex_rows), the
-cross-domain describe_rid, and the orientation pair (primer,
+(create_vocabulary, reindex_vocabularies, reindex_rows), the two
+cross-domain tools (describe_rid, check_authentication), and the
+orientation pair (primer,
 deriva_ml_get_guide) -- + 21 read-only resources (18 catalog-scoped under the
 ``deriva://catalog/{h}/{c}/deriva-ml/...`` URI prefix + 3 static
 cold-start) + GitHub doc sources indexed for RAG (``deriva-ml-docs``,

--- a/src/deriva_ml_mcp_plugin/tools/auth.py
+++ b/src/deriva_ml_mcp_plugin/tools/auth.py
@@ -1,0 +1,124 @@
+"""Authentication pre-flight tool.
+
+``deriva_ml_check_authentication`` answers "can the MCP server reach and
+authenticate to this catalog, and as whom?" -- the pre-flight a user runs
+before catalog operations to confirm the server's credential is present,
+unexpired, and accepted by the catalog's auth layer (the thing that
+otherwise blanket-401s every operation).
+
+Authentication is a GENERIC Deriva concern (it's an ERMrest session
+check), but the wrapper lives here because the MCP server's credential
+model -- one server-side credential per (host, calling user), built by
+``ml_context.get_ml`` from core's request credential -- is what the
+caller is actually asking about ("is *the server* authenticated for
+*me* against this catalog?"). The tool wraps deriva-ml's
+``DerivaML.whoami`` (added in deriva-ml #353): one network call to
+``GET /authn/session``.
+
+The check confirms *authentication*, not *authorization*: a True result
+proves the server knows who the credential is, not that any specific
+privileged operation will pass the catalog's ACLs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from deriva_mcp_core import deriva_call
+
+from deriva_ml_mcp_plugin._helpers import _error_envelope
+from deriva_ml_mcp_plugin._response_models import CheckAuthenticationResponse
+from deriva_ml_mcp_plugin.ml_context import get_ml
+
+if TYPE_CHECKING:
+    from deriva_mcp_core.plugin.api import PluginContext
+
+
+def register(ctx: PluginContext) -> None:
+    """Register the authentication pre-flight tool with the plugin context.
+
+    Args:
+        ctx: The plugin context supplied by ``deriva-mcp-core`` at
+            server startup.
+
+    Example:
+        >>> # ctx provided by the framework; not constructed by user code
+        >>> register(ctx)  # doctest: +SKIP
+    """
+
+    @ctx.tool(mutates=False)
+    async def deriva_ml_check_authentication(
+        hostname: str,
+        catalog_id: str,
+    ) -> str:
+        """Check whether the MCP server is authenticated to a catalog, and as whom.
+
+        A PRE-FLIGHT to run before catalog operations when you're not
+        sure the server's credential is valid for the target catalog
+        (e.g. a fresh session, a host you haven't touched, or after a
+        run of 401-looking failures). One network call to the catalog's
+        ``GET /authn/session`` via ``DerivaML.whoami``.
+
+        Confirms *authentication* (the server knows who the credential
+        is), NOT *authorization*: a True result is a safe bet that
+        reads will work and proves the credential is present, unexpired,
+        and accepted by the auth layer -- but a privileged write can
+        still be refused by a table's ACLs even when authenticated.
+
+        ``authenticated: false`` means specifically "reached the server,
+        there is no valid session" (the endpoint returned 401/404). A
+        connection failure or a non-auth HTTP error (5xx, DNS, TLS) is
+        a different thing -- it comes back as ``{"error": ...}``, not as
+        ``authenticated: false`` -- so the two failure modes are
+        distinguishable.
+
+        Args:
+            hostname: Catalog host (e.g. ``"data.example.org"``).
+            catalog_id: Catalog id (e.g. ``"1"``).
+
+        Returns:
+            JSON string ``{"authenticated": bool, "identity": {...} |
+            null, "hostname", "catalog_id"}``. ``identity`` is the
+            logged-in client dict (``id``, ``display_name``, ``email``,
+            ``full_name``, ``identities``) when authenticated, else
+            ``null``.
+
+        Raises:
+            RuntimeError / HTTPError: Wrapped as ``{"error": ...,
+                "error_type": ...}`` for connection failures or non-auth
+                HTTP errors -- distinct from the ``authenticated: false``
+                "no session" answer.
+
+        Example:
+            ``{"authenticated": true, "identity": {"display_name":
+            "Test User", "email": "user@example.org", ...},
+            "hostname": "data.example.org", "catalog_id": "1"}``
+        """
+        try:
+            with deriva_call():
+                # Run the synchronous deriva-ml calls in a thread pool so
+                # the event loop stays responsive. ``whoami`` makes a
+                # blocking ``GET /authn/session`` network call. See
+                # deriva-mcp-core plugin-authoring-guide.md §"Synchronous
+                # work in threads".
+                ml = await asyncio.to_thread(get_ml, hostname, catalog_id)
+                identity = await asyncio.to_thread(ml.whoami)
+            return CheckAuthenticationResponse(
+                authenticated=identity is not None,
+                identity=identity,
+                hostname=hostname,
+                catalog_id=catalog_id,
+            ).model_dump_json(by_alias=True)
+        except Exception as exc:
+            # Read-only tool: log + return without an audit row. A
+            # connection / non-auth HTTP failure is a real error, NOT a
+            # "not authenticated" answer (which whoami signals by
+            # returning None, handled above).
+            return _error_envelope(
+                exc,
+                operation="check_authentication",
+                hostname=hostname,
+                catalog_id=catalog_id,
+                audit=False,
+            )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,126 @@
+"""Unit tests for the deriva_ml_check_authentication tool (tools/auth.py).
+
+``deriva_ml_check_authentication`` answers "can the MCP server reach and
+authenticate to this catalog, and as whom?" -- a pre-flight a user runs
+before catalog operations to confirm the server's credential is present,
+unexpired, and accepted by the catalog's auth layer.
+
+Fully mocked: ``get_ml`` is patched at the module's import site and the
+fake DerivaML exposes ``whoami()`` (the identity dict or ``None``).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def auth_ctx(ctx):
+    """Register the auth tool on a fresh PluginContext."""
+    from deriva_ml_mcp_plugin.tools import auth as auth_module
+
+    auth_module.register(ctx)
+    return ctx
+
+
+def _fake_ml(*, whoami_return=None, whoami_raises=None):
+    ml = MagicMock()
+    if whoami_raises is not None:
+        ml.whoami.side_effect = whoami_raises
+    else:
+        ml.whoami.return_value = whoami_return
+    return ml
+
+
+async def test_check_authentication_authenticated(auth_ctx, capturing_mcp):
+    """A live session -> authenticated True + the identity dict echoed back."""
+    from deriva_ml_mcp_plugin.tools import auth as auth_module
+
+    identity = {
+        "id": "https://auth.globus.org/abc",
+        "display_name": "Test User",
+        "email": "user@example.org",
+        "full_name": "Test User",
+    }
+    fake = _fake_ml(whoami_return=identity)
+    with patch.object(auth_module, "get_ml", return_value=fake):
+        out = json.loads(
+            await capturing_mcp.tools["deriva_ml_check_authentication"](
+                hostname="h", catalog_id="1"
+            )
+        )
+    assert out["authenticated"] is True
+    assert out["hostname"] == "h"
+    assert out["catalog_id"] == "1"
+    assert out["identity"]["display_name"] == "Test User"
+    assert out["identity"]["email"] == "user@example.org"
+    fake.whoami.assert_called_once_with()
+
+
+async def test_check_authentication_not_authenticated(auth_ctx, capturing_mcp):
+    """No session (whoami -> None) -> authenticated False, identity null."""
+    from deriva_ml_mcp_plugin.tools import auth as auth_module
+
+    fake = _fake_ml(whoami_return=None)
+    with patch.object(auth_module, "get_ml", return_value=fake):
+        out = json.loads(
+            await capturing_mcp.tools["deriva_ml_check_authentication"](
+                hostname="h", catalog_id="1"
+            )
+        )
+    assert out == {
+        "authenticated": False,
+        "identity": None,
+        "hostname": "h",
+        "catalog_id": "1",
+    }
+
+
+async def test_check_authentication_error_envelope(auth_ctx, capturing_mcp):
+    """A real error (non-auth HTTP / connect failure) -> error envelope, not a False."""
+    from deriva_ml_mcp_plugin.tools import auth as auth_module
+
+    fake = _fake_ml(whoami_raises=RuntimeError("could not connect to host h"))
+    with patch.object(auth_module, "get_ml", return_value=fake):
+        out = json.loads(
+            await capturing_mcp.tools["deriva_ml_check_authentication"](
+                hostname="h", catalog_id="1"
+            )
+        )
+    assert out == {
+        "error": "could not connect to host h",
+        "error_type": "RuntimeError",
+    }
+
+
+def test_check_authentication_is_read_only(ctx):
+    """The tool must be registered mutates=False (it makes no catalog change).
+
+    ``PluginContext.tool`` strips ``mutates`` before forwarding, so we wrap
+    ``ctx.tool`` to capture the declared value -- same idiom as
+    ``test_resolve.py``'s read-only check.
+    """
+    from deriva_ml_mcp_plugin.tools import auth as auth_module
+
+    seen: dict[str, bool] = {}
+    original_tool = ctx.tool
+
+    def capturing_tool(*args, mutates, **kwargs):
+        decorator = original_tool(*args, mutates=mutates, **kwargs)
+
+        def wrapper(fn):
+            seen[fn.__name__] = mutates
+            return decorator(fn)
+
+        return wrapper
+
+    ctx.tool = capturing_tool
+    try:
+        auth_module.register(ctx)
+    finally:
+        ctx.tool = original_tool
+
+    assert seen == {"deriva_ml_check_authentication": False}

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -163,6 +163,15 @@ _RESOLVE_TOOLS = frozenset(
     }
 )
 
+# Cross-domain authentication pre-flight (tools/auth.py): "can the MCP
+# server authenticate to this catalog, and as whom?" -- wraps
+# DerivaML.whoami (deriva-ml #353). mutates=False, no audit row.
+_AUTH_TOOLS = frozenset(
+    {
+        "deriva_ml_check_authentication",
+    }
+)
+
 # Orientation tools registered by ``prompts.py`` (not part of the five ML
 # domains). ``deriva_ml_primer`` returns the startup primer body; it is the
 # tool-shaped counterpart of the ``deriva_ml_primer`` prompt, for agents that
@@ -188,6 +197,7 @@ _ALL_REGISTERED_TOOLS = (
     | _VOCABULARY_TOOLS
     | _ASSET_TOOLS
     | _RESOLVE_TOOLS
+    | _AUTH_TOOLS
     | _PRIMER_TOOLS
 )
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?rev=943bfa394c8246ae379b4a15b3f7b615d7da1fdd" }]
+overrides = [{ name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?rev=c93e71e480e2ef501ed58077e5fff3705bcdb5a1" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -179,7 +179,7 @@ wheels = [
 [[package]]
 name = "bdbag"
 version = "1.9.0.dev0"
-source = { git = "https://github.com/fair-research/bdbag?rev=1.9.0-dev#4de3a48b2132afb7e0ee26768b745da5cfd6cbe6" }
+source = { git = "https://github.com/fair-research/bdbag.git?rev=1.9.0-dev#4de3a48b2132afb7e0ee26768b745da5cfd6cbe6" }
 dependencies = [
     { name = "bagit" },
     { name = "bagit-profile" },
@@ -658,7 +658,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?rev=943bfa394c8246ae379b4a15b3f7b615d7da1fdd#943bfa394c8246ae379b4a15b3f7b615d7da1fdd" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?rev=c93e71e480e2ef501ed58077e5fff3705bcdb5a1#c93e71e480e2ef501ed58077e5fff3705bcdb5a1" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },
@@ -671,6 +671,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "requests" },
+    { name = "setuptools" },
     { name = "sqlalchemy" },
     { name = "urllib3" },
 ]
@@ -691,8 +692,8 @@ dependencies = [
 
 [[package]]
 name = "deriva-ml"
-version = "1.54.0.post1+ge7a5a5983"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#e7a5a598318a5527a359447ac21616e0b542dfcc" }
+version = "1.54.1"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#abd78e56d00423900c542292d0c8bc32425fcb04" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },

--- a/uv.lock
+++ b/uv.lock
@@ -691,8 +691,8 @@ dependencies = [
 
 [[package]]
 name = "deriva-ml"
-version = "1.54.0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#f523eece10bd6752f638225dff53dfa37b7aacc0" }
+version = "1.54.0.post1+ge7a5a5983"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#e7a5a598318a5527a359447ac21616e0b542dfcc" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },


### PR DESCRIPTION
Adds a cross-domain read tool that answers **"can the MCP server authenticate to this catalog, and as whom?"** — a pre-flight to run before catalog operations (a fresh session, an untested host, or after a run of 401-looking failures).

## Tool

`deriva_ml_check_authentication(hostname, catalog_id)` → `{authenticated, identity, hostname, catalog_id}`. Wraps **`DerivaML.whoami`** (deriva-ml #353): one `GET /authn/session` network call.

- `authenticated: true` + the logged-in client dict (`id`, `display_name`, `email`, `full_name`, `identities`).
- `authenticated: false` means specifically **"reached the server, no valid session"** (401/404).
- A connection failure or non-auth HTTP error (5xx/DNS/TLS) comes back as the standard `{error, error_type}` envelope — **distinct** from `authenticated: false`, so the two failure modes are distinguishable.

Confirms **authentication**, not **authorization**: a valid session can still be ACL-refused for a privileged write.

## Dependency

`whoami` / `is_authenticated` landed in deriva-ml **#353**, which is on deriva-ml main but **past v1.54.0** (unreleased). The plugin lock is advanced to that commit (`e7a5a598`) so the tool resolves — consistent with how the lock already tracks deriva-ml main.

## Wiring & sweeps

- `tools/auth.py` (new), `CheckAuthenticationResponse` model (`extra=forbid`; `identity` dict `extra=allow` since the auth-layer client shape is server-owned), `plugin.py` register, `_AUTH_TOOLS` frozenset.
- `whoami` wrapped in `asyncio.to_thread` (network call) per the plugin's async rule — verified by the AST test.
- Prompt + CLAUDE.md: **52 → 53 tools**; COMMON TASKS gains an "am I logged in?" row.

## Tests

4 new (authenticated / not-authenticated / error-envelope / read-only). Full suite **413 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)